### PR TITLE
Fix README.md instructions for demos/remote-mcp-server

### DIFF
--- a/demos/remote-mcp-server/README.md
+++ b/demos/remote-mcp-server/README.md
@@ -6,11 +6,14 @@ Let's get a remote MCP server up-and-running on Cloudflare Workers complete with
 
 ```bash
 # clone the repository
-git clone git@github.com:cloudflare/ai.git
+git clone https://github.com/cloudflare/ai.git
+# Or if using ssh:
+# git clone git@github.com:cloudflare/ai.git
 
 # install dependencies
 cd ai
-npm install
+# Note: using pnpm instead of just "npm"
+pnpm install
 
 # run locally
 npx nx dev remote-mcp-server


### PR DESCRIPTION
1: You must run `pnpm` instead of `npm`, or you will get an error.
2: `git clone` example was using ssh, rather than http. I believe http is a more standard/default example.