### PR TITLE
Use latest version of Agents SDK + ensure that nodejs_compat is set

### DIFF
--- a/demos/mcp-server-bearer-auth/package.json
+++ b/demos/mcp-server-bearer-auth/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@modelcontextprotocol/sdk": "^1.7.0",
-		"agents": "^0.0.43",
+		"agents": "^0.0.53",
 		"hono": "^4.7.4",
 		"zod": "^3.24.2"
 	}

--- a/demos/mcp-server-bearer-auth/wrangler.jsonc
+++ b/demos/mcp-server-bearer-auth/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"name": "remote-mcp-server-bearer-auth",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
+	"compatibility_flags": ["nodejs_compat"],
 	"migrations": [
 		{
 			"new_sqlite_classes": ["MyMCP"],

--- a/demos/mcp-stytch-b2b-okr-manager/package.json
+++ b/demos/mcp-stytch-b2b-okr-manager/package.json
@@ -17,7 +17,7 @@
 		"@stytch/react": "^19.4.1",
 		"@stytch/vanilla-js": "^5.18.6",
 		"commander": "^11.1.0",
-		"agents": "^0.0.47",
+		"agents": "^0.0.53",
 		"hono": "^4.7.4",
 		"lucide-react": "^0.484.0",
 		"react": "^18.3.1",

--- a/demos/mcp-stytch-consumer-todo-list/package.json
+++ b/demos/mcp-stytch-consumer-todo-list/package.json
@@ -16,7 +16,7 @@
 		"@modelcontextprotocol/sdk": "^1.7.0",
 		"@stytch/react": "^19.4.1",
 		"@stytch/vanilla-js": "^5.18.6",
-		"agents": "^0.0.46",
+		"agents": "^0.0.53",
 		"hono": "^4.7.4",
 		"jose": "^6.0.10",
 		"react": "^18.3.1",

--- a/demos/remote-mcp-auth0/mcp-auth0-oidc/wrangler.jsonc
+++ b/demos/remote-mcp-auth0/mcp-auth0-oidc/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"name": "mcp-auth0-oidc",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-04-01",
+	"compatibility_flags": ["nodejs_compat"],
 	"migrations": [
 		{
 			"new_sqlite_classes": ["AuthenticatedMCP"],

--- a/demos/remote-mcp-github-oauth/package.json
+++ b/demos/remote-mcp-github-oauth/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "mcp-github-oauth",
+	"name": "remote-mcp-github-oauth",
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
@@ -12,7 +12,7 @@
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@cloudflare/workers-types": "^4.20250310.0",
 		"@modelcontextprotocol/sdk": "^1.7.0",
-		"agents": "^0.0.45",
+		"agents": "^0.0.53",
 		"hono": "^4.7.4",
 		"just-pick": "^4.2.0",
 		"octokit": "^4.1.2",

--- a/demos/remote-mcp-github-oauth/wrangler.jsonc
+++ b/demos/remote-mcp-github-oauth/wrangler.jsonc
@@ -7,14 +7,12 @@
 	"name": "mcp-github-oauth",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
+	"compatibility_flags": ["nodejs_compat"],
 	"migrations": [
 		{
 			"new_sqlite_classes": ["MyMCP"],
 			"tag": "v1"
 		}
-	],
-	"compatibility_flags": [
-		"nodejs_compat"
 	],
 	"durable_objects": {
 		"bindings": [

--- a/demos/remote-mcp-server/package.json
+++ b/demos/remote-mcp-server/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@modelcontextprotocol/sdk": "^1.7.0",
-		"agents": "^0.0.43",
+		"agents": "^0.0.53",
 		"hono": "^4.7.4",
 		"zod": "^3.24.2"
 	}

--- a/demos/remote-mcp-server/wrangler.jsonc
+++ b/demos/remote-mcp-server/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"name": "remote-mcp-server",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-03-10",
+	"compatibility_flags": ["nodejs_compat"],
 	"migrations": [
 		{
 			"new_sqlite_classes": ["MyMCP"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@changesets/cli": "^2.28.1",
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@modelcontextprotocol/sdk": "^1.7.0",
-				"agents-sdk": "^0.0.27",
+				"agents": "^0.0.53",
 				"ai": "^4.1.39",
 				"chalk": "^5.4.1",
 				"dayjs": "^1.11.13",
@@ -1075,7 +1075,7 @@
 			"dependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@modelcontextprotocol/sdk": "^1.7.0",
-				"agents": "^0.0.43",
+				"agents": "^0.0.53",
 				"hono": "^4.7.4",
 				"zod": "^3.24.2"
 			},
@@ -1127,7 +1127,7 @@
 				"@modelcontextprotocol/sdk": "^1.7.0",
 				"@stytch/react": "^19.4.1",
 				"@stytch/vanilla-js": "^5.18.6",
-				"agents": "^0.0.47",
+				"agents": "^0.0.53",
 				"commander": "^11.1.0",
 				"hono": "^4.7.4",
 				"lucide-react": "^0.484.0",
@@ -1196,18 +1196,6 @@
 				"@types/react": "^18.0.0"
 			}
 		},
-		"demos/mcp-stytch-b2b-okr-manager/node_modules/agents": {
-			"version": "0.0.47",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.47.tgz",
-			"integrity": "sha512-DiNRi4cps9FEh67j0CntlV4hHy4vkJgRaZtGmAUdf1yslj0TUvx89liS2wAVYKAyy3HgFiMxvELGLV4nWNs+jw==",
-			"license": "MIT",
-			"dependencies": {
-				"cron-schedule": "^5.0.4",
-				"nanoid": "^5.1.5",
-				"partyserver": "^0.0.66",
-				"partysocket": "1.1.3"
-			}
-		},
 		"demos/mcp-stytch-b2b-okr-manager/node_modules/commander": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -1241,45 +1229,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"demos/mcp-stytch-b2b-okr-manager/node_modules/nanoid": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
-		"demos/mcp-stytch-b2b-okr-manager/node_modules/partyserver": {
-			"version": "0.0.66",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.66.tgz",
-			"integrity": "sha512-GyC1uy4dvC4zPkwdzHqCkQ1J1CMiI0swIJQ0qqsJh16WNkEo5QHuU3l3ikLO8t+Yq0cRr0qO8++xbr11h+107w==",
-			"license": "ISC",
-			"dependencies": {
-				"nanoid": "^5.1.2"
-			},
-			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20240729.0"
-			}
-		},
-		"demos/mcp-stytch-b2b-okr-manager/node_modules/partysocket": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.3.tgz",
-			"integrity": "sha512-87Jd/nqPoWnVfzHE6Z12WLWTJ+TAgxs0b7i2S163HfQSrVDUK5tW/FC64T5N8L5ss+gqF+EV0BwjZMWggMY3UA==",
-			"license": "ISC",
-			"dependencies": {
-				"event-target-polyfill": "^0.0.4"
 			}
 		},
 		"demos/mcp-stytch-b2b-okr-manager/node_modules/react": {
@@ -1371,7 +1320,7 @@
 				"@modelcontextprotocol/sdk": "^1.7.0",
 				"@stytch/react": "^19.4.1",
 				"@stytch/vanilla-js": "^5.18.6",
-				"agents": "^0.0.46",
+				"agents": "^0.0.53",
 				"hono": "^4.7.4",
 				"jose": "^6.0.10",
 				"react": "^18.3.1",
@@ -1438,30 +1387,6 @@
 				"@types/react": "^18.0.0"
 			}
 		},
-		"demos/mcp-stytch-consumer-todo-list/node_modules/agents": {
-			"version": "0.0.46",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.46.tgz",
-			"integrity": "sha512-YC49h/KCP1Og7Pd0XVWD22f5Xg6MevUL0qtIJUjK3xP7Zb2F9lGzGqcvgkRmqalLEwZByZqDknvMb9nuDPnVXg==",
-			"license": "MIT",
-			"dependencies": {
-				"cron-schedule": "^5.0.4",
-				"nanoid": "^5.1.5",
-				"partyserver": "^0.0.66",
-				"partysocket": "1.1.2"
-			}
-		},
-		"demos/mcp-stytch-consumer-todo-list/node_modules/event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
 		"demos/mcp-stytch-consumer-todo-list/node_modules/fs-extra": {
 			"version": "11.3.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -1486,45 +1411,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"demos/mcp-stytch-consumer-todo-list/node_modules/nanoid": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
-		"demos/mcp-stytch-consumer-todo-list/node_modules/partyserver": {
-			"version": "0.0.66",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.66.tgz",
-			"integrity": "sha512-GyC1uy4dvC4zPkwdzHqCkQ1J1CMiI0swIJQ0qqsJh16WNkEo5QHuU3l3ikLO8t+Yq0cRr0qO8++xbr11h+107w==",
-			"license": "ISC",
-			"dependencies": {
-				"nanoid": "^5.1.2"
-			},
-			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20240729.0"
-			}
-		},
-		"demos/mcp-stytch-consumer-todo-list/node_modules/partysocket": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.2.tgz",
-			"integrity": "sha512-vWyxg0dYJewBsT6BaYkq+DEavYw+N/8J0jUXYSuZRRJdnmMJY+rkCg19t/8c3pTSyg8FjJH8VzIaHBhFMQRDIw==",
-			"license": "ISC",
-			"dependencies": {
-				"event-target-shim": "^6.0.2"
 			}
 		},
 		"demos/mcp-stytch-consumer-todo-list/node_modules/react": {
@@ -2094,20 +1980,6 @@
 				"node": ">=12"
 			}
 		},
