### PR TITLE
Add refresh token callback to Slack MCP oauth demo

### DIFF
--- a/demos/mcp-slack-oauth/README.md
+++ b/demos/mcp-slack-oauth/README.md
@@ -35,6 +35,7 @@ Acts as OAuth Client to your real OAuth server (in this case, Slack)
    - `users:read`
 3. Add your redirect URL: `https://mcp-slack-oauth.<your-subdomain>.workers.dev/callback`
 4. Make note of your Client ID and Client Secret from the "Basic Information" page
+5. *Optional* enable "Token Rotation" to use short-lived access tokens, which are automatically refreshed when the MCP client refreshes _its_ tokens (see `refreshSlackToken` for more details)
 
 ### Deploy to Cloudflare Workers
 

--- a/demos/mcp-slack-oauth/src/index.ts
+++ b/demos/mcp-slack-oauth/src/index.ts
@@ -3,7 +3,7 @@ import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { WebClient } from "@slack/web-api";
-import { Props, refreshSlackToken, SlackHandler } from "./slack-handler";
+import { type Props, refreshSlackToken, SlackHandler } from "./slack-handler";
 
 // To restrict access to specific users only, add their Slack userIDs to this Set.
 // Leave it empty to allow access to all authenticated users.
@@ -11,7 +11,7 @@ const ALLOWED_USERIDS = new Set([
 	// Example: 'U01234567',
 ]);
 
-export class SlackMCP extends McpAgent<Env, {}, Props> {
+export class SlackMCP extends McpAgent<Env, unknown, Props> {
 	server = new McpServer({
 		name: "Slack Assistant MCP",
 		version: "1.0.0",


### PR DESCRIPTION
This is only relevant if your slack app includes "token rotation", but is a good demonstration of the work required in synchronising downstream auth tokens (1 hour expiry by default, issued from the MCP server to the MCP client), and upstream ones (encrypted and available in `this.props` in the MCP server).

When the client token refresh request comes in, you manually refresh the upstream one and store the result in the new `props` object.