### PR TITLE
feat: add embed and embedMany

### DIFF
--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -21,22 +21,8 @@
 		"test:ci": "vitest --watch=false",
 		"test": "vitest"
 	},
-	"files": [
-		"dist",
-		"src",
-		"README.md",
-		"package.json"
-	],
-	"keywords": [
-		"workers",
-		"cloudflare",
-		"ai",
-		"vercel",
-		"sdk",
-		"provider",
-		"chat",
-		"serverless"
-	],
+	"files": ["dist", "src", "README.md", "package.json"],
+	"keywords": ["workers", "cloudflare", "ai", "vercel", "sdk", "provider", "chat", "serverless"],
 	"dependencies": {
 		"@cloudflare/workers-types": ">=4",
 		"@ai-sdk/provider": "^1.1.3"

--- a/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
+++ b/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
@@ -1,7 +1,4 @@
-import type {
-	LanguageModelV1Prompt,
-	LanguageModelV1ProviderMetadata,
-} from "@ai-sdk/provider";
+import type { LanguageModelV1Prompt, LanguageModelV1ProviderMetadata } from "@ai-sdk/provider";
 import type { WorkersAIChatPrompt } from "./workersai-chat-prompt";
 
 export function convertToWorkersAIChatMessages(prompt: LanguageModelV1Prompt): {
@@ -43,8 +40,7 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV1Prompt): {
 										images.push({
 											mimeType: part.mimeType,
 											image: part.image,
-											providerMetadata:
-												part.providerMetadata,
+											providerMetadata: part.providerMetadata,
 										});
 									}
 									return ""; // No text for the image part
@@ -88,9 +84,7 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV1Prompt): {
 						}
 						default: {
 							const exhaustiveCheck = part;
-							throw new Error(
-								`Unsupported part: ${exhaustiveCheck}`,
-							);
+							throw new Error(`Unsupported part: ${exhaustiveCheck}`);
 						}
 					}
 				}
@@ -100,15 +94,11 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV1Prompt): {
 					content: text,
 					tool_calls:
 						toolCalls.length > 0
-							? toolCalls.map(
-									({
-										function: { name, arguments: args },
-									}) => ({
-										id: "null",
-										type: "function",
-										function: { name, arguments: args },
-									}),
-								)
+							? toolCalls.map(({ function: { name, arguments: args } }) => ({
+									id: "null",
+									type: "function",
+									function: { name, arguments: args },
+								}))
 							: undefined,
 				});
 

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -1,11 +1,19 @@
 import { AutoRAGChatLanguageModel } from "./autorag-chat-language-model";
 import type { AutoRAGChatSettings } from "./autorag-chat-settings";
 import { createRun } from "./utils";
+import {
+	WorkersAIEmbeddingModel,
+	type WorkersAIEmbeddingSettings,
+} from "./workers-ai-embedding-model";
 import { WorkersAIChatLanguageModel } from "./workersai-chat-language-model";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
 import { WorkersAIImageModel } from "./workersai-image-model";
 import type { WorkersAIImageSettings } from "./workersai-image-settings";
