### PR TITLE
Fix redirect issue with example

### DIFF
--- a/demos/mcp-slack-oauth/src/index.ts
+++ b/demos/mcp-slack-oauth/src/index.ts
@@ -144,5 +144,5 @@ export default new OAuthProvider({
 	defaultHandler: SlackHandler,
 	authorizeEndpoint: "/authorize",
 	tokenEndpoint: "/token",
-	clientRegistrationEndpoint: "/register"
+	clientRegistrationEndpoint: "/register",
 });

--- a/demos/mcp-slack-oauth/src/slack-handler.ts
+++ b/demos/mcp-slack-oauth/src/slack-handler.ts
@@ -17,19 +17,19 @@ const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
 app.get("/authorize", async (c) => {
 	const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
 	if (!oauthReqInfo.clientId) {
-	  return c.text("Invalid request", 400);
+		return c.text("Invalid request", 400);
 	}
-  
+
 	return Response.redirect(
-	  getUpstreamAuthorizeUrl({
-		upstream_url: "https://slack.com/oauth/v2/authorize",
-		scope: "channels:history,channels:read,users:read",
-		client_id: c.env.SLACK_CLIENT_ID,
-		redirect_uri: new URL("/callback", c.req.url).href,
-		state: btoa(JSON.stringify(oauthReqInfo)),
-	  }),
+		getUpstreamAuthorizeUrl({
+			upstream_url: "https://slack.com/oauth/v2/authorize",
+			scope: "channels:history,channels:read,users:read",
+			client_id: c.env.SLACK_CLIENT_ID,
+			redirect_uri: new URL("/callback", c.req.url).href,
+			state: btoa(JSON.stringify(oauthReqInfo)),
+		}),
 	);
-  });
+});
 
 /**
  * OAuth Callback Endpoint
@@ -41,84 +41,84 @@ app.get("/authorize", async (c) => {
  */
 app.get("/callback", async (c) => {
 	const code = c.req.query("code") as string;
-  
+
 	// Get the oauthReqInfo directly from the state parameter
 	const state = c.req.query("state");
 	if (!state) {
-	  return c.text("Missing state", 400);
+		return c.text("Missing state", 400);
 	}
-	
+
 	// Parse the state to get the original OAuth request info
 	const oauthReqInfo = JSON.parse(atob(state)) as AuthRequest;
 	if (!oauthReqInfo.clientId) {
-	  return c.text("Invalid state", 400);
+		return c.text("Invalid state", 400);
 	}
-  
+
 	console.log("Attempting token exchange with params:", {
-	  redirect_uri: new URL("/callback", c.req.url).href,
-	  code_exists: !!code
+		redirect_uri: new URL("/callback", c.req.url).href,
+		code_exists: !!code,
 	});
-  
+
 	// Exchange the code for an access token
 	const response = await fetch("https://slack.com/api/oauth.v2.access", {
-	  method: "POST",
-	  headers: {
-		"Content-Type": "application/x-www-form-urlencoded",
-	  },
-	  body: new URLSearchParams({
-		client_id: c.env.SLACK_CLIENT_ID,
-		client_secret: c.env.SLACK_CLIENT_SECRET,
-		code,
-		redirect_uri: new URL("/callback", c.req.url).href,
-	  }).toString(),
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams({
+			client_id: c.env.SLACK_CLIENT_ID,
+			client_secret: c.env.SLACK_CLIENT_SECRET,
+			code,
+			redirect_uri: new URL("/callback", c.req.url).href,
+		}).toString(),
 	});
-  
+
 	if (!response.ok) {
-	  const errorText = await response.text();
-	  console.log("Token exchange failed:", response.status, errorText);
-	  return c.text(`Failed to fetch access token: ${response.status} ${errorText}`, 500);
+		const errorText = await response.text();
+		console.log("Token exchange failed:", response.status, errorText);
+		return c.text(`Failed to fetch access token: ${response.status} ${errorText}`, 500);
 	}
-  
+
 	const data = await response.json();
 	if (!data.ok) {
-	  console.log("Slack API error:", data.error);
-	  return c.text(`Slack API error: ${data.error || "Unknown error"}`, 500);
+		console.log("Slack API error:", data.error);
+		return c.text(`Slack API error: ${data.error || "Unknown error"}`, 500);
 	}
-  
+
 	const accessToken = data.access_token;
 	if (!accessToken) {
-	  return c.text("Missing access token", 400);
+		return c.text("Missing access token", 400);
 	}
-  
+
 	// Get user info from the Slack API response
 	const userId = data.authed_user?.id || "unknown";
 	const userName = data.authed_user?.name || "unknown";
 	const teamId = data.team?.id || "unknown";
 	const teamName = data.team?.name || "unknown";
 	const scope = data.scope || "";
-  
+
 	console.log("Completing authorization with user:", userId);
-  
+
 	// Return back to the MCP client a new token
 	const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
-	  request: oauthReqInfo,
-	  userId: userId,
-	  metadata: {
-		label: userName,
-	  },
-	  scope: oauthReqInfo.scope,
-	  // This will be available on this.props inside SlackMCP
-	  props: {
-		userId,
-		userName,
-		teamId,
-		teamName,
-		accessToken,
-		scope,
-	  },
+		request: oauthReqInfo,
+		userId: userId,
+		metadata: {
+			label: userName,
+		},
+		scope: oauthReqInfo.scope,
+		// This will be available on this.props inside SlackMCP
+		props: {
+			userId,
+			userName,
+			teamId,
+			teamName,
+			accessToken,
+			scope,
+		},
 	});