-		"demos/remote-mcp-authkit/node_modules/agents": {
-			"version": "0.0.53",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.53.tgz",
-			"integrity": "sha512-FNQlUW4pNJ/vOlHfMzIH15rB+7IY2TykyyPtnR0cIRJkDAKKSKYlboMmBcyWUpMumw0En/CMR/G/lEU2kPwxcQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.8.0",
-				"cron-schedule": "^5.0.4",
-				"nanoid": "^5.1.5",
-				"partyserver": "^0.0.66",
-				"partysocket": "1.1.3"
-			}
-		},
 		"demos/remote-mcp-authkit/node_modules/esbuild": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
@@ -2182,48 +2054,6 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"demos/remote-mcp-authkit/node_modules/nanoid": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
-		"demos/remote-mcp-authkit/node_modules/partyserver": {
-			"version": "0.0.66",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.66.tgz",
-			"integrity": "sha512-GyC1uy4dvC4zPkwdzHqCkQ1J1CMiI0swIJQ0qqsJh16WNkEo5QHuU3l3ikLO8t+Yq0cRr0qO8++xbr11h+107w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"nanoid": "^5.1.2"
-			},
-			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20240729.0"
-			}
-		},
-		"demos/remote-mcp-authkit/node_modules/partysocket": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.3.tgz",
-			"integrity": "sha512-87Jd/nqPoWnVfzHE6Z12WLWTJ+TAgxs0b7i2S163HfQSrVDUK5tW/FC64T5N8L5ss+gqF+EV0BwjZMWggMY3UA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"event-target-polyfill": "^0.0.4"
-			}
-		},
 		"demos/remote-mcp-authkit/node_modules/unenv": {
 			"version": "2.0.0-rc.14",
 			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
@@ -2277,13 +2107,12 @@
 			}
 		},
 		"demos/remote-mcp-github-oauth": {
-			"name": "mcp-github-oauth",
 			"version": "0.0.1",
 			"devDependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@cloudflare/workers-types": "^4.20250310.0",
 				"@modelcontextprotocol/sdk": "^1.7.0",
-				"agents": "^0.0.45",
+				"agents": "^0.0.53",
 				"hono": "^4.7.4",
 				"just-pick": "^4.2.0",
 				"octokit": "^4.1.2",
@@ -2684,18 +2513,6 @@
 				"node": ">=12"
 			}
 		},
