### PR TITLE
Remove "prepare": "husky" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 	"author": "Andy Jessop",
 	"scripts": {
 		"create-demo": "npx tsx ./tools/create-demo/index.ts",
-		"prepare": "husky",
 		"format": "biome format --write",
 		"lint": "biome lint",
 		"lint:fix": "biome lint --fix"


### PR DESCRIPTION
I don't think this is necessary to have husky be in the prepare script. 

It creates a circular dependency issue in Workers Builds. Prepare step `husky` runs before install, but we need to have run install in order to have husky installed.

As far as I can tell, husky just installs and verifies package-locks, which should always be valid anyways upon installation anyways. Pushing will verify any changes, so I don't think there's problems in removing this prepare script.