### PR TITLE
Fixing some deploy to workers flows for other packages and add back husky checks

### DIFF
--- a/demos/agent-scheduler/package.json
+++ b/demos/agent-scheduler/package.json
@@ -18,11 +18,12 @@
 		"@biomejs/biome": "^1.8.2",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"typescript": "^5.5.2",
+		"vite": "^6.2.3",
 		"vitest": "~3.0.7",
-		"vite": "^6.1.0",
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",

--- a/demos/agent-task-manager-human-in-the-loop/package.json
+++ b/demos/agent-task-manager-human-in-the-loop/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/agent-task-manager/package.json
+++ b/demos/agent-task-manager/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/evaluator-optimiser/package.json
+++ b/demos/evaluator-optimiser/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/image-generation/package.json
+++ b/demos/image-generation/package.json
@@ -21,9 +21,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
-		"workers-ai-provider": "^0.2.1",
+		"@cloudflare/vite-plugin": "^0.1.19",
+		"ai": "^4.1.39",
 		"hono": "^4.7.1",
-		"zod": "^3.24.2",
-		"ai": "^4.1.39"
+		"vite": "^6.2.3",
+		"workers-ai-provider": "^0.2.1",
+		"zod": "^3.24.2"
 	}
 }

--- a/demos/mcp-slack-oauth/package.json
+++ b/demos/mcp-slack-oauth/package.json
@@ -22,6 +22,8 @@
 		"zod": "^3.24.2"
 	},
 	"dependencies": {
-		"@slack/web-api": "^7.9.0"
+		"@cloudflare/vite-plugin": "^0.1.19",
+		"@slack/web-api": "^7.9.0",
+		"vite": "^6.2.3"
 	}
 }

--- a/demos/model-scraper/package.json
+++ b/demos/model-scraper/package.json
@@ -25,9 +25,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/orchestrator-workers/package.json
+++ b/demos/orchestrator-workers/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/parallelisation/package.json
+++ b/demos/parallelisation/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/prompt-chaining/package.json
+++ b/demos/prompt-chaining/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/remote-mcp-github-oauth/package.json
+++ b/demos/remote-mcp-github-oauth/package.json
@@ -9,8 +9,8 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250310.0",
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
+		"@cloudflare/workers-types": "^4.20250310.0",
 		"@modelcontextprotocol/sdk": "^1.7.0",
 		"hono": "^4.7.4",
 		"just-pick": "^4.2.0",
@@ -20,5 +20,9 @@
 		"workers-mcp": "0.1.0-3",
 		"wrangler": "^3.112.0",
 		"zod": "^3.24.2"
+	},
+	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
+		"vite": "^6.2.3"
 	}
 }

--- a/demos/remote-mcp-server/package.json
+++ b/demos/remote-mcp-server/package.json
@@ -17,10 +17,12 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@modelcontextprotocol/sdk": "^1.7.0",
 		"agents": "^0.0.43",
 		"hono": "^4.7.4",
+		"vite": "^6.2.3",
 		"zod": "^3.24.2"
 	}
 }

--- a/demos/routing/package.json
+++ b/demos/routing/package.json
@@ -21,9 +21,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/structured-output-node/package.json
+++ b/demos/structured-output-node/package.json
@@ -14,7 +14,9 @@
 		"vitest": "~3.0.7"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"ai": "^4.1.39",
+		"vite": "^6.2.3",
 		"zod": "^3.24.2"
 	}
 }

--- a/demos/structured-output/package.json
+++ b/demos/structured-output/package.json
@@ -23,9 +23,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"zod": "^3.24.2"
 	}
 }

--- a/demos/text-generation-stream/package.json
+++ b/demos/text-generation-stream/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/text-generation/package.json
+++ b/demos/text-generation/package.json
@@ -21,9 +21,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/tool-calling-stream-traditional/package.json
+++ b/demos/tool-calling-stream-traditional/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"zod": "^3.24.2"
 	}
 }

--- a/demos/tool-calling-stream/package.json
+++ b/demos/tool-calling-stream/package.json
@@ -22,9 +22,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/tool-calling/package.json
+++ b/demos/tool-calling/package.json
@@ -23,9 +23,11 @@
 		"wrangler": "^4.2.0"
 	},
 	"dependencies": {
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"agents-sdk": "^0.0.27",
 		"ai": "^4.1.39",
 		"hono": "^4.7.1",
+		"vite": "^6.2.3",
 		"workers-ai-provider": "^0.2.1",
 		"zod": "^3.24.2"
 	}

