### PR TITLE
Update mcp-client to be at parity with agents example

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -16,7 +16,7 @@
       "package_json_hash": "963ca7994852be444895b69fc2e51742e010c2e3"
     },
     "./demos/mcp-client": {
-      "package_json_hash": "b3d26acfb20062a85d8cb0ee25a4ed2053990b2a"
+      "package_json_hash": "b0353be709d2633db44f06e2dc1ee1eecc4d6f3c"
     },
     "./demos/mcp-server-bearer-auth": {
       "package_json_hash": "f58abb4fcb8afb3aa125f9cef338a024c145f786"

--- a/demos.json
+++ b/demos.json
@@ -16,7 +16,7 @@
       "package_json_hash": "963ca7994852be444895b69fc2e51742e010c2e3"
     },
     "./demos/mcp-client": {
-      "package_json_hash": "b0353be709d2633db44f06e2dc1ee1eecc4d6f3c"
+      "package_json_hash": "d6e7882722a179908a3eb216dbd610c00c674ac9"
     },
     "./demos/mcp-server-bearer-auth": {
       "package_json_hash": "f58abb4fcb8afb3aa125f9cef338a024c145f786"

--- a/demos/mcp-client/package-lock.json
+++ b/demos/mcp-client/package-lock.json
@@ -10,6 +10,7 @@
 				"@modelcontextprotocol/sdk": "^1.11.1",
 				"@vitejs/plugin-react": "^4.4.1",
 				"agents": "^0.0.88",
+				"nanoid": "^5.1.5",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
 				"vite": "^6.3.5"

--- a/demos/mcp-client/package-lock.json
+++ b/demos/mcp-client/package-lock.json
@@ -398,20 +398,20 @@
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.1.1.tgz",
-			"integrity": "sha512-ZzLtAiN/XMxsOKrjF3S7VdKrj3fRMF7wZHUNUjbaZXnW9MSPgndp//edjYl4nzIkX0ZDeAG/iWzAhW1AFsw5HQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.2.2.tgz",
+			"integrity": "sha512-VUqXIIXrZ1d6HGtAcp8GnmPJz5OQUnmwGp98EdcDK3VlLmVjhigyVt9rRUCFFo4AeJtBBUG74eqLH7zsSEsU2Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@cloudflare/unenv-preset": "2.3.1",
-				"@hattip/adapter-node": "^0.0.49",
+				"@mjackson/node-fetch-server": "^0.6.1",
 				"@rollup/plugin-replace": "^6.0.1",
 				"get-port": "^7.1.0",
-				"miniflare": "4.20250507.0",
+				"miniflare": "4.20250508.2",
 				"picocolors": "^1.1.1",
 				"tinyglobby": "^0.2.12",
 				"unenv": "2.0.0-rc.15",
-				"wrangler": "4.14.3",
+				"wrangler": "4.15.2",
 				"ws": "8.18.0"
 			},
 			"peerDependencies": {
@@ -420,9 +420,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250507.0.tgz",
-			"integrity": "sha512-xC+8hmQuOUUNCVT9DWpLMfxhR4Xs4kI8v7Bkybh4pzGC85moH6fMfCBNaP0YQCNAA/BR56aL/AwfvMVGskTK/A==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250508.0.tgz",
+			"integrity": "sha512-9x09MrA9Y5RQs3zqWvWns8xHgM2pVNXWpeJ+3hQYu4PrwPFZXtTD6b/iMmOnlYKzINlREq1RGeEybMFyWEUlUg==",
 			"cpu": [
 				"x64"
 			],
@@ -436,9 +436,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250507.0.tgz",
-			"integrity": "sha512-Oynff5H8yM4trfUFaKdkOvPV3jac8mg7QC19ILZluCVgLx/JGEVLEJ7do1Na9rLqV8CK4gmUXPrUMX7uerhQgg==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250508.0.tgz",
+			"integrity": "sha512-0Ili+nE2LLRzYue/yPc1pepSyNNg6LxR3/ng/rlQzVQUxPXIXldHFkJ/ynsYwQnAcf6OxasSi/kbTm6yvDoSAQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -452,9 +452,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250507.0.tgz",
-			"integrity": "sha512-/HAA+Zg/R7Q/Smyl835FUFKjotZN1UzN9j/BHBd0xKmKov97QkXAX8gsyGnyKqRReIOinp8x/8+UebTICR7VJw==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250508.0.tgz",
+			"integrity": "sha512-5saVrZ3uVwYxvBa7BaonXjeqB6X0YF3ak05qvBaWcmZ3FNmnarMm2W8842cnbhnckDVBpB/iDo51Sy6Y7y1jcw==",
 			"cpu": [
 				"x64"
 			],
@@ -468,9 +468,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250507.0.tgz",
-			"integrity": "sha512-NMPibSdOYeycU0IrKkgOESFJQy7dEpHvuatZxQxlT+mIQK0INzI3irp2kKxhF99s25kPC4p+xg9bU3ugTrs3VQ==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250508.0.tgz",
+			"integrity": "sha512-muQe1pkxRi3eaq1Q417xvfGd2SlktbLTzNhT5Yftsx8OecWrYuB8i4ttR6Nr5ER06bfEj0FqQjqJJhcp6wLLUQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -484,9 +484,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250507.0.tgz",
-			"integrity": "sha512-c91fhNP8ufycdIDqjVyKTqeb4ewkbAYXFQbLreMVgh4LLQQPDDEte8wCdmaFy5bIL0M9d85PpdCq51RCzq/FaQ==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250508.0.tgz",
+			"integrity": "sha512-EJj8iTWFMqjgvZUxxNvzK7frA1JMFi3y/9eDIdZPL/OaQh3cmk5Lai5DCXsKYUxfooMBZWYTp53zOLrvuJI8VQ==",
 			"cpu": [
 				"x64"
 			],
@@ -500,9 +500,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20250509.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250509.0.tgz",
-			"integrity": "sha512-Zqxda8NapibaTnag4pjfa7DIcObSnItcqimvfhqoYq/ShsGJ/nYGx4QaXRTKo1t6HzvC8Qn4g4UKFmdyON5e6Q==",
+			"version": "4.20250520.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250520.0.tgz",
+			"integrity": "sha512-bMPrpZREctlSaKtqIp3mdRjgyRSgioPQDUlhOeCUYRIo9DzWUACvw/u5kq3GQMmE4V1/nVCGHb7a1Ie8f5wG5g==",
 			"license": "MIT OR Apache-2.0",
 			"peer": true
 		},
