### PR TITLE
support sequential tool calls and fix mistral

### DIFF
--- a/packages/workers-ai-provider/src/workersai-chat-settings.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-settings.ts
@@ -8,6 +8,12 @@ export type WorkersAIChatSettings = {
 	safePrompt?: boolean;
 
 	/**
+	 * Whether to allow the model to execute calls when the last message was not a user message. Turns off streaming.
+	 * Defaults to `false`.
+	 */
+	sequentialCalls?: boolean;
+
+	/**
 	 * Optionally set Cloudflare AI Gateway options.
 	 * @deprecated
 	 */


### PR DESCRIPTION
- Mistral errors if an assistant message includes both `content` and `tool_calls` so this adds a check for it.
- Mistral also errors if a tool call does not include `tool_call_id`, so this includes it.
- Add a model setting `sequentialCalls`, so a model is allowed to chain tool calls together, instead of only when the last message is a user message. This makes all responses be a simulated stream.

Usage:
```ts
const workersAI = createWorkersAI({ binding: env.AI });
const model = workersAI(Model.Mistral24B, { sequentialCalls: true })
```