--- a/demos/ui-worker/package.json
+++ b/demos/ui-worker/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.8.2",
-		"@cloudflare/vite-plugin": "^0.1.5",
+		"@cloudflare/vite-plugin": "^0.1.19",
 		"@cloudflare/vitest-pool-workers": "^0.7.5",
 		"@types/react": "^19.0.8",
 		"@types/react-dom": "^19.0.3",
@@ -25,7 +25,7 @@
 		"postcss-preset-mantine": "^1.17.0",
 		"postcss-simple-vars": "^7.0.1",
 		"typescript": "^5.5.2",
-		"vite": "^6.1.0",
+		"vite": "^6.2.3",
 		"vitest": "~3.0.7",
 		"wrangler": "^4.2.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
 		},
 		"demos/agent-scheduler": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
@@ -109,16 +110,18 @@
 				"@biomejs/biome": "^1.8.2",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"typescript": "^5.5.2",
-				"vite": "^6.1.0",
+				"vite": "^6.2.3",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
 		},
 		"demos/agent-task-manager": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -132,9 +135,11 @@
 		},
 		"demos/agent-task-manager-human-in-the-loop": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -148,9 +153,11 @@
 		},
 		"demos/evaluator-optimiser": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -164,8 +171,10 @@
 		},
 		"demos/image-generation": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -179,7 +188,9 @@
 		"demos/mcp-slack-oauth": {
 			"version": "0.0.1",
 			"dependencies": {
-				"@slack/web-api": "^7.9.0"
+				"@cloudflare/vite-plugin": "^0.1.19",
+				"@slack/web-api": "^7.9.0",
+				"vite": "^6.2.3"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
@@ -213,9 +224,11 @@
 		},
 		"demos/model-scraper": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -229,9 +242,11 @@
 		},
 		"demos/orchestrator-workers": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -245,9 +260,11 @@
 		},
 		"demos/parallelisation": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -261,9 +278,11 @@
 		},
 		"demos/prompt-chaining": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -278,6 +297,10 @@
 		"demos/remote-mcp-github-oauth": {
 			"name": "mcp-github-oauth",
 			"version": "0.0.1",
+			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
+				"vite": "^6.2.3"
+			},
 			"devDependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@cloudflare/workers-types": "^4.20250310.0",
@@ -756,20 +779,6 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"demos/remote-mcp-github-oauth/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"demos/remote-mcp-github-oauth/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"demos/remote-mcp-github-oauth/node_modules/prettier": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
@@ -841,10 +850,12 @@
 		"demos/remote-mcp-server": {
 			"version": "0.0.0",
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@modelcontextprotocol/sdk": "^1.7.0",
 				"agents": "^0.0.43",
 				"hono": "^4.7.4",
+				"vite": "^6.2.3",
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
@@ -872,9 +883,11 @@
 		},
 		"demos/routing": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -888,9 +901,11 @@
 		},
 		"demos/structured-output": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
@@ -903,7 +918,9 @@
 		},
 		"demos/structured-output-node": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"ai": "^4.1.39",
+				"vite": "^6.2.3",
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
@@ -930,9 +947,11 @@
 		},
 		"demos/text-generation": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -945,9 +964,11 @@
 		},
 		"demos/text-generation-stream": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -961,9 +982,11 @@
 		},
 		"demos/tool-calling": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -977,9 +1000,11 @@
 		},
 		"demos/tool-calling-stream": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"workers-ai-provider": "^0.2.1",
 				"zod": "^3.24.2"
 			},
@@ -993,9 +1018,11 @@
 		},
 		"demos/tool-calling-stream-traditional": {
 			"dependencies": {
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"agents-sdk": "^0.0.27",
 				"ai": "^4.1.39",
 				"hono": "^4.7.1",
+				"vite": "^6.2.3",
 				"zod": "^3.24.2"
 			},
 			"devDependencies": {
@@ -1024,7 +1051,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.8.2",
-				"@cloudflare/vite-plugin": "^0.1.5",
+				"@cloudflare/vite-plugin": "^0.1.19",
 				"@cloudflare/vitest-pool-workers": "^0.7.5",
 				"@types/react": "^19.0.8",
 				"@types/react-dom": "^19.0.3",
@@ -1033,7 +1060,7 @@
 				"postcss-preset-mantine": "^1.17.0",
 				"postcss-simple-vars": "^7.0.1",
 				"typescript": "^5.5.2",
-				"vite": "^6.1.0",
+				"vite": "^6.2.3",
 				"vitest": "~3.0.7",
 				"wrangler": "^4.2.0"
 			}
@@ -2057,15 +2084,43 @@
 				"node": ">=16.13"
 			}
 		},