@@ -947,56 +947,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@hattip/adapter-node": {
-			"version": "0.0.49",
-			"resolved": "https://registry.npmjs.org/@hattip/adapter-node/-/adapter-node-0.0.49.tgz",
-			"integrity": "sha512-BE+Y8Q4U0YcH34FZUYU4DssGKOaZLbNL0zK57Z41UZp0m9kS79ZIolBmjjpPhTVpIlRY3Rs+uhXbVXKk7mUcJA==",
-			"license": "MIT",
-			"dependencies": {
-				"@hattip/core": "0.0.49",
-				"@hattip/polyfills": "0.0.49",
-				"@hattip/walk": "0.0.49"
-			}
-		},
-		"node_modules/@hattip/core": {
-			"version": "0.0.49",
-			"resolved": "https://registry.npmjs.org/@hattip/core/-/core-0.0.49.tgz",
-			"integrity": "sha512-3/ZJtC17cv8m6Sph8+nw4exUp9yhEf2Shi7HK6AHSUSBtaaQXZ9rJBVxTfZj3PGNOR/P49UBXOym/52WYKFTJQ=="
-		},
-		"node_modules/@hattip/headers": {
-			"version": "0.0.49",
-			"resolved": "https://registry.npmjs.org/@hattip/headers/-/headers-0.0.49.tgz",
-			"integrity": "sha512-rrB2lEhTf0+MNVt5WdW184Ky706F1Ze9Aazn/R8c+/FMUYF9yjem2CgXp49csPt3dALsecrnAUOHFiV0LrrHXA==",
-			"license": "MIT",
-			"dependencies": {
-				"@hattip/core": "0.0.49"
-			}
-		},
-		"node_modules/@hattip/polyfills": {
-			"version": "0.0.49",
-			"resolved": "https://registry.npmjs.org/@hattip/polyfills/-/polyfills-0.0.49.tgz",
-			"integrity": "sha512-5g7W5s6Gq+HDxwULGFQ861yAnEx3yd9V8GDwS96HBZ1nM1u93vN+KTuwXvNsV7Z3FJmCrD/pgU8WakvchclYuA==",
-			"license": "MIT",
-			"dependencies": {
-				"@hattip/core": "0.0.49",
-				"@whatwg-node/fetch": "^0.9.22",
-				"node-fetch-native": "^1.6.4"
-			}
-		},
-		"node_modules/@hattip/walk": {
-			"version": "0.0.49",
-			"resolved": "https://registry.npmjs.org/@hattip/walk/-/walk-0.0.49.tgz",
-			"integrity": "sha512-AgJgKLooZyQnzMfoFg5Mo/aHM+HGBC9ExpXIjNqGimYTRgNbL/K7X5EM1kR2JY90BNKk9lo6Usq1T/nWFdT7TQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@hattip/headers": "0.0.49",
-				"cac": "^6.7.14",
-				"mime-types": "^2.1.35"
-			},
-			"bin": {
-				"hattip-walk": "cli.js"
-			}
-		},
 		"node_modules/@img/sharp-darwin-arm64": {
 			"version": "0.33.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
@@ -1406,16 +1356,17 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@kamilkisiela/fast-url-parser": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
-			"integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+		"node_modules/@mjackson/node-fetch-server": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.6.1.tgz",
+			"integrity": "sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==",
 			"license": "MIT"
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.11.4",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.4.tgz",
 			"integrity": "sha512-OTbhe5slIjiOtLxXhKalkKGhIQrwvhgCDs/C2r8kcBTy5HR/g43aDQU0l7r8O0VGbJPTNJvDc7ZdQMdQDJXmbw==",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
 				"content-type": "^1.0.5",
@@ -1486,9 +1437,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
-			"integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.0.tgz",
+			"integrity": "sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==",
 			"cpu": [
 				"arm"
 			],
@@ -1499,9 +1450,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz",
-			"integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.0.tgz",
+			"integrity": "sha512-yDvqx3lWlcugozax3DItKJI5j05B0d4Kvnjx+5mwiUpWramVvmAByYigMplaoAQ3pvdprGCTCE03eduqE/8mPQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1512,9 +1463,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-			"integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.0.tgz",
+			"integrity": "sha512-2KOU574vD3gzcPSjxO0eyR5iWlnxxtmW1F5CkNOHmMlueKNCQkxR6+ekgWyVnz6zaZihpUNkGxjsYrkTJKhkaw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1525,9 +1476,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz",
-			"integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.0.tgz",
+			"integrity": "sha512-gE5ACNSxHcEZyP2BA9TuTakfZvULEW4YAOtxl/A/YDbIir/wPKukde0BNPlnBiP88ecaN4BJI2TtAd+HKuZPQQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1538,9 +1489,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz",
-			"integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.0.tgz",
+			"integrity": "sha512-GSxU6r5HnWij7FoSo7cZg3l5GPg4HFLkzsFFh0N/b16q5buW1NAWuCJ+HMtIdUEi6XF0qH+hN0TEd78laRp7Dg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1551,9 +1502,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz",
-			"integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.0.tgz",
+			"integrity": "sha512-KGiGKGDg8qLRyOWmk6IeiHJzsN/OYxO6nSbT0Vj4MwjS2XQy/5emsmtoqLAabqrohbgLWJ5GV3s/ljdrIr8Qjg==",
 			"cpu": [
 				"x64"
 			],
@@ -1564,9 +1515,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz",
-			"integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.0.tgz",
+			"integrity": "sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==",
 			"cpu": [
 				"arm"
 			],
@@ -1577,9 +1528,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz",
-			"integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.0.tgz",
+			"integrity": "sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==",
 			"cpu": [
 				"arm"
 			],
@@ -1590,9 +1541,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz",
-			"integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.0.tgz",
+			"integrity": "sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1603,9 +1554,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz",
-			"integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.0.tgz",
+			"integrity": "sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1616,9 +1567,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz",
-			"integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.0.tgz",
+			"integrity": "sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==",
 			"cpu": [
 				"loong64"
 			],
@@ -1629,9 +1580,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz",
-			"integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.0.tgz",
+			"integrity": "sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1642,9 +1593,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz",
-			"integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.0.tgz",
+			"integrity": "sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1655,9 +1606,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz",
-			"integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.0.tgz",
+			"integrity": "sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1668,9 +1619,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz",
-			"integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.0.tgz",
+			"integrity": "sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1681,9 +1632,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz",
-			"integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.0.tgz",
+			"integrity": "sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1694,9 +1645,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz",
-			"integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.0.tgz",
+			"integrity": "sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==",
 			"cpu": [
 				"x64"
 			],
@@ -1707,9 +1658,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz",
-			"integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.0.tgz",
+			"integrity": "sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1720,9 +1671,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz",
-			"integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.0.tgz",
+			"integrity": "sha512-tmazCrAsKzdkXssEc65zIE1oC6xPHwfy9d5Ta25SRCDOZS+I6RypVVShWALNuU9bxIfGA0aqrmzlzoM5wO5SPQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1733,9 +1684,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz",
-			"integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.0.tgz",
+			"integrity": "sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==",
 			"cpu": [
 				"x64"
 			],
@@ -1817,34 +1768,6 @@
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
 			}
 		},