-  
+
 	return Response.redirect(redirectTo);
-  });
+});
 
 export const SlackHandler = app;

--- a/demos/mcp-slack-oauth/src/utils.ts
+++ b/demos/mcp-slack-oauth/src/utils.ts
@@ -11,51 +11,51 @@
  * @returns {string} The authorization URL.
  */
 export function getUpstreamAuthorizeUrl({
-    upstream_url,
-    client_id,
-    scope,
-    redirect_uri,
-    state,
-  }: {
-    upstream_url: string;
-    client_id: string;
-    scope: string;
-    redirect_uri: string;
-    state?: string;
-  }) {
-    const upstream = new URL(upstream_url);
-    upstream.searchParams.set("client_id", client_id);
-    upstream.searchParams.set("redirect_uri", redirect_uri);
-    upstream.searchParams.set("scope", scope);
-    if (state) upstream.searchParams.set("state", state);
-    return upstream.href;
-  }
-  
-  /**
-   * Adds CORS headers to a response
-   * @param response - The response to add CORS headers to
-   * @param request - The original request
-   * @returns A new Response with CORS headers added
-   */
-  export function addCorsHeaders(response: Response, request: Request): Response {
-    // Get the Origin header from the request
-    const origin = request.headers.get("Origin");
-  
-    // If there's no Origin header, return the original response
-    if (!origin) {
-      return response;
-    }
-  
-    // Create a new response that copies all properties from the original response
-    // This makes the response mutable so we can modify its headers
-    const newResponse = new Response(response.body, response);
-  
-    // Add CORS headers
-    newResponse.headers.set("Access-Control-Allow-Origin", origin);
-    newResponse.headers.set("Access-Control-Allow-Methods", "*");
-    // Include Authorization explicitly since it's not included in * for security reasons
-    newResponse.headers.set("Access-Control-Allow-Headers", "Authorization, *");
-    newResponse.headers.set("Access-Control-Max-Age", "86400"); // 24 hours
-  
-    return newResponse;
-  }
+	upstream_url,
+	client_id,
+	scope,
+	redirect_uri,
+	state,
+}: {
+	upstream_url: string;
+	client_id: string;
+	scope: string;
+	redirect_uri: string;
+	state?: string;
+}) {
+	const upstream = new URL(upstream_url);
+	upstream.searchParams.set("client_id", client_id);
+	upstream.searchParams.set("redirect_uri", redirect_uri);
+	upstream.searchParams.set("scope", scope);
+	if (state) upstream.searchParams.set("state", state);
+	return upstream.href;
+}
+
+/**
+ * Adds CORS headers to a response
+ * @param response - The response to add CORS headers to
+ * @param request - The original request
+ * @returns A new Response with CORS headers added
+ */
+export function addCorsHeaders(response: Response, request: Request): Response {
+	// Get the Origin header from the request
+	const origin = request.headers.get("Origin");
+
+	// If there's no Origin header, return the original response
+	if (!origin) {
+		return response;
+	}
+
+	// Create a new response that copies all properties from the original response
+	// This makes the response mutable so we can modify its headers
+	const newResponse = new Response(response.body, response);
+
+	// Add CORS headers
+	newResponse.headers.set("Access-Control-Allow-Origin", origin);
+	newResponse.headers.set("Access-Control-Allow-Methods", "*");
+	// Include Authorization explicitly since it's not included in * for security reasons
+	newResponse.headers.set("Access-Control-Allow-Headers", "Authorization, *");
+	newResponse.headers.set("Access-Control-Max-Age", "86400"); // 24 hours
+
+	return newResponse;
+}

--- a/demos/mcp-slack-oauth/tsconfig.json
+++ b/demos/mcp-slack-oauth/tsconfig.json
@@ -1,42 +1,42 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-    /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "target": "es2021",
-    /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "lib": ["es2021"],
-    /* Specify what JSX code is generated. */
-    "jsx": "react-jsx",
+		/* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+		"target": "es2021",
+		/* Specify a set of bundled library declaration files that describe the target runtime environment. */
+		"lib": ["es2021"],
+		/* Specify what JSX code is generated. */
+		"jsx": "react-jsx",
 
