### PR TITLE
Add passthrough options to model settings

### DIFF
--- a/packages/workers-ai-provider/src/config.ts
+++ b/packages/workers-ai-provider/src/config.ts
@@ -1,0 +1,1 @@
+export const URL_OPTIONS = ["tiger"];

--- a/packages/workers-ai-provider/src/config.ts
+++ b/packages/workers-ai-provider/src/config.ts
@@ -1,1 +1,0 @@
-export const URL_OPTIONS = ["tiger"];

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -29,7 +29,7 @@ export interface AiRun {
 	): Promise<AiModels[Name]["postProcessedOutputs"]>;
 }
 
-type StringLike = string | { toString(): string };
+export type StringLike = string | { toString(): string };
 
 /**
  * Parameters for configuring the Cloudflare-based AI runner.

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -29,6 +29,8 @@ export interface AiRun {
 	): Promise<AiModels[Name]["postProcessedOutputs"]>;
 }
 
+type StringLike = string | { toString(): string };
+
 /**
  * Parameters for configuring the Cloudflare-based AI runner.
  */
@@ -60,14 +62,7 @@ export function createRun(config: CreateRunConfig): AiRun {
 	return async function run<Name extends keyof AiModels>(
 		model: Name,
 		inputs: AiModels[Name]["inputs"],
-		options?: AiOptions &
-			// Define the passthroughOptions as toStringable
-			Record<
-				string,
-				{
-					toString(): string;
-				}
-			>,
+		options?: AiOptions & Record<string, StringLike>,
 	): Promise<Response | ReadableStream<Uint8Array> | AiModels[Name]["postProcessedOutputs"]> {
 		const { gateway, prefix, extraHeaders, returnRawResponse, ...passthroughOptions } =
 			options || {};

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -69,11 +69,18 @@ export function createRun(config: CreateRunConfig): AiRun {
 
 		const urlParams = new URLSearchParams();
 		for (const [key, value] of Object.entries(passthroughOptions)) {
-			const valueStr = value.toString();
-			if (!valueStr) {
-				continue;
+			// throw a useful error if the value is not to-stringable
+			try {
+				const valueStr = value.toString();
+				if (!valueStr) {
+					continue;
+				}
+				urlParams.append(key, valueStr);
+			} catch (error) {
+				throw new Error(
+					`Value for option '${key}' is not able to be coerced into a string.`,
+				);
 			}
-			urlParams.append(key, valueStr);
 		}
 
 		const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}${urlParams ? `?${urlParams}` : ""}`;

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -139,6 +139,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 	): Promise<Awaited<ReturnType<LanguageModelV1["doGenerate"]>>> {
 		const { args, warnings } = this.getArgs(options);
 
+		const { gateway, safePrompt, ...passthroughOptions } = this.settings;
+
 		const output = await this.config.binding.run(
 			args.model,
 			{
@@ -150,7 +152,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 				// @ts-expect-error response_format not yet added to types
 				response_format: args.response_format,
 			},
-			{ gateway: this.config.gateway ?? this.settings.gateway },
+			{ gateway: this.config.gateway ?? gateway, ...passthroughOptions },
 		);
 
 		if (output instanceof ReadableStream) {
@@ -221,6 +223,8 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 		}
 
 		// [2] ...otherwise, we just proceed as normal and stream the response directly from the remote model.
+		const { gateway, ...passthroughOptions } = this.settings;
+
 		const response = await this.config.binding.run(
 			args.model,
 			{
@@ -233,7 +237,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV1 {
 				// @ts-expect-error response_format not yet added to types
 				response_format: args.response_format,
 			},
-			{ gateway: this.config.gateway ?? this.settings.gateway },
+			{ gateway: this.config.gateway ?? gateway, ...passthroughOptions },
 		);
 
 		if (!(response instanceof ReadableStream)) {

--- a/packages/workers-ai-provider/src/workersai-chat-settings.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-settings.ts
@@ -10,4 +10,9 @@ export interface WorkersAIChatSettings {
 	 * @deprecated
 	 */
 	gateway?: GatewayOptions;
+
+	/**
+	 * Passthrough settings that are provided directly to the run function.
+	 */
+	[key: string]: unknown;
 }

--- a/packages/workers-ai-provider/src/workersai-chat-settings.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-settings.ts
@@ -1,4 +1,6 @@
-export interface WorkersAIChatSettings {
+import type { StringLike } from "./utils";
+
+export type WorkersAIChatSettings = {
 	/**
 	 * Whether to inject a safety prompt before all conversations.
 	 * Defaults to `false`.
@@ -10,9 +12,9 @@ export interface WorkersAIChatSettings {
 	 * @deprecated
 	 */
 	gateway?: GatewayOptions;
-
+} & {
 	/**
 	 * Passthrough settings that are provided directly to the run function.
 	 */
-	[key: string]: unknown;
-}
+	[key: string]: StringLike;
+};

--- a/packages/workers-ai-provider/test/structured-output.test.ts
+++ b/packages/workers-ai-provider/test/structured-output.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
-import { setupServer } from "msw/node";
-import { http, HttpResponse } from "msw";
-import { createWorkersAI } from "../src/index";
 import { generateObject } from "ai";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
+import { createWorkersAI } from "../src/index";
 
 const TEST_ACCOUNT_ID = "test-account-id";
 const TEST_API_KEY = "test-api-key";
@@ -43,23 +43,65 @@ const structuredOutputHandler = http.post(
 
 const server = setupServer(structuredOutputHandler);
 
-describe("Structured Output Tests", () => {
+const recipeSchema = z.object({
+	recipe: z.object({
+		name: z.string(),
+		ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+		steps: z.array(z.string()),
+	}),
+});
+
+describe("REST API - Structured Output Tests", () => {
 	beforeAll(() => server.listen());
 	afterEach(() => server.resetHandlers());
 	afterAll(() => server.close());
-
-	const recipeSchema = z.object({
-		recipe: z.object({
-			name: z.string(),
-			ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
-			steps: z.array(z.string()),
-		}),
-	});
 
 	it("should generate structured output with schema (non-streaming)", async () => {
 		const workersai = createWorkersAI({
 			apiKey: TEST_API_KEY,
 			accountId: TEST_ACCOUNT_ID,
+		});
+
+		const { object } = await generateObject({
+			model: workersai(TEST_MODEL),
+			schema: recipeSchema,
+			prompt: "Give me a Spaghetti Bolognese recipe",
+		});
+
+		expect(object.recipe.name).toBe("Spaghetti Bolognese");
+		expect(object.recipe.ingredients.length).toBeGreaterThan(0);
+		expect(object.recipe.steps.length).toBeGreaterThan(0);
+	});
+});
+
+describe("Binding - Structured Output Tests", () => {
+	it("should generate structured output with schema (non-streaming)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (modelName: string, inputs: any, options?: any) => {
+					return {
+						response: {
+							recipe: {
+								name: "Spaghetti Bolognese",
+								ingredients: [
+									{ name: "spaghetti", amount: "200g" },
+									{ name: "minced beef", amount: "300g" },
+									{ name: "tomato sauce", amount: "500ml" },
+									{ name: "onion", amount: "1 medium" },
+									{ name: "garlic", amount: "2 cloves" },
+								],
+								steps: [
+									"Cook spaghetti.",
+									"Fry onion & garlic.",
+									"Add minced beef.",
+									"Simmer with sauce.",
+									"Serve.",
+								],
+							},
+						},
+					};
+				},
+			},
 		});
 
 		const { object } = await generateObject({

--- a/packages/workers-ai-provider/test/text-generation.test.ts
+++ b/packages/workers-ai-provider/test/text-generation.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
-import { setupServer } from "msw/node";
-import { http, HttpResponse } from "msw";
-import { createWorkersAI } from "../src/index";
 import { generateText } from "ai";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createWorkersAI } from "../src/index";
 
 const TEST_ACCOUNT_ID = "test-account-id";
 const TEST_API_KEY = "test-api-key";
@@ -17,7 +17,7 @@ const textGenerationHandler = http.post(
 
 const server = setupServer(textGenerationHandler);
 
-describe("Text Generation Tests", () => {
+describe("REST API - Text Generation Tests", () => {
 	beforeAll(() => server.listen());
 	afterEach(() => server.resetHandlers());
 	afterAll(() => server.close());
@@ -31,6 +31,25 @@ describe("Text Generation Tests", () => {
 			model: workersai(TEST_MODEL),
 			prompt: "Write a greeting",
 		});
+		expect(result.text).toBe("Hello");
+	});
+});
+
+describe("Binding - Text Generation Tests", () => {
+	it("should generate text (non-streaming)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (modelName: string, inputs: any, options?: any) => {
+					return { response: "Hello" };
+				},
+			},
+		});
+
+		const result = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Write a greeting",
+		});
+
 		expect(result.text).toBe("Hello");
 	});
 });

--- a/packages/workers-ai-provider/test/text-generation.test.ts
+++ b/packages/workers-ai-provider/test/text-generation.test.ts
@@ -33,6 +33,75 @@ describe("REST API - Text Generation Tests", () => {
 		});
 		expect(result.text).toBe("Hello");
 	});
+
+	it("should pass through additional options to the query string", async () => {
+		let capturedOptions: any = null;
+
+		const workersai = createWorkersAI({
+			apiKey: TEST_API_KEY,
+			accountId: TEST_ACCOUNT_ID,
+		});
+
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async ({ request }) => {
+					// get passthrough params from url query
+					const url = new URL(request.url);
+					capturedOptions = Object.fromEntries(url.searchParams.entries());
+
+					return HttpResponse.json({ result: { response: "Hello" } });
+				},
+			),
+		);
+
+		const model = workersai(TEST_MODEL, {
+			aString: "a",
+			aBool: true,
+			aNumber: 1,
+		});
+
+		const result = await generateText({
+			model: model,
+			prompt: "Write a greetings",
+		});
+
+		expect(result.text).toBe("Hello");
+		expect(capturedOptions).toHaveProperty("aString", "a");
+		expect(capturedOptions).toHaveProperty("aBool", "true");
+		expect(capturedOptions).toHaveProperty("aNumber", "1");
+	});
+
+	it("should throw if passthrough option cannot be coerced into a string", async () => {
+		const workersai = createWorkersAI({
+			apiKey: TEST_API_KEY,
+			accountId: TEST_ACCOUNT_ID,
+		});
+
+		await expect(
+			generateText({
+				model: workersai(TEST_MODEL, {
+					// @ts-expect-error
+					notDefined: undefined,
+				}),
+				prompt: "Write a greetings",
+			}),
+		).rejects.toThrowError(
+			"Value for option 'notDefined' is not able to be coerced into a string.",
+		);
+
+		await expect(
+			generateText({
+				model: workersai(TEST_MODEL, {
+					// @ts-expect-error
+					isNull: null,
+				}),
+				prompt: "Write a greetings",
+			}),
+		).rejects.toThrowError(
+			"Value for option 'isNull' is not able to be coerced into a string.",
+		);
+	});
 });
 
 describe("Binding - Text Generation Tests", () => {
@@ -51,5 +120,34 @@ describe("Binding - Text Generation Tests", () => {
 		});
 
 		expect(result.text).toBe("Hello");
+	});
+
+	it("should pass through additional options to the AI run method in the mock", async () => {
+		let capturedOptions: any = null;
+
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (modelName: string, inputs: any, options?: any) => {
+					capturedOptions = options;
+					return { response: "Hello" };
+				},
+			},
+		});
+
+		const model = workersai(TEST_MODEL, {
+			aString: "a",
+			aBool: true,
+			aNumber: 1,
+		});
+
+		const result = await generateText({
+			model: model,
+			prompt: "Write a greetings",
+		});
+
+		expect(result.text).toBe("Hello");
+		expect(capturedOptions).toHaveProperty("aString", "a");
+		expect(capturedOptions).toHaveProperty("aBool", true);
+		expect(capturedOptions).toHaveProperty("aNumber", 1);
 	});
 });


### PR DESCRIPTION
Fixes #62 

This adds the ability to pass options through the model constructor to `binding.run` and the run endpoint on the REST API.

```ts
const model = workersai(TEST_MODEL, {
  aString: "a",
  aBool: true,
  aNumber: 1,
});
```

If using the binding, this will be passed, in addition to existing options, to `run` inside the third parameter, e.g.:

```ts
const output = await env.AI.run(
	model,
	{
		messages: args.messages,
	},
	{
		aString: "a",
		aBool: true,
		aNumber: 1,
	},
);
```

If using the REST API (i.e. you're supplying an `accountId` and `apiKey` instead of a binding to `createWorkersAI`), then these options are first stringified and then encoded as a query string:

```ts
const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}?aString=a&aBool=true&aNumber=1`;
```