-		"node_modules/@whatwg-node/fetch": {
-			"version": "0.9.23",
-			"resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.23.tgz",
-			"integrity": "sha512-7xlqWel9JsmxahJnYVUj/LLxWcnA93DR4c9xlw3U814jWTiYalryiH1qToik1hOxweKKRLi4haXHM5ycRksPBA==",
-			"license": "MIT",
-			"dependencies": {
-				"@whatwg-node/node-fetch": "^0.6.0",
-				"urlpattern-polyfill": "^10.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@whatwg-node/node-fetch": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.6.0.tgz",
-			"integrity": "sha512-tcZAhrpx6oVlkEsRngeTEEE7I5/QdLjeEz4IlekabGaESP7+Dkm/6a9KcF1KdCBB7mO9PXtBkwCuTCt8+UPg8Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@kamilkisiela/fast-url-parser": "^1.1.4",
-				"busboy": "^1.6.0",
-				"fast-querystring": "^1.1.1",
-				"tslib": "^2.6.3"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/accepts": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1853,27 +1776,6 @@
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -1904,6 +1806,7 @@
 			"version": "0.0.88",
 			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.88.tgz",
 			"integrity": "sha512-ysQ3LMONALxx1VL0X/Tq49EzfuuLj1SHfztCCIfAX8hVtYw2Jr9rytnM94lZQ29yFFqmcIKWR+D13j/l7Cyf8A==",
+			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.2",
 				"ai": "^4.3.15",
@@ -1918,9 +1821,9 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "4.3.15",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.15.tgz",
-			"integrity": "sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg==",
+			"version": "4.3.16",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-4.3.16.tgz",
+			"integrity": "sha512-KUDwlThJ5tr2Vw0A1ZkbDKNME3wzWhuVfAOwIvFUzl1TPVDFAXDFTXio3p+jaKneB+dKNCvFFlolYmmgHttG1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ai-sdk/provider": "1.1.3",
@@ -1947,6 +1850,7 @@
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -2025,17 +1929,6 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
-			}
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2043,15 +1936,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/cac": {
-			"version": "6.7.14",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -2084,9 +1968,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001717",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-			"integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+			"version": "1.0.30001718",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+			"integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2248,9 +2132,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2325,9 +2209,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.151",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz",
-			"integrity": "sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==",
+			"version": "1.5.155",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
+			"integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
 			"license": "ISC"
 		},
 		"node_modules/encodeurl": {
@@ -2442,12 +2326,13 @@
 		"node_modules/event-target-polyfill": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
-			"integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ=="
+			"integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+			"license": "MIT"
 		},
 		"node_modules/eventsource": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-			"integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
 			"license": "MIT",
 			"dependencies": {
 				"eventsource-parser": "^3.0.1"
@@ -2457,9 +2342,9 @@
 			}
 		},
 		"node_modules/eventsource-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+			"integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