-		"demos/remote-mcp-github-oauth/node_modules/agents": {
-			"version": "0.0.45",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.45.tgz",
-			"integrity": "sha512-HWVs2McC1DNCQ5V54Lplbx/VmIf84FYjJZTDVwB00YHnM7Yh6TlmAM5uBOd77MW7WyRZKGIo1D4R/sAPkz10/w==",
-			"dev": true,
-			"dependencies": {
-				"cron-schedule": "^5.0.4",
-				"nanoid": "^5.1.5",
-				"partyserver": "^0.0.66",
-				"partysocket": "1.1.2"
-			}
-		},
 		"demos/remote-mcp-github-oauth/node_modules/esbuild": {
 			"version": "0.17.19",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
@@ -2734,18 +2551,6 @@
 				"@esbuild/win32-x64": "0.17.19"
 			}
 		},
-		"demos/remote-mcp-github-oauth/node_modules/event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
 		"demos/remote-mcp-github-oauth/node_modules/miniflare": {
 			"version": "3.20250310.1",
 			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250310.1.tgz",
@@ -2782,51 +2587,12 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"demos/remote-mcp-github-oauth/node_modules/nanoid": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
 		"demos/remote-mcp-github-oauth/node_modules/ohash": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"demos/remote-mcp-github-oauth/node_modules/partyserver": {
-			"version": "0.0.66",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.66.tgz",
-			"integrity": "sha512-GyC1uy4dvC4zPkwdzHqCkQ1J1CMiI0swIJQ0qqsJh16WNkEo5QHuU3l3ikLO8t+Yq0cRr0qO8++xbr11h+107w==",
-			"dev": true,
-			"dependencies": {
-				"nanoid": "^5.1.2"
-			},
-			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20240729.0"
-			}
-		},
-		"demos/remote-mcp-github-oauth/node_modules/partysocket": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.2.tgz",
-			"integrity": "sha512-vWyxg0dYJewBsT6BaYkq+DEavYw+N/8J0jUXYSuZRRJdnmMJY+rkCg19t/8c3pTSyg8FjJH8VzIaHBhFMQRDIw==",
-			"dev": true,
-			"dependencies": {
-				"event-target-shim": "^6.0.2"
-			}
 		},
 		"demos/remote-mcp-github-oauth/node_modules/pathe": {
 			"version": "2.0.3",
@@ -2908,7 +2674,7 @@
 			"dependencies": {
 				"@cloudflare/workers-oauth-provider": "^0.0.2",
 				"@modelcontextprotocol/sdk": "^1.7.0",
-				"agents": "^0.0.43",
+				"agents": "^0.0.53",
 				"hono": "^4.7.4",
 				"zod": "^3.24.2"
 			},
@@ -9781,15 +9547,16 @@
 			}
 		},
 		"node_modules/agents": {
-			"version": "0.0.43",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.43.tgz",
-			"integrity": "sha512-4acJ/rseNeF7k4oU29KjBXPWZXMrsBwY3Z6cBGvfwkrs3X+7dIlyNpm/eqTSUTgndUoPTdt8ygNWyA2CG+By7A==",
+			"version": "0.0.53",
+			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.53.tgz",
+			"integrity": "sha512-FNQlUW4pNJ/vOlHfMzIH15rB+7IY2TykyyPtnR0cIRJkDAKKSKYlboMmBcyWUpMumw0En/CMR/G/lEU2kPwxcQ==",
 			"license": "MIT",
 			"dependencies": {
+				"@modelcontextprotocol/sdk": "^1.8.0",
 				"cron-schedule": "^5.0.4",
 				"nanoid": "^5.1.5",
 				"partyserver": "^0.0.66",
-				"partysocket": "1.1.0"
+				"partysocket": "1.1.3"
 			}
 		},
 		"node_modules/agents-sdk": {
@@ -9820,18 +9587,6 @@
 			},
 			"engines": {
 				"node": "^18 || >=20"
-			}
-		},
-		"node_modules/agents/node_modules/event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
 		"node_modules/agents/node_modules/nanoid": {
@@ -9865,12 +9620,12 @@
 			}
 		},
 		"node_modules/agents/node_modules/partysocket": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.0.tgz",
