### PR TITLE
Slack demo bugfix

### DIFF
--- a/demos/mcp-slack-oauth/src/index.ts
+++ b/demos/mcp-slack-oauth/src/index.ts
@@ -142,8 +142,10 @@ export default new OAuthProvider({
 
 			// Keep most of the existing props, but override whatever needs changing
 			return {
-				...options.props,
-				...await refreshSlackToken(options.props.refreshToken)
+				newProps: {
+					...options.props,
+					...await refreshSlackToken(options.props.refreshToken)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This API is a little confusing, as you can return `newProps` and optionally `accessTokenProps`. If you don't, then `newProps` applies to both, but you still need to nest everything under `newProps`