@@ -2534,52 +2419,17 @@
 				"express": "^4.11 || 5 || ^5.0.0-beta.1"
 			}
 		},
-		"node_modules/express/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/express/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/exsolve": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
 			"integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
 			"license": "MIT"
 		},
-		"node_modules/fast-decode-uri-component": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-			"license": "MIT"
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-		},
-		"node_modules/fast-querystring": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-decode-uri-component": "^1.0.1"
-			}
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
 			"version": "3.0.6",
@@ -2594,7 +2444,8 @@
 					"type": "opencollective",
 					"url": "https://opencollective.com/fastify"
 				}
-			]
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fdir": {
 			"version": "6.4.4",
@@ -2876,7 +2727,8 @@
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -2968,30 +2820,30 @@
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
 			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.52.0"
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20250507.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250507.0.tgz",
-			"integrity": "sha512-EgbQRt/Hnr8HCmW2J/4LRNE3yOzJTdNd98XJ8gnGXFKcimXxUFPiWP3k1df+ZPCtEHp6cXxi8+jP7v9vuIbIsg==",
+			"version": "4.20250508.2",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250508.2.tgz",
+			"integrity": "sha512-+2XoHLSbY49LNQgZoAJRX+SyUwC767Cz46pgx4T/j1YGKSrMzAxCOk59b12QoFNnN50Gtd9HkT3ukZn2nzrIVw==",
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
@@ -3001,7 +2853,7 @@
 				"glob-to-regexp": "0.4.1",
 				"stoppable": "1.1.0",
 				"undici": "^5.28.5",
-				"workerd": "1.20250507.0",
+				"workerd": "1.20250508.0",
 				"ws": "8.18.0",
 				"youch": "3.3.4",
 				"zod": "3.22.3"
@@ -3047,6 +2899,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.js"
 			},
@@ -3062,12 +2915,6 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/node-fetch-native": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-			"integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
-			"license": "MIT"
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.19",
@@ -3136,6 +2983,7 @@
 			"version": "0.0.71",
 			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.71.tgz",
 			"integrity": "sha512-PJZoX08tyNcNJVXqWJedZ6Jzj8EOFGBA/PJ37KhAnWmTkq6A8SqA4u2ol+zq8zwSfRy9FPvVgABCY0yLpe62Dg==",
