### PR TITLE
Format the redirectUrl to work with the AI Playground

### DIFF
--- a/demos/remote-mcp-server/src/utils.ts
+++ b/demos/remote-mcp-server/src/utils.ts
@@ -371,7 +371,7 @@ export const renderApproveContent = async (
 			</a>
 			<script>
 				setTimeout(() => {
-					window.location.href = "${redirectUrl}";
+	 				window.location.href = decodeURIComponent("${redirectUrl}").replace(/\&amp\;/g, '&');
 				}, 2000);
 			</script>
 		</div>


### PR DESCRIPTION
The `&amp;` will break on the AI Playground. Not sure if this is exactly how you want to fix this or if you should probably just fix the AI playground checker but this does fix the problem