### PR TITLE
Fixes message textbox hotkey

### DIFF
--- a/playground/ai/src/App.tsx
+++ b/playground/ai/src/App.tsx
@@ -184,7 +184,7 @@ const App = () => {
 			});
 	}, []);
 
-	useHotkeys("meta+enter", () => handleSubmit(), {
+	useHotkeys("meta+enter, ctrl+enter", () => handleSubmit(), {
 		enableOnFormTags: ["textarea"],
 	});
 


### PR DESCRIPTION
In windows, `Ctrl + Enter` does not work, and there's a hint stating:

> Send messages and generate a response (⌘/Ctrl + Enter)

This PR fixes it.