+			"license": "ISC",
 			"dependencies": {
 				"nanoid": "^5.1.5"
 			},
@@ -3147,6 +2995,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.4.tgz",
 			"integrity": "sha512-jXP7PFj2h5/v4UjDS8P7MZy6NJUQ7sspiFyxL4uc/+oKOL+KdtXzHnTV8INPGxBrLTXgalyG3kd12Qm7WrYc3A==",
+			"license": "ISC",
 			"dependencies": {
 				"event-target-polyfill": "^0.0.4"
 			}
@@ -3340,14 +3189,15 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.40.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
-			"integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.0.tgz",
+			"integrity": "sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.7"
@@ -3360,26 +3210,26 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.40.2",
-				"@rollup/rollup-android-arm64": "4.40.2",
-				"@rollup/rollup-darwin-arm64": "4.40.2",
-				"@rollup/rollup-darwin-x64": "4.40.2",
-				"@rollup/rollup-freebsd-arm64": "4.40.2",
-				"@rollup/rollup-freebsd-x64": "4.40.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.40.2",
-				"@rollup/rollup-linux-arm64-musl": "4.40.2",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-				"@rollup/rollup-linux-riscv64-musl": "4.40.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.40.2",
-				"@rollup/rollup-linux-x64-gnu": "4.40.2",
-				"@rollup/rollup-linux-x64-musl": "4.40.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.40.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.40.2",
-				"@rollup/rollup-win32-x64-msvc": "4.40.2",
+				"@rollup/rollup-android-arm-eabi": "4.41.0",
+				"@rollup/rollup-android-arm64": "4.41.0",
+				"@rollup/rollup-darwin-arm64": "4.41.0",
+				"@rollup/rollup-darwin-x64": "4.41.0",
+				"@rollup/rollup-freebsd-arm64": "4.41.0",
+				"@rollup/rollup-freebsd-x64": "4.41.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.41.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.41.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.41.0",
+				"@rollup/rollup-linux-arm64-musl": "4.41.0",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.41.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.41.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.41.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.41.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.41.0",
+				"@rollup/rollup-linux-x64-gnu": "4.41.0",
+				"@rollup/rollup-linux-x64-musl": "4.41.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.41.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.41.0",
+				"@rollup/rollup-win32-x64-msvc": "4.41.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -3468,27 +3318,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/send/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/send/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/serve-static": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -3551,9 +3380,9 @@
 			}
 		},
 		"node_modules/sharp/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"license": "ISC",
 			"optional": true,
 			"bin": {
@@ -3713,14 +3542,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/swr": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
@@ -3775,7 +3596,8 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"optional": true
 		},
 		"node_modules/type-is": {
 			"version": "2.0.1",
@@ -3786,27 +3608,6 @@
 				"content-type": "^1.0.5",
 				"media-typer": "^1.1.0",
 				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/type-is/node_modules/mime-db": {
-			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/type-is/node_modules/mime-types": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -3881,12 +3682,6 @@
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
-		},
-		"node_modules/urlpattern-polyfill": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
-			"integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
-			"license": "MIT"
 		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.5.0",
@@ -3996,9 +3791,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20250507.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250507.0.tgz",
-			"integrity": "sha512-OXaGjEh5THT9iblwWIyPrYBoaPe/d4zN03Go7/w8CmS8sma7//O9hjbk43sboWkc89taGPmU0/LNyZUUiUlHeQ==",
+			"version": "1.20250508.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250508.0.tgz",
+			"integrity": "sha512-ffLxe7dXSuGoA6jb3Qx2SClIV1aLHfJQ6RhGhzYHjQgv7dL6fdUOSIIGgzmu2mRKs+WFSujp6c8WgKquco6w3w==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4008,27 +3803,27 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20250507.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20250507.0",
-				"@cloudflare/workerd-linux-64": "1.20250507.0",
-				"@cloudflare/workerd-linux-arm64": "1.20250507.0",
-				"@cloudflare/workerd-windows-64": "1.20250507.0"
+				"@cloudflare/workerd-darwin-64": "1.20250508.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20250508.0",
+				"@cloudflare/workerd-linux-64": "1.20250508.0",
+				"@cloudflare/workerd-linux-arm64": "1.20250508.0",
+				"@cloudflare/workerd-windows-64": "1.20250508.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.14.3",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.14.3.tgz",
-			"integrity": "sha512-gY2n3cC8yb8VyaM0aY9fXX5AIah+VkGefmAHltUBgVpJaM4QXun6O85BydtTEljLL67JTyFyBDn/UPyg2WhESQ==",
+			"version": "4.15.2",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.15.2.tgz",
+			"integrity": "sha512-Rv7zP61DOVzIS3af+/1UzJkRVpqu6VDRi6uIVMiwD1LkXG5Ov08tv94jgnE9bSjVf0paQg3dl0E89h+wQ0x/Bw==",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.4.0",
 				"@cloudflare/unenv-preset": "2.3.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.25.4",