-    /* Specify what module code is generated. */
-    "module": "es2022",
-    /* Specify how TypeScript looks up a file from a given module specifier. */
-    "moduleResolution": "node",
-    /* Specify type package names to be included without being referenced in a source file. */
-    "types": ["@cloudflare/workers-types/2023-07-01"],
-    /* Enable importing .json files */
-    "resolveJsonModule": true,
+		/* Specify what module code is generated. */
+		"module": "es2022",
+		/* Specify how TypeScript looks up a file from a given module specifier. */
+		"moduleResolution": "node",
+		/* Specify type package names to be included without being referenced in a source file. */
+		"types": ["@cloudflare/workers-types/2023-07-01"],
+		/* Enable importing .json files */
+		"resolveJsonModule": true,
 
-    /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-    "allowJs": true,
-    /* Enable error reporting in type-checked JavaScript files. */
-    "checkJs": false,
+		/* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+		"allowJs": true,
+		/* Enable error reporting in type-checked JavaScript files. */
+		"checkJs": false,
 
-    /* Disable emitting files from a compilation. */
-    "noEmit": true,
+		/* Disable emitting files from a compilation. */
+		"noEmit": true,
 
-    /* Ensure that each file can be safely transpiled without relying on other imports. */
-    "isolatedModules": true,
-    /* Allow 'import x from y' when a module doesn't have a default export. */
-    "allowSyntheticDefaultImports": true,
-    /* Ensure that casing is correct in imports. */
-    "forceConsistentCasingInFileNames": true,
+		/* Ensure that each file can be safely transpiled without relying on other imports. */
+		"isolatedModules": true,
+		/* Allow 'import x from y' when a module doesn't have a default export. */
+		"allowSyntheticDefaultImports": true,
+		/* Ensure that casing is correct in imports. */
+		"forceConsistentCasingInFileNames": true,
 
-    /* Enable all strict type-checking options. */
-    "strict": true,
+		/* Enable all strict type-checking options. */
+		"strict": true,
 
-    /* Skip type checking all .d.ts files. */
-    "skipLibCheck": true
-  }
+		/* Skip type checking all .d.ts files. */
+		"skipLibCheck": true
+	}
 }

--- a/demos/mcp-slack-oauth/wrangler.jsonc
+++ b/demos/mcp-slack-oauth/wrangler.jsonc
@@ -1,33 +1,33 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "mcp-slack-oauth",
-  "main": "src/index.ts",
-  "compatibility_date": "2025-03-10",
-  "compatibility_flags": ["nodejs_compat"],
-  "migrations": [
-    {
-      "new_sqlite_classes": ["SlackMCP"],
-      "tag": "v1"
-    }
-  ],
-  "durable_objects": {
-    "bindings": [
-      {
-        "class_name": "SlackMCP",
-        "name": "MCP_OBJECT"
-      }
-    ]
-  },
-  "kv_namespaces": [
-    {
-      "binding": "OAUTH_KV",
-      "id": "<YOUR_KV_NAMESPACE_ID>"
-    }
-  ],
-  "observability": {
-    "enabled": true
-  },
-  "dev": {
-    "port": 8788
-  }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "mcp-slack-oauth",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-03-10",
+	"compatibility_flags": ["nodejs_compat"],
+	"migrations": [
+		{
+			"new_sqlite_classes": ["SlackMCP"],
+			"tag": "v1"
+		}
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "SlackMCP",
+				"name": "MCP_OBJECT"
+			}
+		]
+	},
+	"kv_namespaces": [
+		{
+			"binding": "OAUTH_KV",
+			"id": "<YOUR_KV_NAMESPACE_ID>"
+		}
+	],
+	"observability": {
+		"enabled": true
+	},
+	"dev": {
+		"port": 8788
+	}
 }

--- a/demos/remote-mcp-server/src/utils.ts
+++ b/demos/remote-mcp-server/src/utils.ts
@@ -369,11 +369,13 @@ export const renderApproveContent = async (
 			>
 				Return to Home
 			</a>
-			<script>
-				setTimeout(() => {
-					window.location.href = "${redirectUrl}";
-				}, 2000);
-			</script>
+			${raw(`
+				<script>
+					setTimeout(() => {
+						window.location.href = "${redirectUrl}";
+					}, 2000);
+				</script>
+			`)}
 		</div>
 	`;
 };


### PR DESCRIPTION
We're seeing some issues in the AI playground with our example app where the state parameter isn't being received:

![unnamed](https://github.com/user-attachments/assets/908cd63f-5ee1-46aa-b632-8cd5a06a6300)

This is due to the calback url that it is redirecting to being url-encoded:

`https://playground.ai.cloudflare.com/oauth/callback?code=user%40example.com%3A7NY6hWLahos12xYn%3AGNqt55a53CxUpPaDa2Hqc7XWMXAs60KE&amp;state=6w66fqpv6fs`

This does not look like a problem with the playground itself, but rather this demo. We write the redirect script inline with the rest of the page's HTML using hono's html helper, and this automatically re-encodes the url. Explicitly marking this as a raw string resolves the issue.