### PR TITLE
refactor: Move Props type to github-handler and update TypeScript config for Remote MCP GitHub demo

### DIFF
--- a/demos/remote-mcp-github-oauth/src/github-handler.ts
+++ b/demos/remote-mcp-github-oauth/src/github-handler.ts
@@ -3,6 +3,15 @@ import { Hono } from "hono";
 import { Octokit } from "octokit";
 import { fetchUpstreamAuthToken, getUpstreamAuthorizeUrl } from "./utils";
 
+// Context from the auth process, encrypted & stored in the auth token
+// and provided to the DurableMCP as this.props
+export type Props = {
+	login: string;
+	name: string;
+	email: string;
+	accessToken: string;
+};
+
 const app = new Hono<{ Bindings: Env & { OAUTH_PROVIDER: OAuthHelpers } }>();
 
 /**

--- a/demos/remote-mcp-github-oauth/src/index.ts
+++ b/demos/remote-mcp-github-oauth/src/index.ts
@@ -3,16 +3,8 @@ import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { Octokit } from "octokit";
-import { GitHubHandler } from "./github-handler";
+import { type Props, GitHubHandler } from "./github-handler";
 
-// Context from the auth process, encrypted & stored in the auth token
-// and provided to the DurableMCP as this.props
-type Props = {
-	login: string;
-	name: string;
-	email: string;
-	accessToken: string;
-};
 
 const ALLOWED_USERNAMES = new Set([
 	// Add GitHub usernames of users who should have access to the image generation tool

--- a/demos/remote-mcp-github-oauth/tsconfig.json
+++ b/demos/remote-mcp-github-oauth/tsconfig.json
@@ -12,7 +12,7 @@
 		/* Specify what module code is generated. */
 		"module": "es2022",
 		/* Specify how TypeScript looks up a file from a given module specifier. */
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		/* Specify type package names to be included without being referenced in a source file. */
 		"types": ["@cloudflare/workers-types/2023-07-01"],
 		/* Enable importing .json files */


### PR DESCRIPTION
# Description

This PR includes TypeScript configuration improvements and better organization of type definitions in the GitHub OAuth demo.

## Changes

- Moved the `Props` type definition from `index.ts` to `github-handler.ts` for better code organization since it's closely related to the GitHub handler functionality
- Updated the type import in `index.ts` to use the newly exported `Props` type
- Changed TypeScript's `moduleResolution` from "node" to "bundler" in `tsconfig.json` to better align with modern bundling practices

## Changeset

Since this is a demo-only change and doesn't affect any published packages, no changeset is required.