### PR TITLE
chore: add basic tests for text generation and stuctured output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
 				"handlebars": "^4.7.8",
 				"husky": "^9.1.7",
 				"miniflare": "^3.20250204.1",
+				"msw": "^2.7.3",
 				"nx": "^20.4.3",
 				"postcss": "^8.5.2",
 				"postcss-preset-mantine": "^1.17.0",
@@ -707,6 +708,47 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@bundled-es-modules/cookie": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+			"integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cookie": "^0.7.2"
+			}
+		},
+		"node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@bundled-es-modules/statuses": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+			"integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"statuses": "^2.0.1"
+			}
+		},
+		"node_modules/@bundled-es-modules/tough-cookie": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+			"integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@types/tough-cookie": "^4.0.5",
+				"tough-cookie": "^4.1.4"
 			}
 		},
 		"node_modules/@cfworker/json-schema": {
@@ -2251,6 +2293,128 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+			"integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.1.9",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+			"integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+			"integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+			"integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2661,6 +2825,24 @@
 				"node": ">=6 <7 || >=8"
 			}
 		},
+		"node_modules/@mswjs/interceptors": {
+			"version": "0.37.6",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+			"integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@open-draft/deferred-promise": "^2.2.0",
+				"@open-draft/logger": "^0.3.0",
+				"@open-draft/until": "^2.0.0",
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.3",
+				"strict-event-emitter": "^0.5.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -2877,6 +3059,31 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/@open-draft/deferred-promise": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@open-draft/logger": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+			"integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.0"
+			}
+		},
+		"node_modules/@open-draft/until": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
@@ -3230,6 +3437,13 @@
 				"@babel/types": "^7.20.7"
 			}
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/d3-array": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -3355,6 +3569,20 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/statuses": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+			"integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/uuid": {
@@ -3680,6 +3908,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -4102,6 +4359,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/cliui": {
@@ -5526,6 +5793,16 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
 		},
+		"node_modules/graphql": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+			"integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+			}
+		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -5595,6 +5872,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/headers-polyfill": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/highlight.js": {
 			"version": "11.11.1",
@@ -5779,6 +6063,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/is-node-process": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+			"integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -6639,6 +6930,51 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
+		"node_modules/msw": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.7.3.tgz",
+			"integrity": "sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bundled-es-modules/cookie": "^2.0.1",
+				"@bundled-es-modules/statuses": "^1.0.1",
+				"@bundled-es-modules/tough-cookie": "^0.1.6",
+				"@inquirer/confirm": "^5.0.0",
+				"@mswjs/interceptors": "^0.37.0",
+				"@open-draft/deferred-promise": "^2.2.0",
+				"@open-draft/until": "^2.1.0",
+				"@types/cookie": "^0.6.0",
+				"@types/statuses": "^2.0.4",
+				"graphql": "^16.8.1",
+				"headers-polyfill": "^4.0.2",
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.3",
+				"path-to-regexp": "^6.3.0",
+				"picocolors": "^1.1.1",
+				"strict-event-emitter": "^0.5.1",
+				"type-fest": "^4.26.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"msw": "cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mswjs"
+			},
+			"peerDependencies": {
+				"typescript": ">= 4.8.x"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/mustache": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -6646,6 +6982,16 @@
 			"license": "MIT",
 			"bin": {
 				"mustache": "bin/mustache"
+			}
+		},
+		"node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/mz": {
@@ -7070,6 +7416,13 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
 			"integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+			"license": "MIT"
+		},
+		"node_modules/outvariant": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+			"integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/p-filter": {
@@ -7643,6 +7996,19 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7666,6 +8032,13 @@
 					"url": "https://github.com/sponsors/sxzz"
 				}
 			],
+			"license": "MIT"
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
@@ -7964,6 +8337,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
@@ -8395,6 +8775,16 @@
 				"get-source": "^2.0.12"
 			}
 		},
+		"node_modules/statuses": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/std-env": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
@@ -8421,6 +8811,13 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/strict-event-emitter": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
@@ -8801,6 +9198,32 @@
 			"resolved": "demos/tool-calling-stream-traditional",
 			"link": true
 		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -9064,6 +9487,17 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/urlpattern-polyfill": {
@@ -11132,6 +11566,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"handlebars": "^4.7.8",
 		"husky": "^9.1.7",
 		"miniflare": "^3.20250204.1",
+		"msw": "^2.7.3",
 		"nx": "^20.4.3",
 		"postcss": "^8.5.2",
 		"postcss-preset-mantine": "^1.17.0",

