### PR TITLE
Add vite to demo package.json files

### DIFF
--- a/demos/agent-scheduler/package.json
+++ b/demos/agent-scheduler/package.json
@@ -16,6 +16,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
 		"vitest": "~3.0.7",

--- a/demos/agent-task-manager-human-in-the-loop/package.json
+++ b/demos/agent-task-manager-human-in-the-loop/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/agent-task-manager/package.json
+++ b/demos/agent-task-manager/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/evaluator-optimiser/package.json
+++ b/demos/evaluator-optimiser/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/model-scraper/package.json
+++ b/demos/model-scraper/package.json
@@ -19,8 +19,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/orchestrator-workers/package.json
+++ b/demos/orchestrator-workers/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/parallelisation/package.json
+++ b/demos/parallelisation/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/prompt-chaining/package.json
+++ b/demos/prompt-chaining/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/routing/package.json
+++ b/demos/routing/package.json
@@ -15,8 +15,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/structured-output/package.json
+++ b/demos/structured-output/package.json
@@ -17,8 +17,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/text-generation-stream/package.json
+++ b/demos/text-generation-stream/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/text-generation/package.json
+++ b/demos/text-generation/package.json
@@ -16,7 +16,9 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/tool-calling-stream-traditional/package.json
+++ b/demos/tool-calling-stream-traditional/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/tool-calling-stream/package.json
+++ b/demos/tool-calling-stream/package.json
@@ -16,8 +16,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/demos/tool-calling/package.json
+++ b/demos/tool-calling/package.json
@@ -17,8 +17,10 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.1.0",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
 				"@clack/prompts": "^0.10.0",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@types/ejs": "^3.1.5",
 				"@types/node": "^22.13.10",
 				"@types/wait-on": "^5.3.4",
@@ -107,6 +108,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
 				"vite": "^6.1.0",
@@ -124,8 +126,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -140,8 +144,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -156,8 +162,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -172,8 +180,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -188,8 +198,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -204,8 +216,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -220,8 +234,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -707,20 +723,6 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"demos/remote-mcp-github-oauth/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"demos/remote-mcp-github-oauth/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"demos/remote-mcp-github-oauth/node_modules/prettier": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
@@ -830,8 +832,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -845,8 +849,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -888,7 +894,9 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -903,8 +911,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -919,8 +929,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -935,8 +947,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -950,8 +964,10 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
+				"@cloudflare/vite-plugin": "^0.1.15",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
+				"vite": "^6.1.0",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -2007,15 +2023,46 @@
 				"node": ">=16.13"
 			}
 		},
-		"node_modules/@cloudflare/unenv-preset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-1.1.1.tgz",
-			"integrity": "sha512-8y7gFmXnOF9kycm8eIaL0rNBd5np3a/aLaG04pfFG4aEF0rIHAMiGFxQfg1ZIV77ApLHzPomr9/ixLbZWXwX3w==",
+		"node_modules/@cloudflare/vite-plugin": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-0.1.15.tgz",
+			"integrity": "sha512-MNSakOz6iAo1Cv7Z45+blbz17gxEt6c7h0rTh1NLfcVPYMWw4qNl4KtfY+fAVrRsRlXBHhs9+9mRne6QNyPJUw==",
 			"dev": true,