-				"miniflare": "4.20250507.0",
+				"miniflare": "4.20250508.2",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.15",
-				"workerd": "1.20250507.0"
+				"workerd": "1.20250508.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -4042,7 +3837,7 @@
 				"sharp": "^0.33.5"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20250507.0"
+				"@cloudflare/workers-types": "^4.20250508.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -4101,9 +3896,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-			"integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+			"version": "3.25.7",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
+			"integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/demos/mcp-client/package-lock.json
+++ b/demos/mcp-client/package-lock.json
@@ -9,7 +9,7 @@
 				"@cloudflare/vite-plugin": "^1.1.1",
 				"@modelcontextprotocol/sdk": "^1.11.1",
 				"@vitejs/plugin-react": "^4.4.1",
-				"agents": "^0.0.80",
+				"agents": "^0.0.88",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
 				"vite": "^6.3.5"
@@ -1413,14 +1413,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz",
-			"integrity": "sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==",
-			"license": "MIT",
+			"version": "1.11.4",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.4.tgz",
+			"integrity": "sha512-OTbhe5slIjiOtLxXhKalkKGhIQrwvhgCDs/C2r8kcBTy5HR/g43aDQU0l7r8O0VGbJPTNJvDc7ZdQMdQDJXmbw==",
 			"dependencies": {
+				"ajv": "^8.17.1",
 				"content-type": "^1.0.5",
 				"cors": "^2.8.5",
-				"cross-spawn": "^7.0.3",
+				"cross-spawn": "^7.0.5",
 				"eventsource": "^3.0.2",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
@@ -1901,17 +1901,16 @@
 			}
 		},
 		"node_modules/agents": {
-			"version": "0.0.80",
-			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.80.tgz",
-			"integrity": "sha512-Nlk9ihz3ejhndYSteml0qKh0yj0GMNMewHcHngLrJR470qruacpeLkdldAhWIC6ezF8H2lwtaHTPveAG6jfO9A==",
-			"license": "MIT",
+			"version": "0.0.88",
+			"resolved": "https://registry.npmjs.org/agents/-/agents-0.0.88.tgz",
+			"integrity": "sha512-ysQ3LMONALxx1VL0X/Tq49EzfuuLj1SHfztCCIfAX8hVtYw2Jr9rytnM94lZQ29yFFqmcIKWR+D13j/l7Cyf8A==",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.11.0",
-				"ai": "^4.3.14",
+				"@modelcontextprotocol/sdk": "^1.11.2",
+				"ai": "^4.3.15",
 				"cron-schedule": "^5.0.4",
 				"nanoid": "^5.1.5",
-				"partyserver": "^0.0.70",
-				"partysocket": "1.1.3",
+				"partyserver": "^0.0.71",
+				"partysocket": "1.1.4",
 				"zod": "^3.24.4"
 			},
 			"peerDependencies": {
@@ -1942,6 +1941,21 @@
 				"react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/as-table": {
@@ -2428,8 +2442,7 @@
 		"node_modules/event-target-polyfill": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
-			"integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
-			"license": "MIT"
+			"integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ=="
 		},
 		"node_modules/eventsource": {
 			"version": "3.0.6",
@@ -2554,6 +2567,11 @@
 			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
 			"license": "MIT"
 		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
 		"node_modules/fast-querystring": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
@@ -2562,6 +2580,21 @@
 			"dependencies": {
 				"fast-decode-uri-component": "^1.0.1"
 			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			]
 		},
 		"node_modules/fdir": {
 			"version": "6.4.4",
@@ -2840,6 +2873,11 @@
 			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
 			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+		},
 		"node_modules/json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3009,7 +3047,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.js"
 			},
@@ -3096,10 +3133,9 @@
 			}
 		},
 		"node_modules/partyserver": {
-			"version": "0.0.70",
-			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.70.tgz",
-			"integrity": "sha512-v6hfcNFdSS+5pLBHXGXnuRH6m3luc2veWhd3klY2iOx3HXG17egHBP4oZ/Is1Qk5CmuNce8xXMqHp52+cxCAyw==",
-			"license": "ISC",
+			"version": "0.0.71",
+			"resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.71.tgz",
+			"integrity": "sha512-PJZoX08tyNcNJVXqWJedZ6Jzj8EOFGBA/PJ37KhAnWmTkq6A8SqA4u2ol+zq8zwSfRy9FPvVgABCY0yLpe62Dg==",
 			"dependencies": {
 				"nanoid": "^5.1.5"
 			},
@@ -3108,10 +3144,9 @@
 			}
 		},
 		"node_modules/partysocket": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.3.tgz",