--- a/packages/workers-ai-provider/README.md
+++ b/packages/workers-ai-provider/README.md
@@ -22,7 +22,6 @@ binding = "AI"
 Then in your Worker, import the factory function and create a new AI provider:
 
 ```ts
-// index.test.ts
 import { createWorkersAI } from "../../../packages/workers-ai-provider/src";
 import { streamText } from "ai";
 

--- a/packages/workers-ai-provider/README.md
+++ b/packages/workers-ai-provider/README.md
@@ -22,7 +22,7 @@ binding = "AI"
 Then in your Worker, import the factory function and create a new AI provider:
 
 ```ts
-// index.ts
+// index.test.ts
 import { createWorkersAI } from "../../../packages/workers-ai-provider/src";
 import { streamText } from "ai";
 

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -16,10 +16,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist && tsup src/index.ts --dts --sourcemap --format esm --target es2020",
-  	"test:ci": "vitest --watch=false",
-	"test": "vitest",
-	"lint": "biome lint --error-on-warnings ./src",
-	"type-check": "tsc --noEmit"
+    "test:ci": "vitest --watch=false",
+    "test": "vitest"
   },
   "files": [
     "dist",

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -15,7 +15,11 @@
   "authors": "Sunil Pai <spai@cloudflare.com>",
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && tsup src/index.ts --dts --sourcemap --format esm --target es2020"
+    "build": "rm -rf dist && tsup src/index.ts --dts --sourcemap --format esm --target es2020",
+  	"test:ci": "vitest --watch=false",
+	"test": "vitest",
+	"lint": "biome lint --error-on-warnings ./src",
+	"type-check": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/workers-ai-provider/test/structured-output.test.ts
+++ b/packages/workers-ai-provider/test/structured-output.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { createWorkersAI } from '../src/index';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const TEST_ACCOUNT_ID = 'test-account-id';
+const TEST_API_KEY = 'test-api-key';
+const TEST_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+
+const structuredOutputHandler = http.post(
+	`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+	async () => {
+		return HttpResponse.json({
+			result: {
+				response: JSON.stringify({
+					recipe: {
+						name: 'Spaghetti Bolognese',
+						ingredients: [
+							{ name: 'spaghetti', amount: '200g' },
+							{ name: 'minced beef', amount: '300g' },
+							{ name: 'tomato sauce', amount: '500ml' },
+							{ name: 'onion', amount: '1 medium' },
+							{ name: 'garlic', amount: '2 cloves' },
+						],
+						steps: [
+							'Cook spaghetti.',
+							'Fry onion & garlic.',
+							'Add minced beef.',
+							'Simmer with sauce.',
+							'Serve.',
+						],
+					},
+				}),
+			},
+			success: true,
+			errors: [],
+			messages: [],
+		});
+	}
+);
+
+const server = setupServer(structuredOutputHandler);
+
+describe('Structured Output Tests', () => {
+	beforeAll(() => server.listen());
+	afterEach(() => server.resetHandlers());
+	afterAll(() => server.close());
+
+	const recipeSchema = z.object({
+		recipe: z.object({
+			name: z.string(),
+			ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+			steps: z.array(z.string()),
+		}),
+	});
+
+	it('should generate structured output with schema (non-streaming)', async () => {
+		const workersai = createWorkersAI({ apiKey: TEST_API_KEY, accountId: TEST_ACCOUNT_ID });
+
+		const { object } = await generateObject({
+			model: workersai(TEST_MODEL),
+			schema: recipeSchema,
+			prompt: 'Give me a Spaghetti Bolognese recipe',
+		});
+
+		expect(object.recipe.name).toBe('Spaghetti Bolognese');
+		expect(object.recipe.ingredients.length).toBeGreaterThan(0);
+		expect(object.recipe.steps.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/workers-ai-provider/test/text-generation.test.ts
+++ b/packages/workers-ai-provider/test/text-generation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { createWorkersAI } from '../src/index';
+import { generateText } from 'ai';
+
+const TEST_ACCOUNT_ID = 'test-account-id';
+const TEST_API_KEY = 'test-api-key';
+const TEST_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+
+const textGenerationHandler = http.post(
+	`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+	async () => {
+		return HttpResponse.json({ result: { response: 'Hello' } });
+	}
+);
+
+const server = setupServer(textGenerationHandler);
+
+describe('Text Generation Tests', () => {
+	beforeAll(() => server.listen());
+	afterEach(() => server.resetHandlers());
+	afterAll(() => server.close());
+
+	it('should generate text (non-streaming)', async () => {
+		const workersai = createWorkersAI({ apiKey: TEST_API_KEY, accountId: TEST_ACCOUNT_ID });
+		const result = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: 'Write a greeting',
+		});
+		expect(result.text).toBe('Hello');
+	});
+});

--- a/packages/workers-ai-provider/vitest.config.ts
+++ b/packages/workers-ai-provider/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		passWithNoTests: true
+	},
+});


### PR DESCRIPTION
- adds test config for `workers-ai-provider`
- adds tests for text generation and structured outputs (non-streaming)