### PR TITLE
Add build script to Python demo

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -85,7 +85,7 @@
       "package_json_hash": "3b659fe585dff1e5f2683b0a9bd4e964f964de66"
     },
     "./demos/python-workers-mcp": {
-      "package_json_hash": "531eb91c5faf91579877eba29f20236738040e8b"
+      "package_json_hash": "3ff42b5e5e6aa69aae6d00668301b2f84805cf66"
     }
   }
 }

--- a/demos/python-workers-mcp/build.sh
+++ b/demos/python-workers-mcp/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Check if Python 3.12 is installed
+if ! command -v python3.12 &> /dev/null; then
+    echo "Error: Python 3.12 is required but not installed."
+    exit 1
+fi
+
+# Install pyodide CLI if needed
+if ! pip show pyodide-build &> /dev/null; then
+    echo "Installing pyodide-build..."
+    pip install pyodide-build
+else
+    echo "pyodide-build already installed."
+fi
+
+# Create pyodide virtual environment if it doesn't exist
+if [ ! -d ".venv-pyodide" ]; then
+    echo "Creating pyodide virtual environment (.venv-pyodide)..."
+    pyodide venv .venv-pyodide
+else
+    echo "Using existing pyodide virtual environment (.venv-pyodide)..."
+fi
+
+# Download vendored packages
+echo "Installing vendored packages from vendor.txt..."
+.venv-pyodide/bin/pip install -t src/vendor -r vendor.txt
+
+echo "Build completed successfully!"

--- a/demos/python-workers-mcp/package.json
+++ b/demos/python-workers-mcp/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Python Workers MCP Demo",
   "scripts": {
-    "deploy": "wrangler deploy",
-    "dev": "wrangler dev"
+    "build": "./build.sh",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
   },
   "devDependencies": {
     "wrangler": "^4.14.0"


### PR DESCRIPTION
This will add support for Deploy To Cloudflare

Try out with https://deploy.workers.cloudflare.com/?url=https://github.com/danlapid/ai/tree/dlapid/add_build_script/demos/python-workers-mcp