### PR TITLE
Use McpAgent in examples

### DIFF
--- a/demos/remote-mcp-github-oauth/src/index.ts
+++ b/demos/remote-mcp-github-oauth/src/index.ts
@@ -1,5 +1,5 @@
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
-import { DurableMCP } from "workers-mcp";
+import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { Octokit } from "octokit";
@@ -19,7 +19,7 @@ const ALLOWED_USERNAMES = new Set([
 	// For example: 'yourusername', 'coworkerusername'
 ]);
 
-export class MyMCP extends DurableMCP<Props, Env> {
+export class MyMCP extends McpAgent<Props, Env> {
 	server = new McpServer({
 		name: "Github OAuth Proxy Demo",
 		version: "1.0.0",

--- a/demos/remote-mcp-server/package.json
+++ b/demos/remote-mcp-server/package.json
@@ -19,6 +19,7 @@
 	"dependencies": {
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@modelcontextprotocol/sdk": "^1.7.0",
+		"agents": "^0.0.43",
 		"hono": "^4.7.4",
 		"zod": "^3.24.2"
 	}

--- a/demos/remote-mcp-server/src/index.ts
+++ b/demos/remote-mcp-server/src/index.ts
@@ -1,10 +1,10 @@
 import app from "./app";
-import { DurableMCP } from "workers-mcp";
+import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
 
-export class MyMCP extends DurableMCP {
+export class MyMCP extends McpAgent {
 	server = new McpServer({
 		name: "Demo",
 		version: "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,6 +794,7 @@
 			"dependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@modelcontextprotocol/sdk": "^1.7.0",
+				"agents": "^0.0.43",
 				"hono": "^4.7.4",
 				"zod": "^3.24.2"
 			},
@@ -6506,6 +6507,18 @@
 				"node": ">= 8.0.0"
 			}
 		},
+		"node_modules/agents": {
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.43.tgz",
+			"integrity": "sha512-4acJ/rseNeF7k4oU29KjBXPWZXMrsBwY3Z6cBGvfwkrs3X+7dIlyNpm/eqTSUTgndUoPTdt8ygNWyA2CG+By7A==",
+			"license": "MIT",
+			"dependencies": {
+				"cron-schedule": "^5.0.4",
+				"nanoid": "^5.1.5",
+				"partyserver": "^0.0.66",
+				"partysocket": "1.1.0"
+			}
+		},
 		"node_modules/agents-sdk": {
 			"version": "0.0.27",
 			"resolved": "https://registry.npmjs.org/agents-sdk/-/agents-sdk-0.0.27.tgz",
@@ -6534,6 +6547,57 @@
 			},
 			"engines": {
 				"node": "^18 || >=20"
+			}
+		},
+		"node_modules/agents/node_modules/event-target-shim": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/agents/node_modules/nanoid": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.js"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			}
+		},
+		"node_modules/agents/node_modules/partyserver": {
+			"version": "0.0.66",
+			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.66.tgz",
+			"integrity": "sha512-GyC1uy4dvC4zPkwdzHqCkQ1J1CMiI0swIJQ0qqsJh16WNkEo5QHuU3l3ikLO8t+Yq0cRr0qO8++xbr11h+107w==",
+			"license": "ISC",
+			"dependencies": {
+				"nanoid": "^5.1.2"
+			},
+			"peerDependencies": {
+				"@cloudflare/workers-types": "^4.20240729.0"
+			}
+		},
+		"node_modules/agents/node_modules/partysocket": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.0.tgz",
+			"integrity": "sha512-G+fYGqBPx5tCjqmUmhtIKxZqnS/JjYd0E94hqRe+MRvggZ/RNy3+07t+WxewqdW+BlXEhW9eXu9WA5CjCn9BDQ==",
+			"license": "ISC",
+			"dependencies": {
+				"event-target-shim": "^6.0.2"
 			}
 		},
 		"node_modules/ai": {


### PR DESCRIPTION
refs https://github.com/cloudflare/cloudflare-docs/pull/21077

- Reduces confusion about what `workers-mcp` package is for and does
- Ensures MCP servers people build can evolve to become Agents if people choose
- Avoids explaining what `DurableMcp` means
- Makes more sense why MCP docs are within `/agents`