-			"integrity": "sha512-G+fYGqBPx5tCjqmUmhtIKxZqnS/JjYd0E94hqRe+MRvggZ/RNy3+07t+WxewqdW+BlXEhW9eXu9WA5CjCn9BDQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.3.tgz",
+			"integrity": "sha512-87Jd/nqPoWnVfzHE6Z12WLWTJ+TAgxs0b7i2S163HfQSrVDUK5tW/FC64T5N8L5ss+gqF+EV0BwjZMWggMY3UA==",
 			"license": "ISC",
 			"dependencies": {
-				"event-target-shim": "^6.0.2"
+				"event-target-polyfill": "^0.0.4"
 			}
 		},
 		"node_modules/ai": {
@@ -13708,10 +13463,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/mcp-github-oauth": {
-			"resolved": "demos/remote-mcp-github-oauth",
-			"link": true
-		},
 		"node_modules/mcp-slack-oauth": {
 			"resolved": "demos/mcp-slack-oauth",
 			"link": true
@@ -15596,6 +15347,10 @@
 		},
 		"node_modules/remote-mcp-authkit": {
 			"resolved": "demos/remote-mcp-authkit",
+			"link": true
+		},
+		"node_modules/remote-mcp-github-oauth": {
+			"resolved": "demos/remote-mcp-github-oauth",
 			"link": true
 		},
 		"node_modules/remote-mcp-server": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@changesets/cli": "^2.28.1",
 		"@cloudflare/workers-oauth-provider": "^0.0.2",
 		"@modelcontextprotocol/sdk": "^1.7.0",
-		"agents-sdk": "^0.0.27",
+		"agents": "^0.0.53",
 		"ai": "^4.1.39",
 		"chalk": "^5.4.1",
 		"dayjs": "^1.11.13",


### PR DESCRIPTION
The Agents SDK uses `node:async_hooks` — so `nodejs_compat` needs to be present on all the MCP demos.

https://github.com/cloudflare/agents/blob/4d2679b9829dee5f0998352ac0a21b5ff922f0c2/packages/agents/src/index.ts#L14

Also — now that https://github.com/cloudflare/agents/pull/128 has landed and we have hibernation, import to make sure that everyone trying out demos is on latest version of the Agents SDK. Bumping the min version should mean that even if someone had cloned this, if they pull from main, and already have dependencies cached, the latest version of the Agents SDK gets installed.