-			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@cloudflare/unenv-preset": "2.3.0",
+				"@hattip/adapter-node": "^0.0.49",
+				"miniflare": "4.20250320.0",
+				"picocolors": "^1.1.1",
+				"tinyglobby": "^0.2.12",
+				"unenv": "2.0.0-rc.15",
+				"wrangler": "4.4.0",
+				"ws": "8.18.0"
+			},
 			"peerDependencies": {
-				"unenv": "2.0.0-rc.1",
-				"workerd": "^1.20250124.0"
+				"vite": "^6.1.0",
+				"wrangler": "^3.101.0 || ^4.0.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/kv-asset-handler": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
+			"integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+			"dev": true,
+			"dependencies": {
+				"mime": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/unenv-preset": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.0.tgz",
+			"integrity": "sha512-AaKYnbFpHaVDZGh3Hjy3oLYd12+LZw9aupAOudYJ+tjekahxcIqlSAr0zK9kPOdtgn10tzaqH7QJFUWcLE+k7g==",
+			"dev": true,
+			"peerDependencies": {
+				"unenv": "2.0.0-rc.15",
+				"workerd": "^1.20250311.0"
 			},
 			"peerDependenciesMeta": {
 				"workerd": {
@@ -2023,483 +2070,706 @@
 				}
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-0.1.10.tgz",
-			"integrity": "sha512-jGQKXle5JeXFHIKHC6n7Vv+L5B5G25b3Uu13xAwiQqsBXDHK78VmUzpVViZLIxrA+YjNcM5znXCxbdvoWkc1xA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cloudflare/unenv-preset": "1.1.1",
-				"@hattip/adapter-node": "^0.0.49",
-				"miniflare": "3.20250310.0",
-				"tinyglobby": "^0.2.12",
-				"unenv": "2.0.0-rc.1",
-				"wrangler": "3.114.1",
-				"ws": "8.18.0"
-			},
-			"peerDependencies": {
-				"vite": "^6.1.0",
-				"wrangler": "^3.101.0"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250321.0.tgz",
+			"integrity": "sha512-y273GfLaNCxkL8hTfo0c8FZKkOPdq+CPZAKJXPWB+YpS1JCOULu6lNTptpD7ZtF14dTYPkn5Weug31TTlviJmw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-qvf7/gkkQq7fAsoMlntJSimN/WfwQqxi2oL0aWZMGodTvs/yRHO2I4oE0eOihVdK1BXyBHJXNxEvNDBjF0+Yuw==",
 			"cpu": [
-				"x64"
+				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250321.0.tgz",
+			"integrity": "sha512-AEp3xjWFrNPO/h0StCOgOb0bWCcNThnkESpy91Wf4mfUF2p7tOCdp37Nk/1QIRqSxnfv4Hgxyi7gcWud9cJuMw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-wRWyMIoPIS1UBXCisW0FYTgGsfZD4AVS0hXA5nuLc0c21CvzZpmmTjqEWMcwPFenwy/MNL61NautVOC4qJqQ3Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250321.0.tgz",
+			"integrity": "sha512-8vYP3QYO0zo2faUDfWl88jjfUvz7Si9GS3mUYaTh/TR9LcAUtsO7muLxPamqEyoxNFtbQgy08R4rTid94KRi3w==",
 			"cpu": [
-				"ia32"
+				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
-				"linux"
+				"win32"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ia32": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-loong64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
 			"cpu": [
-				"x64"
+				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/sunos-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/esbuild": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
 			"dev": true,
 			"hasInstallScript": true,
-			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.19",
-				"@esbuild/android-arm64": "0.17.19",
-				"@esbuild/android-x64": "0.17.19",
-				"@esbuild/darwin-arm64": "0.17.19",
-				"@esbuild/darwin-x64": "0.17.19",
-				"@esbuild/freebsd-arm64": "0.17.19",
-				"@esbuild/freebsd-x64": "0.17.19",
-				"@esbuild/linux-arm": "0.17.19",
-				"@esbuild/linux-arm64": "0.17.19",
-				"@esbuild/linux-ia32": "0.17.19",
-				"@esbuild/linux-loong64": "0.17.19",
-				"@esbuild/linux-mips64el": "0.17.19",
-				"@esbuild/linux-ppc64": "0.17.19",
-				"@esbuild/linux-riscv64": "0.17.19",
-				"@esbuild/linux-s390x": "0.17.19",
-				"@esbuild/linux-x64": "0.17.19",
-				"@esbuild/netbsd-x64": "0.17.19",
-				"@esbuild/openbsd-x64": "0.17.19",
-				"@esbuild/sunos-x64": "0.17.19",
-				"@esbuild/win32-arm64": "0.17.19",
-				"@esbuild/win32-ia32": "0.17.19",
-				"@esbuild/win32-x64": "0.17.19"
+				"@esbuild/aix-ppc64": "0.24.2",
+				"@esbuild/android-arm": "0.24.2",
+				"@esbuild/android-arm64": "0.24.2",
+				"@esbuild/android-x64": "0.24.2",
+				"@esbuild/darwin-arm64": "0.24.2",
+				"@esbuild/darwin-x64": "0.24.2",
+				"@esbuild/freebsd-arm64": "0.24.2",
+				"@esbuild/freebsd-x64": "0.24.2",
+				"@esbuild/linux-arm": "0.24.2",
+				"@esbuild/linux-arm64": "0.24.2",
+				"@esbuild/linux-ia32": "0.24.2",
+				"@esbuild/linux-loong64": "0.24.2",
+				"@esbuild/linux-mips64el": "0.24.2",
+				"@esbuild/linux-ppc64": "0.24.2",
+				"@esbuild/linux-riscv64": "0.24.2",
+				"@esbuild/linux-s390x": "0.24.2",
+				"@esbuild/linux-x64": "0.24.2",
+				"@esbuild/netbsd-arm64": "0.24.2",
+				"@esbuild/netbsd-x64": "0.24.2",
+				"@esbuild/openbsd-arm64": "0.24.2",
+				"@esbuild/openbsd-x64": "0.24.2",
+				"@esbuild/sunos-x64": "0.24.2",
+				"@esbuild/win32-arm64": "0.24.2",
+				"@esbuild/win32-ia32": "0.24.2",
+				"@esbuild/win32-x64": "0.24.2"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare": {
+			"version": "4.20250320.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250320.0.tgz",
+			"integrity": "sha512-dD9gpO/nWaLURbBXctB/FOJEDexPlSbplIApb5Ea3xGuSSh+3Iq/cfbgh3IdgueIGMJb6vvTiOWpiPA5naX6vg==",
 			"dev": true,
-			"license": "MIT"
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"acorn": "8.14.0",
+				"acorn-walk": "8.3.2",
+				"exit-hook": "2.2.1",
+				"glob-to-regexp": "0.4.1",
+				"stoppable": "1.1.0",
+				"undici": "^5.28.5",
+				"workerd": "1.20250320.0",
+				"ws": "8.18.0",
+				"youch": "3.2.3",
+				"zod": "3.22.3"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250320.0.tgz",
+			"integrity": "sha512-wS2fcowxgbrKtfahU0Mtt/0XYjnuAjZd+2FsTZ3GDgxlywVTTl8SeApM11cjYo7QNdGh56HEGYMsYojya5sHHQ==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"license": "MIT"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250320.0.tgz",
+			"integrity": "sha512-QMqFay2buv3pPE+mi30QenX/cmlaB72sXTspk5e4LwEEgsxpoS8BryeIOeo8ScGDyt0NBfOutCRFTTiZLSqyzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250320.0.tgz",
+			"integrity": "sha512-PBkmZdNtSIBRiFUhEMhkDoR5WX0bZWE+nSys0/v6DeFU3Pc6KiH+2VPGqWOLVH85uzL1wWFpAJk9ptsWwTC9Ww==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250320.0.tgz",
+			"integrity": "sha512-nHSMsNbUwaOJRYuHYK4EcZreOP3FlFqD47FUxGP6k1tjYs4l4z86XJMONbY8vE9WZ9BWPAzZX/xzSalB0DhGIA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250320.0.tgz",
+			"integrity": "sha512-Uj5z/PyGqO8xuVCkS19exmQ5yGcC1RbB3nUaf6j5rlft7lBTBkjC+l7NAhEiRxNKaZuT2Lfy+r4vAEPsiotegw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/workerd": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250320.0.tgz",
+			"integrity": "sha512-XrjREboPo1AZNF3kSEly/H1Ejmpu2Mk/Wzsxprn7MHUmBnQNASFtvQdN0ef0bN+MaNdCWUawpsDLpNWNOyK4FA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250320.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250320.0",
+				"@cloudflare/workerd-linux-64": "1.20250320.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250320.0",
+				"@cloudflare/workerd-windows-64": "1.20250320.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/workerd": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250321.0.tgz",
+			"integrity": "sha512-vyuz9pdJ+7o1lC79vQ2UVRLXPARa2Lq94PbTfqEcYQeSxeR9X+YqhNq2yysv8Zs5vpokmexLCtMniPp9u+2LVQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250321.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250321.0",
+				"@cloudflare/workerd-linux-64": "1.20250321.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250321.0",
+				"@cloudflare/workerd-windows-64": "1.20250321.0"
+			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler": {
-			"version": "3.114.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.1.tgz",
-			"integrity": "sha512-GuS6SrnAZZDiNb20Vf2Ww0KCfnctHUEzi5GyML1i2brfQPI6BikgI/W/u6XDtYtah0OkbIWIiNJ+SdhWT7KEcw==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.4.0.tgz",
+			"integrity": "sha512-VmHBpocMk/GTEER+jJzkQeGNx5i/qJJKoUse5zvKmJOnELG/dhEQBJoaWxllwOfaPhIbnqeXdtrN/B+dfQAsFA==",
 			"dev": true,
-			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.3.4",
-				"@cloudflare/unenv-preset": "2.0.2",
-				"@esbuild-plugins/node-globals-polyfill": "0.2.3",
-				"@esbuild-plugins/node-modules-polyfill": "0.2.2",
+				"@cloudflare/kv-asset-handler": "0.4.0",
+				"@cloudflare/unenv-preset": "2.3.0",
 				"blake3-wasm": "2.1.5",
-				"esbuild": "0.17.19",
-				"miniflare": "3.20250310.0",
+				"esbuild": "0.24.2",
+				"miniflare": "4.20250320.0",
 				"path-to-regexp": "6.3.0",
-				"unenv": "2.0.0-rc.14",
-				"workerd": "1.20250310.0"
+				"unenv": "2.0.0-rc.15",
+				"workerd": "1.20250320.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=16.17.0"
+				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2",
 				"sharp": "^0.33.5"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20250310.0"
+				"@cloudflare/workers-types": "^4.20250320.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -2507,34 +2777,113 @@
 				}
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
-			"integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250320.0.tgz",
+			"integrity": "sha512-wS2fcowxgbrKtfahU0Mtt/0XYjnuAjZd+2FsTZ3GDgxlywVTTl8SeApM11cjYo7QNdGh56HEGYMsYojya5sHHQ==",
+			"cpu": [
+				"x64"
+			],
 			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"peerDependencies": {
-				"unenv": "2.0.0-rc.14",
-				"workerd": "^1.20250124.0"
-			},
-			"peerDependenciesMeta": {
-				"workerd": {
-					"optional": true
-				}
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/unenv": {
-			"version": "2.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
-			"integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250320.0.tgz",
+			"integrity": "sha512-QMqFay2buv3pPE+mi30QenX/cmlaB72sXTspk5e4LwEEgsxpoS8BryeIOeo8ScGDyt0NBfOutCRFTTiZLSqyzQ==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defu": "^6.1.4",
-				"exsolve": "^1.0.1",
-				"ohash": "^2.0.10",
-				"pathe": "^2.0.3",
-				"ufo": "^1.5.4"
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250320.0.tgz",
+			"integrity": "sha512-PBkmZdNtSIBRiFUhEMhkDoR5WX0bZWE+nSys0/v6DeFU3Pc6KiH+2VPGqWOLVH85uzL1wWFpAJk9ptsWwTC9Ww==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250320.0.tgz",
+			"integrity": "sha512-nHSMsNbUwaOJRYuHYK4EcZreOP3FlFqD47FUxGP6k1tjYs4l4z86XJMONbY8vE9WZ9BWPAzZX/xzSalB0DhGIA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250320.0.tgz",
+			"integrity": "sha512-Uj5z/PyGqO8xuVCkS19exmQ5yGcC1RbB3nUaf6j5rlft7lBTBkjC+l7NAhEiRxNKaZuT2Lfy+r4vAEPsiotegw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/workerd": {
+			"version": "1.20250320.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250320.0.tgz",
+			"integrity": "sha512-XrjREboPo1AZNF3kSEly/H1Ejmpu2Mk/Wzsxprn7MHUmBnQNASFtvQdN0ef0bN+MaNdCWUawpsDLpNWNOyK4FA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250320.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250320.0",
+				"@cloudflare/workerd-linux-64": "1.20250320.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250320.0",
+				"@cloudflare/workerd-windows-64": "1.20250320.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/zod": {
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+			"integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
@@ -2987,20 +3336,6 @@
 				"@esbuild/win32-x64": "0.17.19"
 			}
 		},
-		"node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@cloudflare/vitest-pool-workers/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@cloudflare/vitest-pool-workers/node_modules/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -3161,10 +3496,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20250319.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250319.0.tgz",
-			"integrity": "sha512-TTg1WZZuWJomzU3g1TvqE/WWI3zpTu1K+RsJvk6zxEgjhONN2PzqUUqKVYOQBk4/p7d+v7h6wz2gX3Ke7Arm7g==",
-			"license": "MIT OR Apache-2.0"
+			"version": "4.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250321.0.tgz",
+			"integrity": "sha512-jPwtZJC7tVFOwFazuwq96be8haTnY9qik8hJ+oLFi50d9LTWPPrnrNHC4OxZmJTEcPIAy0y1WFZHe8C/b7xFXQ=="
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -6268,13 +6602,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/runner/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@vitest/snapshot": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
@@ -6289,13 +6616,6 @@
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
-		},
-		"node_modules/@vitest/snapshot/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@vitest/spy": {
 			"version": "3.0.9",
@@ -7291,13 +7611,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"license": "MIT"
-		},
-		"node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/consola": {
@@ -9997,26 +10310,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/mlly": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.14.0",
-				"pathe": "^2.0.1",
-				"pkg-types": "^1.3.0",
-				"ufo": "^1.5.4"
-			}
-		},
-		"node_modules/mlly/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/model-scraper": {
 			"resolved": "demos/model-scraper",
 			"link": true
@@ -10483,11 +10776,10 @@
 			}
 		},
 		"node_modules/ohash": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-			"integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+			"dev": true
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -10920,11 +11212,10 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true
 		},
 		"node_modules/pathval": {
 			"version": "2.0.0",
@@ -10980,25 +11271,6 @@
 			"engines": {
 				"node": ">=16.20.0"
 			}
-		},
-		"node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
-		"node_modules/pkg-types/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
@@ -12992,16 +13264,15 @@
 			"license": "MIT"
 		},
 		"node_modules/unenv": {
-			"version": "2.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.1.tgz",
-			"integrity": "sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==",
+			"version": "2.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
+			"integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"defu": "^6.1.4",
-				"mlly": "^1.7.4",
-				"ohash": "^1.1.4",
-				"pathe": "^1.1.2",
+				"exsolve": "^1.0.4",
+				"ohash": "^2.0.11",
+				"pathe": "^2.0.3",
 				"ufo": "^1.5.4"
 			}
 		},
@@ -13320,13 +13591,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/vite-node/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/vitest": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
@@ -13396,13 +13660,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vitest/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/wait-on": {
 			"version": "8.0.3",
@@ -14263,20 +14520,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/wrangler/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrangler/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/wrangler/node_modules/unenv": {
 			"version": "2.0.0-rc.14",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
 		"@clack/prompts": "^0.10.0",
+		"@cloudflare/vite-plugin": "^0.1.15",
 		"@types/ejs": "^3.1.5",
 		"@types/node": "^22.13.10",
 		"@types/wait-on": "^5.3.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"create-demo": "npx tsx ./tools/create-demo/index.ts",
 		"format": "biome format --write",
 		"lint": "biome lint",
+		"prepare": "if [ \"$CI\" ]; then echo 'Skipping husky setup in CI'; else husky; fi",
 		"lint:fix": "biome lint --fix"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Builds of the demos fail in the deploy to workers flow because `vite` & `@clooudflare/vite-plugin` aren't included in the demo `package.json` files. This just adds those packages to ensure builds work.

Additionally, this adds the husky command back but doesn't run in CI