-			"integrity": "sha512-87Jd/nqPoWnVfzHE6Z12WLWTJ+TAgxs0b7i2S163HfQSrVDUK5tW/FC64T5N8L5ss+gqF+EV0BwjZMWggMY3UA==",
-			"license": "ISC",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.4.tgz",
+			"integrity": "sha512-jXP7PFj2h5/v4UjDS8P7MZy6NJUQ7sspiFyxL4uc/+oKOL+KdtXzHnTV8INPGxBrLTXgalyG3kd12Qm7WrYc3A==",
 			"dependencies": {
 				"event-target-polyfill": "^0.0.4"
 			}
@@ -3297,6 +3332,14 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
 			"integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
 			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}

--- a/demos/mcp-client/package.json
+++ b/demos/mcp-client/package.json
@@ -14,6 +14,7 @@
 		"@modelcontextprotocol/sdk": "^1.11.1",
 		"@vitejs/plugin-react": "^4.4.1",
 		"agents": "^0.0.88",
+		"nanoid": "^5.1.5",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"vite": "^6.3.5"

--- a/demos/mcp-client/package.json
+++ b/demos/mcp-client/package.json
@@ -13,7 +13,7 @@
 		"@cloudflare/vite-plugin": "^1.1.1",
 		"@modelcontextprotocol/sdk": "^1.11.1",
 		"@vitejs/plugin-react": "^4.4.1",
-		"agents": "^0.0.80",
+		"agents": "^0.0.88",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"vite": "^6.3.5"

--- a/demos/mcp-client/src/server.ts
+++ b/demos/mcp-client/src/server.ts
@@ -1,109 +1,21 @@
 import { Agent, routeAgentRequest, type AgentNamespace } from "agents";
 import { MCPClientManager } from "agents/mcp/client";
-import type {
-  Tool,
-  Prompt,
-  Resource,
-} from "@modelcontextprotocol/sdk/types.js";
 
 type Env = {
   MyAgent: AgentNamespace<MyAgent>;
   HOST: string;
 };
 
