### PR TITLE
Fix typo in `tsconfig.json`

### DIFF
--- a/demos/remote-mcp-authless/tsconfig.json
+++ b/demos/remote-mcp-authless/tsconfig.json
@@ -4,7 +4,7 @@
 		"lib": ["es2021"],
 		"jsx": "react-jsx",
 		"module": "es2022",
-		"moduleResolution": "Bundler",
+		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"allowJs": true,
 		"checkJs": false,


### PR DESCRIPTION
Hello,

This pull request fixes a minor typo that was causing the TypeScript compiler to fail during type resolution.