-import type { ImageGenerationModels, TextGenerationModels } from "./workersai-models";
+import type {
+	EmbeddingModels,
+	ImageGenerationModels,
+	TextGenerationModels,
+} from "./workersai-models";
 
 export type WorkersAISettings = (
 	| {
@@ -47,6 +55,21 @@ export interface WorkersAI {
 		modelId: TextGenerationModels,
 		settings?: WorkersAIChatSettings,
 	): WorkersAIChatLanguageModel;
+
+	embedding(
+		modelId: EmbeddingModels,
+		settings?: WorkersAIEmbeddingSettings,
+	): WorkersAIEmbeddingModel;
+
+	textEmbedding(
+		modelId: EmbeddingModels,
+		settings?: WorkersAIEmbeddingSettings,
+	): WorkersAIEmbeddingModel;
+
+	textEmbeddingModel(
+		modelId: EmbeddingModels,
+		settings?: WorkersAIEmbeddingSettings,
+	): WorkersAIEmbeddingModel;
 
 	/**
 	 * Creates a model for image generation.
@@ -91,6 +114,15 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 			binding,
 			gateway: options.gateway,
 		});
+	const createEmbeddingModel = (
+		modelId: EmbeddingModels,
+		settings: WorkersAIEmbeddingSettings = {},
+	) =>
+		new WorkersAIEmbeddingModel(modelId, settings, {
+			provider: "workersai.embedding",
+			binding,
+			gateway: options.gateway,
+		});
 
 	const provider = (modelId: TextGenerationModels, settings?: WorkersAIChatSettings) => {
 		if (new.target) {
@@ -100,6 +132,9 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 	};
 
 	provider.chat = createChatModel;
+	provider.embedding = createEmbeddingModel;
+	provider.textEmbedding = createEmbeddingModel;
+	provider.textEmbeddingModel = createEmbeddingModel;
 	provider.image = createImageModel;
 	provider.imageModel = createImageModel;
 

--- a/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
+++ b/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
@@ -1,0 +1,81 @@
+import { TooManyEmbeddingValuesForCallError, type EmbeddingModelV1 } from "@ai-sdk/provider";
+import type { StringLike } from "./utils";
+import type { EmbeddingModels } from "./workersai-models";
+
+export type WorkersAIEmbeddingConfig = {
+	provider: string;
+	binding: Ai;
+	gateway?: GatewayOptions;
+};
+
+export type WorkersAIEmbeddingSettings = {
+	gateway?: GatewayOptions;
+	maxEmbeddingsPerCall?: number;
+	supportsParallelCalls?: boolean;
+} & {
+	/**
+	 * Arbitrary provider-specific options forwarded unmodified.
+	 */
+	[key: string]: StringLike;
+};
+
+export class WorkersAIEmbeddingModel implements EmbeddingModelV1<string> {
+	/**
+	 * Semantic version of the {@link EmbeddingModelV1} specification implemented
+	 * by this class. It never changes.
+	 */
+	readonly specificationVersion = "v1";
+	readonly modelId: EmbeddingModels;
+	private readonly config: WorkersAIEmbeddingConfig;
+	private readonly settings: WorkersAIEmbeddingSettings;
+
+	/**
+	 * Provider name exposed for diagnostics and error reporting.
+	 */
+	get provider(): string {
+		return this.config.provider;
+	}
+
+	get maxEmbeddingsPerCall(): number {
+		// https://developers.cloudflare.com/workers-ai/platform/limits/#text-embeddings
+		const maxEmbeddingsPerCall = this.modelId === "@cf/baai/bge-large-en-v1.5" ? 1500 : 3000;
+		return this.settings.maxEmbeddingsPerCall ?? maxEmbeddingsPerCall;
+	}
+
+	get supportsParallelCalls(): boolean {
+		return this.settings.supportsParallelCalls ?? true;
+	}
+
+	constructor(
+		modelId: EmbeddingModels,
+		settings: WorkersAIEmbeddingSettings,
+		config: WorkersAIEmbeddingConfig,
+	) {
+		this.modelId = modelId;
+		this.settings = settings;
+		this.config = config;
+	}
+
+	async doEmbed({
+		values,
+	}: Parameters<EmbeddingModelV1<string>["doEmbed"]>[0]): Promise<
+		Awaited<ReturnType<EmbeddingModelV1<string>["doEmbed"]>>
+	> {
+		if (values.length > this.maxEmbeddingsPerCall) {
+			throw new TooManyEmbeddingValuesForCallError({
+				provider: this.provider,
+				modelId: this.modelId,
+				maxEmbeddingsPerCall: this.maxEmbeddingsPerCall,
+				values,
+			});
+		}
+
+		const response = await this.config.binding.run(this.modelId, {
+			text: values,
+		});
+
+		return {
+			embeddings: response.data,
+		};
+	}
+}

--- a/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
+++ b/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
@@ -70,9 +70,15 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV1<string> {
 			});
 		}
 