-export type Server = {
-  url: string;
-  state: "authenticating" | "connecting" | "ready" | "discovering" | "failed";
-  authUrl?: string;
-};
-
-export type State = {
-  servers: Record<string, Server>;
-  tools: (Tool & { serverId: string })[];
-  prompts: (Prompt & { serverId: string })[];
-  resources: (Resource & { serverId: string })[];
-};
-
-export class MyAgent extends Agent<Env, State> {
-  initialState = {
-    servers: {},
-    tools: [],
-    prompts: [],
-    resources: [],
-  };
-
-  private mcp_: MCPClientManager | undefined;
-
-  get mcp(): MCPClientManager {
-    if (!this.mcp_) {
-      throw new Error("MCPClientManager not initialized");
-    }
-
-    return this.mcp_;
-  }
-
-  onStart() {
-    this.mcp_ = new MCPClientManager("my-agent", "1.0.0", {
-      baseCallbackUri: `${this.env.HOST}/agents/my-agent/${this.name}/callback`,
-      storage: this.ctx.storage,
-    });
-  }
-
-  setServerState(id: string, state: Server) {
-    this.setState({
-      ...this.state,
-      servers: {
-        ...this.state.servers,
-        [id]: state,
-      },
-    });
-  }
-
-  async refreshServerData() {
-    this.setState({
-      ...this.state,
-      prompts: this.mcp.listPrompts(),
-      tools: this.mcp.listTools(),
-      resources: this.mcp.listResources(),
-    });
-  }
-
-  async addMcpServer(url: string): Promise<string> {
-    console.log(`Registering server: ${url}`);
-    const { id, authUrl } = await this.mcp.connect(url);
-    this.setServerState(id, {
-      url,
-      authUrl,
-      state: this.mcp.mcpConnections[id].connectionState,
-    });
-    return authUrl ?? "";
-  }
+export class MyAgent extends Agent<Env, never> {
+  mcp = new MCPClientManager("my-agent", "1.0.0");
 
   async onRequest(request: Request): Promise<Response> {
-    if (this.mcp.isCallbackRequest(request)) {
-      try {
-        const { serverId } = await this.mcp.handleCallbackRequest(request);
-        this.setServerState(serverId, {
-          url: this.state.servers[serverId].url,
-          state: this.mcp.mcpConnections[serverId].connectionState,
-        });
-        await this.refreshServerData();
-        // Hack: autoclosing window because a redirect fails for some reason
-        // return Response.redirect('http://localhost:5173/', 301)
-        return new Response("<script>window.close();</script>", {
-          status: 200,
-          headers: { "content-type": "text/html" },
-        });
-      } catch (e: any) {
-        return new Response(e, { status: 401 });
-      }
-    }
-
     const reqUrl = new URL(request.url);
+    console.log(this.getMcpServers())
     if (reqUrl.pathname.endsWith("add-mcp") && request.method === "POST") {
-      const mcpServer = (await request.json()) as { url: string };
-      const authUrl = await this.addMcpServer(mcpServer.url);
-      return new Response(authUrl, { status: 200 });
+      const mcpServer = (await request.json()) as { url: string; name: string };
+      await this.addMcpServer(mcpServer.name, mcpServer.url, this.env.HOST);
+      return new Response("Ok", { status: 200 });
     }
 
     return new Response("Not found", { status: 404 });

--- a/demos/mcp-client/src/styles.css
+++ b/demos/mcp-client/src/styles.css
@@ -30,6 +30,11 @@ body {
   font-size: 16px;
 }
 
+.mcp-input.name {
+  flex: 0;
+  width: 150px;
+}
+
 .mcp-input:focus {
   outline: none;
   border-color: #0066ff;
@@ -104,4 +109,9 @@ button:hover {
 
 .mcp-servers {
   margin-top: 8px;
+}
+
+b {
+  margin-bottom: 4px;
+  display: inline-block;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       agents:
         specifier: ^0.0.88
         version: 0.0.88(@cloudflare/workers-types@4.20250514.0)(react@19.1.0)
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       react:
         specifier: ^19.1.0
         version: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1(vite@6.3.5(@types/node@22.15.18)(sugarss@4.0.1(postcss@8.5.3))(tsx@4.19.4)(yaml@2.7.1))
       agents:
-        specifier: ^0.0.80
-        version: 0.0.80(@cloudflare/workers-types@4.20250514.0)(react@19.1.0)
+        specifier: ^0.0.88
+        version: 0.0.88(@cloudflare/workers-types@4.20250514.0)(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3175,6 +3175,11 @@ packages:
     peerDependencies:
       react: '*'
 
+  agents@0.0.88:
+    resolution: {integrity: sha512-ysQ3LMONALxx1VL0X/Tq49EzfuuLj1SHfztCCIfAX8hVtYw2Jr9rytnM94lZQ29yFFqmcIKWR+D13j/l7Cyf8A==}
+    peerDependencies:
+      react: '*'
+
   ai@4.3.15:
     resolution: {integrity: sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg==}
     engines: {node: '>=18'}
@@ -4827,8 +4832,16 @@ packages:
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240729.0
 
+  partyserver@0.0.71:
+    resolution: {integrity: sha512-PJZoX08tyNcNJVXqWJedZ6Jzj8EOFGBA/PJ37KhAnWmTkq6A8SqA4u2ol+zq8zwSfRy9FPvVgABCY0yLpe62Dg==}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20240729.0
+
   partysocket@1.1.3:
     resolution: {integrity: sha512-87Jd/nqPoWnVfzHE6Z12WLWTJ+TAgxs0b7i2S163HfQSrVDUK5tW/FC64T5N8L5ss+gqF+EV0BwjZMWggMY3UA==}
+
+  partysocket@1.1.4:
+    resolution: {integrity: sha512-jXP7PFj2h5/v4UjDS8P7MZy6NJUQ7sspiFyxL4uc/+oKOL+KdtXzHnTV8INPGxBrLTXgalyG3kd12Qm7WrYc3A==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -7726,6 +7739,20 @@ snapshots:
       - '@cloudflare/workers-types'
       - supports-color
 
+  agents@0.0.88(@cloudflare/workers-types@4.20250514.0)(react@19.1.0):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.11.2
+      ai: 4.3.15(react@19.1.0)(zod@3.24.4)
+      cron-schedule: 5.0.4
+      nanoid: 5.1.5
+      partyserver: 0.0.71(@cloudflare/workers-types@4.20250514.0)
+      partysocket: 1.1.4
+      react: 19.1.0
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - supports-color
+
   ai@4.3.15(react@19.1.0)(zod@3.24.4):
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -9328,7 +9355,16 @@ snapshots:
       '@cloudflare/workers-types': 4.20250514.0
       nanoid: 5.1.5
 
+  partyserver@0.0.71(@cloudflare/workers-types@4.20250514.0):
+    dependencies:
+      '@cloudflare/workers-types': 4.20250514.0
+      nanoid: 5.1.5
+
   partysocket@1.1.3:
+    dependencies:
+      event-target-polyfill: 0.0.4
+
+  partysocket@1.1.4:
     dependencies:
       event-target-polyfill: 0.0.4
 


### PR DESCRIPTION
Fixes the mcp-client example. Largely just copy-pasting the code from agents, with a dependency upgrade.