-		"node_modules/@cloudflare/unenv-preset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-1.1.1.tgz",
-			"integrity": "sha512-8y7gFmXnOF9kycm8eIaL0rNBd5np3a/aLaG04pfFG4aEF0rIHAMiGFxQfg1ZIV77ApLHzPomr9/ixLbZWXwX3w==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
+		"node_modules/@cloudflare/vite-plugin": {
+			"version": "0.1.19",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-0.1.19.tgz",
+			"integrity": "sha512-0bb07KFQIRsoj9iWK0DW7Yy6DhwQhoa5e22eJfmWLbAGvrGSpV2GGhRYZJuxMni0rCNLkHoVNV2v2gpRh2P2DA==",
+			"dependencies": {
+				"@cloudflare/unenv-preset": "2.3.1",
+				"@hattip/adapter-node": "^0.0.49",
+				"miniflare": "4.20250321.1",
+				"picocolors": "^1.1.1",
+				"tinyglobby": "^0.2.12",
+				"unenv": "2.0.0-rc.15",
+				"wrangler": "4.6.0",
+				"ws": "8.18.0"
+			},
 			"peerDependencies": {
-				"unenv": "2.0.0-rc.1",
-				"workerd": "^1.20250124.0"
+				"vite": "^6.1.0",
+				"wrangler": "^3.101.0 || ^4.0.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/kv-asset-handler": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
+			"integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+			"dependencies": {
+				"mime": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/unenv-preset": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.1.tgz",
+			"integrity": "sha512-Xq57Qd+ADpt6hibcVBO0uLG9zzRgyRhfCUgBT9s+g3+3Ivg5zDyVgLFy40ES1VdNcu8rPNSivm9A+kGP5IVaPg==",
+			"peerDependencies": {
+				"unenv": "2.0.0-rc.15",
+				"workerd": "^1.20250320.0"
 			},
 			"peerDependenciesMeta": {
 				"workerd": {
@@ -2073,483 +2128,666 @@
 				}
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-0.1.10.tgz",
-			"integrity": "sha512-jGQKXle5JeXFHIKHC6n7Vv+L5B5G25b3Uu13xAwiQqsBXDHK78VmUzpVViZLIxrA+YjNcM5znXCxbdvoWkc1xA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cloudflare/unenv-preset": "1.1.1",
-				"@hattip/adapter-node": "^0.0.49",
-				"miniflare": "3.20250310.0",
-				"tinyglobby": "^0.2.12",
-				"unenv": "2.0.0-rc.1",
-				"wrangler": "3.114.1",
-				"ws": "8.18.0"
-			},
-			"peerDependencies": {
-				"vite": "^6.1.0",
-				"wrangler": "^3.101.0"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-			"integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-			"integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-			"integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250327.0.tgz",
+			"integrity": "sha512-Z3YhGG/duERB8/mDMRf4Vncgy3J+Xnm/6IME2/gvOf6LuO9Tpqe9cDil2p8u1nU2JRLz6kk34R2uGKp2dFUW3A==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-			"integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250327.0.tgz",
+			"integrity": "sha512-f1Ww3QVXBb+OraHLIEfiHbHufeuAQENjH7qwOCUXdWveJm8e6mbfcxMNiHF4Oj2KFLQKY1qo0J0Q/cK37xIYCw==",
 			"cpu": [
-				"x64"
+				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-			"integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-			"integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250327.0.tgz",
+			"integrity": "sha512-Cp44pxVq8b+oOxjwH2LhLzmDvbODCVtMOPwqzRkCYFQ+0tNzkdcZcKb5Fqqub/v7cNz+o6SWtLv15HVqtDewkw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-			"integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-			"integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250327.0.tgz",
+			"integrity": "sha512-8G8+F7nA4mB9Z9EBtNErbZha90lLwr1EaeCnFOBAkeZCarFd9vwIVSDLEXvlg6iIe9e1+X8KTGXBmDxGEDU2XA==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-			"integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250327.0.tgz",
+			"integrity": "sha512-resv5O5dlztci11kWPPwPDglW949WOKumNFxvkboSE3Tbea7JfzYkB6JmNT/xCeobm2H4zgQlewoEeqQtg9Zwg==",
 			"cpu": [
-				"ia32"
+				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
-				"linux"
+				"win32"
 			],
+			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-			"integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-			"integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-			"integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/android-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/darwin-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+			"cpu": [
+				"arm"
+			],
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ia32": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-loong64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-			"integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-			"integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/linux-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-			"integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
 			"cpu": [
-				"x64"
+				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"netbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-			"integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"cpu": [
+				"arm64"
+			],
 			"optional": true,
 			"os": [
 				"openbsd"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-			"integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/sunos-x64": {
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+			"cpu": [
+				"x64"
+			],
 			"optional": true,
 			"os": [
 				"sunos"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-			"integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-			"integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/@esbuild/win32-x64": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-			"integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/esbuild": {
-			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-			"dev": true,
+			"version": "0.24.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
 			"hasInstallScript": true,
-			"license": "MIT",
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.19",
-				"@esbuild/android-arm64": "0.17.19",
-				"@esbuild/android-x64": "0.17.19",
-				"@esbuild/darwin-arm64": "0.17.19",
-				"@esbuild/darwin-x64": "0.17.19",
-				"@esbuild/freebsd-arm64": "0.17.19",
-				"@esbuild/freebsd-x64": "0.17.19",
-				"@esbuild/linux-arm": "0.17.19",
-				"@esbuild/linux-arm64": "0.17.19",
-				"@esbuild/linux-ia32": "0.17.19",
-				"@esbuild/linux-loong64": "0.17.19",
-				"@esbuild/linux-mips64el": "0.17.19",
-				"@esbuild/linux-ppc64": "0.17.19",
-				"@esbuild/linux-riscv64": "0.17.19",
-				"@esbuild/linux-s390x": "0.17.19",
-				"@esbuild/linux-x64": "0.17.19",
-				"@esbuild/netbsd-x64": "0.17.19",
-				"@esbuild/openbsd-x64": "0.17.19",
-				"@esbuild/sunos-x64": "0.17.19",
-				"@esbuild/win32-arm64": "0.17.19",
-				"@esbuild/win32-ia32": "0.17.19",
-				"@esbuild/win32-x64": "0.17.19"
+				"@esbuild/aix-ppc64": "0.24.2",
+				"@esbuild/android-arm": "0.24.2",
+				"@esbuild/android-arm64": "0.24.2",
+				"@esbuild/android-x64": "0.24.2",
+				"@esbuild/darwin-arm64": "0.24.2",
+				"@esbuild/darwin-x64": "0.24.2",
+				"@esbuild/freebsd-arm64": "0.24.2",
+				"@esbuild/freebsd-x64": "0.24.2",
+				"@esbuild/linux-arm": "0.24.2",
+				"@esbuild/linux-arm64": "0.24.2",
+				"@esbuild/linux-ia32": "0.24.2",
+				"@esbuild/linux-loong64": "0.24.2",
+				"@esbuild/linux-mips64el": "0.24.2",
+				"@esbuild/linux-ppc64": "0.24.2",
+				"@esbuild/linux-riscv64": "0.24.2",
+				"@esbuild/linux-s390x": "0.24.2",
+				"@esbuild/linux-x64": "0.24.2",
+				"@esbuild/netbsd-arm64": "0.24.2",
+				"@esbuild/netbsd-x64": "0.24.2",
+				"@esbuild/openbsd-arm64": "0.24.2",
+				"@esbuild/openbsd-x64": "0.24.2",
+				"@esbuild/sunos-x64": "0.24.2",
+				"@esbuild/win32-arm64": "0.24.2",
+				"@esbuild/win32-ia32": "0.24.2",
+				"@esbuild/win32-x64": "0.24.2"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare": {
+			"version": "4.20250321.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250321.1.tgz",
+			"integrity": "sha512-pQuVtF6vQ1zMvPCo3Z19mzSFjgnlEnybzNzAJZipsqIk6kMXpYBZq+d8cWmeQFkBYlgeZKeKJ4EBKT6KapfTNg==",
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"acorn": "8.14.0",
+				"acorn-walk": "8.3.2",
+				"exit-hook": "2.2.1",
+				"glob-to-regexp": "0.4.1",
+				"stoppable": "1.1.0",
+				"undici": "^5.28.5",
+				"workerd": "1.20250321.0",
+				"ws": "8.18.0",
+				"youch": "3.2.3",
+				"zod": "3.22.3"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250321.0.tgz",
+			"integrity": "sha512-y273GfLaNCxkL8hTfo0c8FZKkOPdq+CPZAKJXPWB+YpS1JCOULu6lNTptpD7ZtF14dTYPkn5Weug31TTlviJmw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-qvf7/gkkQq7fAsoMlntJSimN/WfwQqxi2oL0aWZMGodTvs/yRHO2I4oE0eOihVdK1BXyBHJXNxEvNDBjF0+Yuw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250321.0.tgz",
+			"integrity": "sha512-AEp3xjWFrNPO/h0StCOgOb0bWCcNThnkESpy91Wf4mfUF2p7tOCdp37Nk/1QIRqSxnfv4Hgxyi7gcWud9cJuMw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-wRWyMIoPIS1UBXCisW0FYTgGsfZD4AVS0hXA5nuLc0c21CvzZpmmTjqEWMcwPFenwy/MNL61NautVOC4qJqQ3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250321.0.tgz",
+			"integrity": "sha512-8vYP3QYO0zo2faUDfWl88jjfUvz7Si9GS3mUYaTh/TR9LcAUtsO7muLxPamqEyoxNFtbQgy08R4rTid94KRi3w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/miniflare/node_modules/workerd": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250321.0.tgz",
+			"integrity": "sha512-vyuz9pdJ+7o1lC79vQ2UVRLXPARa2Lq94PbTfqEcYQeSxeR9X+YqhNq2yysv8Zs5vpokmexLCtMniPp9u+2LVQ==",
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250321.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250321.0",
+				"@cloudflare/workerd-linux-64": "1.20250321.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250321.0",
+				"@cloudflare/workerd-windows-64": "1.20250321.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/workerd": {
+			"version": "1.20250327.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250327.0.tgz",
+			"integrity": "sha512-DWsEVeafgWryumxVOyiyh/ZIe/LJavuMXOxMUl4DLLU1Rc7Z7uGGLtk6zf067MjWq1AHcVD9QPsqN1LKmaVzBw==",
+			"hasInstallScript": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250327.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250327.0",
+				"@cloudflare/workerd-linux-64": "1.20250327.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250327.0",
+				"@cloudflare/workerd-windows-64": "1.20250327.0"
+			}
 		},
 		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler": {
-			"version": "3.114.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.1.tgz",
-			"integrity": "sha512-GuS6SrnAZZDiNb20Vf2Ww0KCfnctHUEzi5GyML1i2brfQPI6BikgI/W/u6XDtYtah0OkbIWIiNJ+SdhWT7KEcw==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.6.0.tgz",
+			"integrity": "sha512-2a2ZD0adlvxQ1H+nRKkuuD0dkgaYTOPlC7gBolItk5TfqOSliEV4m6DtZtKtJp33ioM+Uy6TlEWPpA2TrDveEQ==",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.3.4",
-				"@cloudflare/unenv-preset": "2.0.2",
-				"@esbuild-plugins/node-globals-polyfill": "0.2.3",
-				"@esbuild-plugins/node-modules-polyfill": "0.2.2",
+				"@cloudflare/kv-asset-handler": "0.4.0",
+				"@cloudflare/unenv-preset": "2.3.1",
 				"blake3-wasm": "2.1.5",
-				"esbuild": "0.17.19",
-				"miniflare": "3.20250310.0",
+				"esbuild": "0.24.2",
+				"miniflare": "4.20250321.1",
 				"path-to-regexp": "6.3.0",
-				"unenv": "2.0.0-rc.14",
-				"workerd": "1.20250310.0"
+				"unenv": "2.0.0-rc.15",
+				"workerd": "1.20250321.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=16.17.0"
+				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2",
 				"sharp": "^0.33.5"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20250310.0"
+				"@cloudflare/workers-types": "^4.20250321.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -2557,34 +2795,106 @@
 				}
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
-			"integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"peerDependencies": {
-				"unenv": "2.0.0-rc.14",
-				"workerd": "^1.20250124.0"
-			},
-			"peerDependenciesMeta": {
-				"workerd": {
-					"optional": true
-				}
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250321.0.tgz",
+			"integrity": "sha512-y273GfLaNCxkL8hTfo0c8FZKkOPdq+CPZAKJXPWB+YpS1JCOULu6lNTptpD7ZtF14dTYPkn5Weug31TTlviJmw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/unenv": {
-			"version": "2.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
-			"integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defu": "^6.1.4",
-				"exsolve": "^1.0.1",
-				"ohash": "^2.0.10",
-				"pathe": "^2.0.3",
-				"ufo": "^1.5.4"
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-qvf7/gkkQq7fAsoMlntJSimN/WfwQqxi2oL0aWZMGodTvs/yRHO2I4oE0eOihVdK1BXyBHJXNxEvNDBjF0+Yuw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250321.0.tgz",
+			"integrity": "sha512-AEp3xjWFrNPO/h0StCOgOb0bWCcNThnkESpy91Wf4mfUF2p7tOCdp37Nk/1QIRqSxnfv4Hgxyi7gcWud9cJuMw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250321.0.tgz",
+			"integrity": "sha512-wRWyMIoPIS1UBXCisW0FYTgGsfZD4AVS0hXA5nuLc0c21CvzZpmmTjqEWMcwPFenwy/MNL61NautVOC4qJqQ3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250321.0.tgz",
+			"integrity": "sha512-8vYP3QYO0zo2faUDfWl88jjfUvz7Si9GS3mUYaTh/TR9LcAUtsO7muLxPamqEyoxNFtbQgy08R4rTid94KRi3w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/wrangler/node_modules/workerd": {
+			"version": "1.20250321.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250321.0.tgz",
+			"integrity": "sha512-vyuz9pdJ+7o1lC79vQ2UVRLXPARa2Lq94PbTfqEcYQeSxeR9X+YqhNq2yysv8Zs5vpokmexLCtMniPp9u+2LVQ==",
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20250321.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250321.0",
+				"@cloudflare/workerd-linux-64": "1.20250321.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250321.0",
+				"@cloudflare/workerd-windows-64": "1.20250321.0"
+			}
+		},
+		"node_modules/@cloudflare/vite-plugin/node_modules/zod": {
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+			"integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
@@ -3037,20 +3347,6 @@
 				"@esbuild/win32-x64": "0.17.19"
 			}
 		},
-		"node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@cloudflare/vitest-pool-workers/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@cloudflare/vitest-pool-workers/node_modules/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -3211,16 +3507,14 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20250319.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250319.0.tgz",
-			"integrity": "sha512-TTg1WZZuWJomzU3g1TvqE/WWI3zpTu1K+RsJvk6zxEgjhONN2PzqUUqKVYOQBk4/p7d+v7h6wz2gX3Ke7Arm7g==",
-			"license": "MIT OR Apache-2.0"
+			"version": "4.20250327.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250327.0.tgz",
+			"integrity": "sha512-rkoGnSY/GgBLCuhjZMIC3mt0jjqqvL17uOK92OI4eivmE+pMFOAchowDxIWOzDyYe5vwNCakbCeIM/FrSmwGJA=="
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
@@ -3233,7 +3527,6 @@
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -3712,7 +4005,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
 			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -3792,7 +4084,6 @@
 			"version": "0.0.49",
 			"resolved": "https://registry.npmjs.org/@hattip/adapter-node/-/adapter-node-0.0.49.tgz",
 			"integrity": "sha512-BE+Y8Q4U0YcH34FZUYU4DssGKOaZLbNL0zK57Z41UZp0m9kS79ZIolBmjjpPhTVpIlRY3Rs+uhXbVXKk7mUcJA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hattip/core": "0.0.49",
@@ -3803,14 +4094,12 @@
 		"node_modules/@hattip/core": {
 			"version": "0.0.49",
 			"resolved": "https://registry.npmjs.org/@hattip/core/-/core-0.0.49.tgz",
-			"integrity": "sha512-3/ZJtC17cv8m6Sph8+nw4exUp9yhEf2Shi7HK6AHSUSBtaaQXZ9rJBVxTfZj3PGNOR/P49UBXOym/52WYKFTJQ==",
-			"dev": true
+			"integrity": "sha512-3/ZJtC17cv8m6Sph8+nw4exUp9yhEf2Shi7HK6AHSUSBtaaQXZ9rJBVxTfZj3PGNOR/P49UBXOym/52WYKFTJQ=="
 		},
 		"node_modules/@hattip/headers": {
 			"version": "0.0.49",
 			"resolved": "https://registry.npmjs.org/@hattip/headers/-/headers-0.0.49.tgz",
 			"integrity": "sha512-rrB2lEhTf0+MNVt5WdW184Ky706F1Ze9Aazn/R8c+/FMUYF9yjem2CgXp49csPt3dALsecrnAUOHFiV0LrrHXA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hattip/core": "0.0.49"
@@ -3820,7 +4109,6 @@
 			"version": "0.0.49",
 			"resolved": "https://registry.npmjs.org/@hattip/polyfills/-/polyfills-0.0.49.tgz",
 			"integrity": "sha512-5g7W5s6Gq+HDxwULGFQ861yAnEx3yd9V8GDwS96HBZ1nM1u93vN+KTuwXvNsV7Z3FJmCrD/pgU8WakvchclYuA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hattip/core": "0.0.49",
@@ -3832,7 +4120,6 @@
 			"version": "0.0.49",
 			"resolved": "https://registry.npmjs.org/@hattip/walk/-/walk-0.0.49.tgz",
 			"integrity": "sha512-AgJgKLooZyQnzMfoFg5Mo/aHM+HGBC9ExpXIjNqGimYTRgNbL/K7X5EM1kR2JY90BNKk9lo6Usq1T/nWFdT7TQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hattip/headers": "0.0.49",
@@ -4519,7 +4806,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
 			"integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@langchain/core": {
@@ -6371,13 +6657,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/@vitest/runner/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@vitest/snapshot": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
@@ -6392,13 +6671,6 @@
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
-		},
-		"node_modules/@vitest/snapshot/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@vitest/spy": {
 			"version": "3.0.9",
@@ -6432,7 +6704,6 @@
 			"version": "0.9.23",
 			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.23.tgz",
 			"integrity": "sha512-7xlqWel9JsmxahJnYVUj/LLxWcnA93DR4c9xlw3U814jWTiYalryiH1qToik1hOxweKKRLi4haXHM5ycRksPBA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@whatwg-node/node-fetch": "^0.6.0",
@@ -6446,7 +6717,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.6.0.tgz",
 			"integrity": "sha512-tcZAhrpx6oVlkEsRngeTEEE7I5/QdLjeEz4IlekabGaESP7+Dkm/6a9KcF1KdCBB7mO9PXtBkwCuTCt8+UPg8Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@kamilkisiela/fast-url-parser": "^1.1.4",
@@ -6566,7 +6836,6 @@
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -6579,7 +6848,6 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
 			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
@@ -6825,7 +7093,6 @@
 			"version": "1.0.55",
 			"resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
 			"integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"printable-characters": "^1.0.42"
@@ -6935,7 +7202,6 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
 			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bluebird": {
@@ -7107,7 +7373,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
 			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dev": true,
 			"dependencies": {
 				"streamsearch": "^1.1.0"
 			},
@@ -7381,7 +7646,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
 			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -7414,7 +7678,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
 			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -7456,13 +7719,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"license": "MIT"
-		},
-		"node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/consola": {
@@ -7515,7 +7771,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -7599,7 +7854,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
 			"integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dataloader": {
@@ -7678,7 +7932,6 @@
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/delayed-stream": {
@@ -7731,7 +7984,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
 			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"engines": {
@@ -8110,7 +8362,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
 			"integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -8244,7 +8495,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.4.tgz",
 			"integrity": "sha512-xsZH6PXaER4XoV+NiT7JHp1bJodJVT+cxeSH1G0f0tlT0lJqYuHUP3bUx2HtfTDvOagMINYp8rsqusxud3RXhw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/extendable-error": {
@@ -8300,7 +8550,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
 			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
@@ -8329,7 +8578,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
 			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-decode-uri-component": "^1.0.1"
@@ -8731,7 +8979,6 @@
 			"version": "2.0.12",
 			"resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
 			"integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
-			"dev": true,
 			"license": "Unlicense",
 			"dependencies": {
 				"data-uri-to-buffer": "^2.0.0",
@@ -8787,7 +9034,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
@@ -9085,7 +9331,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
 			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true
 		},
@@ -10067,7 +10312,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
 			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
@@ -10186,26 +10430,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/mlly": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.14.0",
-				"pathe": "^2.0.1",
-				"pkg-types": "^1.3.0",
-				"ufo": "^1.5.4"
-			}
-		},
-		"node_modules/mlly/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/model-scraper": {
 			"resolved": "demos/model-scraper",
@@ -10378,7 +10602,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
 			"integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-machine-id": {
@@ -10673,11 +10896,9 @@
 			}
 		},
 		"node_modules/ohash": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-			"integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -11097,7 +11318,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-type": {
@@ -11110,11 +11330,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
 		},
 		"node_modules/pathval": {
 			"version": "2.0.0",
@@ -11171,30 +11389,10 @@
 				"node": ">=16.20.0"
 			}
 		},
-		"node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
-			}
-		},
-		"node_modules/pkg-types/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
 			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -11409,7 +11607,6 @@
 			"version": "1.0.42",
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-			"dev": true,
 			"license": "Unlicense"
 		},
 		"node_modules/prompt-chaining": {
@@ -12129,7 +12326,6 @@
 			"version": "0.33.5",
 			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
 			"integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -12170,7 +12366,6 @@
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
 			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"dev": true,
 			"license": "ISC",
 			"optional": true,
 			"bin": {
@@ -12291,7 +12486,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -12324,7 +12518,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -12334,7 +12527,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -12387,7 +12579,6 @@
 			"version": "2.1.8",
 			"resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
 			"integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
-			"dev": true,
 			"license": "Unlicense",
 			"dependencies": {
 				"as-table": "^1.0.36",
@@ -12414,7 +12605,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4",
@@ -12425,7 +12615,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -12563,7 +12752,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-4.0.1.tgz",
 			"integrity": "sha512-WCjS5NfuVJjkQzK10s8WOBY+hhDxxNt/N6ZaGwxFZ+wN3/lKKFSaaKUNecULcTTvE4urLcKaZFQD8vO0mOZujw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0"
@@ -13133,7 +13322,6 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
 			"integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uglify-js": {
@@ -13165,7 +13353,6 @@
 			"version": "5.28.5",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
 			"integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
@@ -13181,16 +13368,14 @@
 			"license": "MIT"
 		},
 		"node_modules/unenv": {
-			"version": "2.0.0-rc.1",
-			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.1.tgz",
-			"integrity": "sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==",
-			"dev": true,
-			"license": "MIT",
+			"version": "2.0.0-rc.15",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz",
+			"integrity": "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==",
 			"dependencies": {
 				"defu": "^6.1.4",
-				"mlly": "^1.7.4",
-				"ohash": "^1.1.4",
-				"pathe": "^1.1.2",
+				"exsolve": "^1.0.4",
+				"ohash": "^2.0.11",
+				"pathe": "^2.0.3",
 				"ufo": "^1.5.4"
 			}
 		},
@@ -13272,7 +13457,6 @@
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
 			"integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/use-callback-ref": {
@@ -13415,11 +13599,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.1.tgz",
-			"integrity": "sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==",
-			"dev": true,
-			"license": "MIT",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+			"integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"postcss": "^8.5.3",
@@ -13509,13 +13691,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/vite-node/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/vitest": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
@@ -13585,13 +13760,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vitest/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/wait-on": {
 			"version": "8.0.3",
@@ -14453,20 +14621,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/wrangler/node_modules/ohash": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrangler/node_modules/pathe": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/wrangler/node_modules/unenv": {
 			"version": "2.0.0-rc.14",
 			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
@@ -14589,7 +14743,6 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -14689,7 +14842,6 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
 			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cookie": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"create-demo": "npx tsx ./tools/create-demo/index.ts",
 		"format": "biome format --write",
 		"lint": "biome lint",
+		"prepare": "if [ \"$CI\" ]; then echo 'Skipping husky setup in CI'; else husky; fi",
 		"lint:fix": "biome lint --fix"
 	},
 	"devDependencies": {

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -20,22 +20,8 @@
 		"test:ci": "vitest --watch=false",
 		"test": "vitest"
 	},
-	"files": [
-		"dist",
-		"src",
-		"README.md",
-		"package.json"
-	],
-	"keywords": [
-		"workers",
-		"cloudflare",
-		"ai",
-		"vercel",
-		"sdk",
-		"provider",
-		"chat",
-		"serverless"
-	],
+	"files": ["dist", "src", "README.md", "package.json"],
+	"keywords": ["workers", "cloudflare", "ai", "vercel", "sdk", "provider", "chat", "serverless"],
 	"dependencies": {
 		"@cloudflare/workers-types": "^4.20250313.0"
 	}


### PR DESCRIPTION
Earlier this week, I disabled the husky checks, this adds them back unless CI is enabled.

Additionally, a lot of the demo packages use vite and @cloudflare/vite-plugin, but they aren't included in the demo package.json files. This adds the correct packages to each demo package.json, which fixes the deploy to workers flows..