-		const response = await this.config.binding.run(this.modelId, {
-			text: values,
-		});
+		const { gateway, ...passthroughOptions } = this.settings;
+
+		const response = await this.config.binding.run(
+			this.modelId,
+			{
+				text: values,
+			},
+			{ gateway: this.config.gateway ?? gateway, ...passthroughOptions },
+		);
 
 		return {
 			embeddings: response.data,

--- a/packages/workers-ai-provider/src/workersai-models.ts
+++ b/packages/workers-ai-provider/src/workersai-models.ts
@@ -11,4 +11,9 @@ export type TextGenerationModels = Exclude<
  */
 export type ImageGenerationModels = value2key<AiModels, BaseAiTextToImage>;
 
+/**
+ * The names of the BaseAiTextToEmbeddings models.
+ */
+export type EmbeddingModels = value2key<AiModels, BaseAiTextEmbeddings>;
+
 type value2key<T, V> = { [K in keyof T]: T[K] extends V ? K : never }[keyof T];

--- a/packages/workers-ai-provider/test/embeddings.test.ts
+++ b/packages/workers-ai-provider/test/embeddings.test.ts
@@ -1,0 +1,116 @@
+import { embed, embedMany } from "ai";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { describe, expect, it } from "vitest";
+import { createWorkersAI } from "../src/index";
+
+const TEST_ACCOUNT_ID = "test-account-id";
+const TEST_API_KEY = "test-api-key";
+const TEST_EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5";
+
+const embedResponse = [[0, 1, 2, 3]];
+const embedHandler = http.post(
+	`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_EMBEDDING_MODEL}`,
+	async () => {
+		return HttpResponse.json({
+			result: {
+				data: embedResponse,
+			},
+		});
+	},
+);
+
+const embedManyResponse = [
+	[0, 1, 2, 3],
+	[4, 5, 6, 7],
+	[8, 9, 10, 11],
+	[12, 13, 14, 15],
+];
+const embedManyHandler = http.post(
+	`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_EMBEDDING_MODEL}`,
+	async () => {
+		return HttpResponse.json({
+			result: {
+				data: embedManyResponse,
+			},
+		});
+	},
+);
+
+describe("REST API - Embedding Tests", () => {
+	it("should embed a single value", async () => {
+		const server = setupServer(embedHandler);
+		server.listen();
+		const workersai = createWorkersAI({
+			apiKey: TEST_API_KEY,
+			accountId: TEST_ACCOUNT_ID,
+		});
+		const result = await embed({
+			model: workersai.embedding(TEST_EMBEDDING_MODEL),
+			value: "Remember when you were young, you shone like the sun",
+		});
+		expect(result.embedding).toEqual(embedResponse[0]);
+		server.close();
+	});
+
+	it("should embed multiple values", async () => {
+		const server = setupServer(embedManyHandler);
+		server.listen();
+		const workersai = createWorkersAI({
+			apiKey: TEST_API_KEY,
+			accountId: TEST_ACCOUNT_ID,
+		});
+		const result = await embedMany({
+			model: workersai.embedding(TEST_EMBEDDING_MODEL),
+			values: [
+				"Remember when you were young, you shone like the sun",
+				"Now there's a look in your eyes, like black holes in the sky",
+				"You reached for the secret too soon, you cried for the moon",
+				"Threatened by shadows at night, and exposed in the light",
+			],
+		});
+		expect(result.embeddings).toEqual(embedManyResponse);
+		server.close();
+	});
+});
+
+describe("Binding - Embedding Tests", () => {
+	it("should embed a single value", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return {
+						data: embedResponse,
+					};
+				},
+			},
+		});
+		const result = await embed({
+			model: workersai.embedding(TEST_EMBEDDING_MODEL),
+			value: "Remember when you were young, you shone like the sun",
+		});
+		expect(result.embedding).toEqual([0, 1, 2, 3]);
+	});
+
+	it("should embed multiple values", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return {
+						data: embedManyResponse,
+					};
+				},
+			},
+		});
+		const result = await embedMany({
+			model: workersai.embedding(TEST_EMBEDDING_MODEL),
+			values: [
+				"Remember when you were young, you shone like the sun",
+				"Now there's a look in your eyes, like black holes in the sky",
+				"You reached for the secret too soon, you cried for the moon",
+				"Threatened by shadows at night, and exposed in the light",
+			],
+		});
+		expect(result.embeddings).toEqual(embedManyResponse);
+	});
+});


### PR DESCRIPTION
Fixes #74 

This adds support for `embed` and `embedMany` in the `workers-ai-provider`.

```ts
import { createWorkersAI } from 'workers-ai-provider';
import { embedMany } from 'ai';

...

const workersai = createWorkersAI({
  binding: env.binding
});

const { embeddings } = await embedMany({
  model: workersai.embedding('@cf/baai/bge-base-en-v1.5'),
  values: [
    "Remember when you were young, you shone like the sun",
    "Now there's a look in your eyes, like black holes in the sky",
    "You reached for the secret too soon, you cried for the moon",
    "Threatened by shadows at night, and exposed in the light",
   ],
});
```

See the Vercel AI SDK docs for detailed usage: https://ai-sdk.dev/docs/ai-sdk-core/embeddings
