### PR TITLE
Move GithHub handler to own file

### DIFF
--- a/demos/remote-mcp-github-oauth/src/github-handler.ts
+++ b/demos/remote-mcp-github-oauth/src/github-handler.ts
@@ -1,0 +1,83 @@
+import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provider";
+import { Hono } from "hono";
+import { Octokit } from "octokit";
+import { fetchUpstreamAuthToken, getUpstreamAuthorizeUrl } from "./utils";
+
+const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
+
+/**
+ * OAuth Authorization Endpoint
+ *
+ * This route initiates the GitHub OAuth flow when a user wants to log in.
+ * It creates a random state parameter to prevent CSRF attacks and stores the
+ * original OAuth request information in KV storage for later retrieval.
+ * Then it redirects the user to GitHub's authorization page with the appropriate
+ * parameters so the user can authenticate and grant permissions.
+ */
+app.get("/authorize", async (c) => {
+	const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+	if (!oauthReqInfo.clientId) {
+		return c.text("Invalid request", 400);
+	}
+
+	return Response.redirect(
+		getUpstreamAuthorizeUrl({
+			upstream_url: "https://github.com/login/oauth/authorize",
+			scope: "read:user",
+			client_id: c.env.GITHUB_CLIENT_ID,
+			redirect_uri: new URL("/callback", c.req.url).href,
+			state: btoa(JSON.stringify(oauthReqInfo)),
+		}),
+	);
+});
+
+/**
+ * OAuth Callback Endpoint
+ *
+ * This route handles the callback from GitHub after user authentication.
+ * It exchanges the temporary code for an access token, then stores some
+ * user metadata & the auth token as part of the 'props' on the token passed
+ * down to the client. It ends by redirecting the client back to _its_ callback URL
+ */
+app.get("/callback", async (c) => {
+	// Get the oathReqInfo out of KV
+	const oauthReqInfo = JSON.parse(atob(c.req.query("state") as string)) as AuthRequest;
+	if (!oauthReqInfo.clientId) {
+		return c.text("Invalid state", 400);
+	}
+
+	// Exchange the code for an access token
+	const [accessToken, errResponse] = await fetchUpstreamAuthToken({
+		upstream_url: "https://github.com/login/oauth/access_token",
+		client_id: c.env.GITHUB_CLIENT_ID,
+		client_secret: c.env.GITHUB_CLIENT_SECRET,
+		code: c.req.query("code"),
+		redirect_uri: new URL("/callback", c.req.url).href,
+	});
+	if (errResponse) return errResponse;
+
+	// Fetch the user info from GitHub
+	const user = await new Octokit({ auth: accessToken }).rest.users.getAuthenticated();
+	const { login, name, email } = user.data;
+
+	// Return back to the MCP client a new token
+	const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
+		request: oauthReqInfo,
+		userId: login,
+		metadata: {
+			label: name,
+		},
+		scope: oauthReqInfo.scope,
+		// This will be available on this.props inside MyMCP
+		props: {
+			login,
+			name,
+			email,
+			accessToken,
+		} as Props,
+	});
+
+	return Response.redirect(redirectTo);
+});
+
+export const GitHubHandler = app;

--- a/demos/remote-mcp-github-oauth/src/index.ts
+++ b/demos/remote-mcp-github-oauth/src/index.ts
@@ -1,13 +1,9 @@
-import OAuthProvider, {
-	type AuthRequest,
-	type OAuthHelpers,
-} from "@cloudflare/workers-oauth-provider";
+import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import { DurableMCP } from "workers-mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { Hono } from "hono";
 import { Octokit } from "octokit";
-import { fetchUpstreamAuthToken, getUpstreamAuthorizeUrl } from "./utils";
+import { GitHubHandler } from "./github-handler";
 
 // Context from the auth process, encrypted & stored in the auth token
 // and provided to the DurableMCP as this.props
@@ -92,87 +88,10 @@ export class MyMCP extends DurableMCP<Props, Env> {
 	}
 }
 
-const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
-
-/**
- * OAuth Authorization Endpoint
- *
- * This route initiates the GitHub OAuth flow when a user wants to log in.
- * It creates a random state parameter to prevent CSRF attacks and stores the
- * original OAuth request information in KV storage for later retrieval.
- * Then it redirects the user to GitHub's authorization page with the appropriate
- * parameters so the user can authenticate and grant permissions.
- */
-app.get("/authorize", async (c) => {
-	const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
-	if (!oauthReqInfo.clientId) {
-		return c.text("Invalid request", 400);
-	}
-
-	return Response.redirect(
-		getUpstreamAuthorizeUrl({
-			upstream_url: "https://github.com/login/oauth/authorize",
-			scope: "read:user",
-			client_id: c.env.GITHUB_CLIENT_ID,
-			redirect_uri: new URL("/callback", c.req.url).href,
-			state: btoa(JSON.stringify(oauthReqInfo)),
-		}),
-	);
-});
-
-/**
- * OAuth Callback Endpoint
- *
- * This route handles the callback from GitHub after user authentication.
- * It exchanges the temporary code for an access token, then stores some
- * user metadata & the auth token as part of the 'props' on the token passed
- * down to the client. It ends by redirecting the client back to _its_ callback URL
- */
-app.get("/callback", async (c) => {
-	// Get the oathReqInfo out of KV
-	const oauthReqInfo = JSON.parse(atob(c.req.query("state") as string)) as AuthRequest;
-	if (!oauthReqInfo.clientId) {
-		return c.text("Invalid state", 400);
-	}
-
-	// Exchange the code for an access token
-	const [accessToken, errResponse] = await fetchUpstreamAuthToken({
-		upstream_url: "https://github.com/login/oauth/access_token",
-		client_id: c.env.GITHUB_CLIENT_ID,
-		client_secret: c.env.GITHUB_CLIENT_SECRET,
-		code: c.req.query("code"),
-		redirect_uri: new URL("/callback", c.req.url).href,
-	});
-	if (errResponse) return errResponse;
-
-	// Fetch the user info from GitHub
-	const user = await new Octokit({ auth: accessToken }).rest.users.getAuthenticated();
-	const { login, name, email } = user.data;
-
-	// Return back to the MCP client a new token
-	const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
-		request: oauthReqInfo,
-		userId: login,
-		metadata: {
-			label: name,
-		},
-		scope: oauthReqInfo.scope,
-		// This will be available on this.props inside MyMCP
-		props: {
-			login,
-			name,
-			email,
-			accessToken,
-		} as Props,
-	});
-
-	return Response.redirect(redirectTo);
-});
-
 export default new OAuthProvider({
 	apiRoute: "/sse",
 	apiHandler: MyMCP.mount("/sse"),
-	defaultHandler: app,
+	defaultHandler: GitHubHandler,
 	authorizeEndpoint: "/authorize",
 	tokenEndpoint: "/token",
 	clientRegistrationEndpoint: "/register",


### PR DESCRIPTION
So that it matches dev docs:

<img width="1013" alt="Screenshot 2025-03-20 at 6 16 05 PM" src="https://github.com/user-attachments/assets/74ad9e20-9818-4a70-964b-30f77b1cb77b" />

...and is easier to reason about different parts of the MCP server and what they are responsible for.