### PR TITLE
Run pnpm format after playground migration

### DIFF
--- a/demos.json
+++ b/demos.json
@@ -1,109 +1,109 @@
 {
-  "demos": {
-    "./demos/agent-scheduler": {
-      "package_json_hash": "cf08ea3161f6f1e43cdba16794c503ba2e2f0e0d"
-    },
-    "./demos/agent-task-manager": {
-      "package_json_hash": "ec7e28c8e505fbbfb5bd9b282db88c5b094da5a0"
-    },
-    "./demos/agent-task-manager-human-in-the-loop": {
-      "package_json_hash": "7fdc5e4486faf447dcc46430fbd7b4daf81e0558"
-    },
-    "./demos/evaluator-optimiser": {
-      "package_json_hash": "53ab803909af35fdef9ee9aafd7bb4b28ebb607e"
-    },
-    "./demos/image-generation": {
-      "package_json_hash": "97d2c7611df3b940e8267acc99cdc7b41985bfd3"
-    },
-    "./demos/mcp-client": {
-      "package_json_hash": "a7728e158325ca54a07d46b325acb79797cb3037"
-    },
-    "./demos/mcp-server-bearer-auth": {
-      "package_json_hash": "e08793673474addbb58a5fd86dc08487eef7a335"
-    },
-    "./demos/mcp-slack-oauth": {
-      "package_json_hash": "366dd535b2118f84f62a62fe5d8c45c4eac149c6"
-    },
-    "./demos/mcp-stytch-b2b-okr-manager": {
-      "package_json_hash": "3d6ca843ffc611d1b49792d81b7455f83ddeb512"
-    },
-    "./demos/mcp-stytch-consumer-todo-list": {
-      "package_json_hash": "8f664d77b937ae6178eaae60a5fedaefe68cb62d"
-    },
-    "./demos/model-scraper": {
-      "package_json_hash": "009e965b950b663fbc043337fbd6a60180f67da1"
-    },
-    "./demos/orchestrator-workers": {
-      "package_json_hash": "bea638fae4aa967e068ed8e37c578341851dcb7b"
-    },
-    "./demos/parallelisation": {
-      "package_json_hash": "ed27352e35bf5112053ac18cb1ca2664c9b850bf"
-    },
-    "./demos/prompt-chaining": {
-      "package_json_hash": "d640a3d58737fbe880dff4523884656dc04e98a9"
-    },
-    "./demos/remote-mcp-authkit": {
-      "package_json_hash": "0f82a65d028614999a16c7807c740687049428cd"
-    },
-    "./demos/remote-mcp-github-oauth": {
-      "package_json_hash": "0b79e566301c077625995597ba4b1e7eba1d915f"
-    },
-    "./demos/remote-mcp-server": {
-      "package_json_hash": "95155f0d8285186152b777b07a919e6de08b3693"
-    },
-    "./demos/routing": {
-      "package_json_hash": "e90779c4f4f61c27c7376c03c8c6dc1580004471"
-    },
-    "./demos/structured-output": {
-      "package_json_hash": "a52d4b67b391dc8801d863ed5c6e3facdaa23c3d"
-    },
-    "./demos/structured-output-node": {
-      "package_json_hash": "e939d224fb80ecd4b49c6b74c235a97413da82ac"
-    },
-    "./demos/text-generation": {
-      "package_json_hash": "bbe295cacade9c0267ef88dc937590ddf3703d52"
-    },
-    "./demos/text-generation-stream": {
-      "package_json_hash": "741cd478fd31f9088c8870af2b4ec4a5dd846aa4"
-    },
-    "./demos/tool-calling": {
-      "package_json_hash": "a2ecc2a204f52eac964316cae4c3a9f82d04a00a"
-    },
-    "./demos/tool-calling-stream": {
-      "package_json_hash": "5049386ab6c3c689033604b3022e7c52b4791d7f"
-    },
-    "./demos/tool-calling-stream-traditional": {
-      "package_json_hash": "726e8ca98bf2cf3d6898b9f4469b54d5550417c5"
-    },
-    "./demos/ui-worker": {
-      "package_json_hash": "04e1607331492b19862202a75244b9c26012812d"
-    },
-    "./demos/remote-mcp-cf-access": {
-      "package_json_hash": "ad2f078a3a2de29243112b7b0a19183d58eaad40"
-    },
-    "./demos/remote-mcp-authless": {
-      "package_json_hash": "b461b3e5e2347fa2a7ee67cd19bd386c48c9b04c"
-    },
-    "./demos/python-workers-mcp": {
-      "package_json_hash": "a4f6e28b2240dca24ebaaadf9baa62cc7f692be1"
-    },
-    "./demos/vision": {
-      "package_json_hash": "a2978b39bfbdd8ca98d7a5ebf9259e4964649174"
-    },
-    "./demos/remote-mcp-google-oauth": {
-      "package_json_hash": "6ad2e82003af3508e5cd92b4a93ae087b3cdf7f3"
-    },
-    "./demos/remote-mcp-logto": {
-      "package_json_hash": "0befc8821e3fd630bc6048c2bd8b95a739e395be"
-    },
-    "./demos/remote-mcp-server-descope-auth": {
-      "package_json_hash": "82d83172531107a1d32c99b652bc95313ad00765"
-    },
-    "./demos/remote-mcp-server-autorag": {
-      "package_json_hash": "b58b59b7c6e3344311e07c2ca0ecde221dab2d4a"
-    },
-    "./demos/use-mcp-inspector": {
-      "package_json_hash": "7b39e5c6392dc48ba6c09c5e2e4cc459fc792b76"
-    }
-  }
+	"demos": {
+		"./demos/agent-scheduler": {
+			"package_json_hash": "cf08ea3161f6f1e43cdba16794c503ba2e2f0e0d"
+		},
+		"./demos/agent-task-manager": {
+			"package_json_hash": "ec7e28c8e505fbbfb5bd9b282db88c5b094da5a0"
+		},
+		"./demos/agent-task-manager-human-in-the-loop": {
+			"package_json_hash": "7fdc5e4486faf447dcc46430fbd7b4daf81e0558"
+		},
+		"./demos/evaluator-optimiser": {
+			"package_json_hash": "53ab803909af35fdef9ee9aafd7bb4b28ebb607e"
+		},
+		"./demos/image-generation": {
+			"package_json_hash": "97d2c7611df3b940e8267acc99cdc7b41985bfd3"
+		},
+		"./demos/mcp-client": {
+			"package_json_hash": "a7728e158325ca54a07d46b325acb79797cb3037"
+		},
+		"./demos/mcp-server-bearer-auth": {
+			"package_json_hash": "e08793673474addbb58a5fd86dc08487eef7a335"
+		},
+		"./demos/mcp-slack-oauth": {
+			"package_json_hash": "366dd535b2118f84f62a62fe5d8c45c4eac149c6"
+		},
+		"./demos/mcp-stytch-b2b-okr-manager": {
+			"package_json_hash": "3d6ca843ffc611d1b49792d81b7455f83ddeb512"
+		},
+		"./demos/mcp-stytch-consumer-todo-list": {
+			"package_json_hash": "8f664d77b937ae6178eaae60a5fedaefe68cb62d"
+		},
+		"./demos/model-scraper": {
+			"package_json_hash": "009e965b950b663fbc043337fbd6a60180f67da1"
+		},
+		"./demos/orchestrator-workers": {
+			"package_json_hash": "bea638fae4aa967e068ed8e37c578341851dcb7b"
+		},
+		"./demos/parallelisation": {
+			"package_json_hash": "ed27352e35bf5112053ac18cb1ca2664c9b850bf"
+		},
+		"./demos/prompt-chaining": {
+			"package_json_hash": "d640a3d58737fbe880dff4523884656dc04e98a9"
+		},
+		"./demos/remote-mcp-authkit": {
+			"package_json_hash": "0f82a65d028614999a16c7807c740687049428cd"
+		},
+		"./demos/remote-mcp-github-oauth": {
+			"package_json_hash": "0b79e566301c077625995597ba4b1e7eba1d915f"
+		},
+		"./demos/remote-mcp-server": {
+			"package_json_hash": "95155f0d8285186152b777b07a919e6de08b3693"
+		},
+		"./demos/routing": {
+			"package_json_hash": "e90779c4f4f61c27c7376c03c8c6dc1580004471"
+		},
+		"./demos/structured-output": {
+			"package_json_hash": "a52d4b67b391dc8801d863ed5c6e3facdaa23c3d"
+		},
+		"./demos/structured-output-node": {
+			"package_json_hash": "e939d224fb80ecd4b49c6b74c235a97413da82ac"
+		},
+		"./demos/text-generation": {
+			"package_json_hash": "bbe295cacade9c0267ef88dc937590ddf3703d52"
+		},
+		"./demos/text-generation-stream": {
+			"package_json_hash": "741cd478fd31f9088c8870af2b4ec4a5dd846aa4"
+		},
+		"./demos/tool-calling": {
+			"package_json_hash": "a2ecc2a204f52eac964316cae4c3a9f82d04a00a"
+		},
+		"./demos/tool-calling-stream": {
+			"package_json_hash": "5049386ab6c3c689033604b3022e7c52b4791d7f"
+		},
+		"./demos/tool-calling-stream-traditional": {
+			"package_json_hash": "726e8ca98bf2cf3d6898b9f4469b54d5550417c5"
+		},
+		"./demos/ui-worker": {
+			"package_json_hash": "04e1607331492b19862202a75244b9c26012812d"
+		},
+		"./demos/remote-mcp-cf-access": {
+			"package_json_hash": "ad2f078a3a2de29243112b7b0a19183d58eaad40"
+		},
+		"./demos/remote-mcp-authless": {
+			"package_json_hash": "b461b3e5e2347fa2a7ee67cd19bd386c48c9b04c"
+		},
+		"./demos/python-workers-mcp": {
+			"package_json_hash": "a4f6e28b2240dca24ebaaadf9baa62cc7f692be1"
+		},
+		"./demos/vision": {
+			"package_json_hash": "a2978b39bfbdd8ca98d7a5ebf9259e4964649174"
+		},
+		"./demos/remote-mcp-google-oauth": {
+			"package_json_hash": "6ad2e82003af3508e5cd92b4a93ae087b3cdf7f3"
+		},
+		"./demos/remote-mcp-logto": {
+			"package_json_hash": "0befc8821e3fd630bc6048c2bd8b95a739e395be"
+		},
+		"./demos/remote-mcp-server-descope-auth": {
+			"package_json_hash": "82d83172531107a1d32c99b652bc95313ad00765"
+		},
+		"./demos/remote-mcp-server-autorag": {
+			"package_json_hash": "b58b59b7c6e3344311e07c2ca0ecde221dab2d4a"
+		},
+		"./demos/use-mcp-inspector": {
+			"package_json_hash": "7b39e5c6392dc48ba6c09c5e2e4cc459fc792b76"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -53,14 +53,7 @@
 	},
 	"packageManager": "pnpm@10.12.1",
 	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild",
-			"msw",
-			"nx",
-			"sharp",
-			"workerd"
-		]
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "msw", "nx", "sharp", "workerd"]
 	},
 	"private": true
 }

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -22,22 +22,8 @@
 		"test": "vitest",
 		"type-check": "tsc --noEmit"
 	},
-	"files": [
-		"dist",
-		"src",
-		"README.md",
-		"package.json"
-	],
-	"keywords": [
-		"workers",
-		"cloudflare",
-		"ai",
-		"vercel",
-		"sdk",
-		"provider",
-		"chat",
-		"serverless"
-	],
+	"files": ["dist", "src", "README.md", "package.json"],
+	"keywords": ["workers", "cloudflare", "ai", "vercel", "sdk", "provider", "chat", "serverless"],
 	"dependencies": {
 		"@ai-sdk/provider": "^1.1.3",
 		"@ai-sdk/provider-utils": "^2.2.8"

--- a/playground/ai/scripts/fetch-models.ts
+++ b/playground/ai/scripts/fetch-models.ts
@@ -34,9 +34,7 @@ async function main() {
 
 	const data = await Promise.all([
 		fetch(modelsEndpoint, reqParams).then((res) => res.json<Result<Model>>()),
-		fetch(finetunesEndpoint, reqParams).then((res) =>
-			res.json<Result<FineTune>>(),
-		),
+		fetch(finetunesEndpoint, reqParams).then((res) => res.json<Result<FineTune>>()),
 	]);
 
 	const models = data[0].result

--- a/playground/ai/src/App.tsx
+++ b/playground/ai/src/App.tsx
@@ -75,19 +75,10 @@ const App = () => {
 	const [error, setError] = useState("");
 	const [codeVisible, setCodeVisible] = useState(false);
 	const [settingsVisible, setSettingsVisible] = useState(false);
-	const [systemMessage, setSystemMessage] = useState(
-		"You are a helpful assistant",
-	);
+	const [systemMessage, setSystemMessage] = useState("You are a helpful assistant");
 	const [mcpTools, setMcpTools] = useState<Tool[]>([]);
 
-	const {
-		messages,
-		input,
-		handleInputChange,
-		handleSubmit,
-		status,
-		setMessages,
-	} = useChat({
+	const { messages, input, handleInputChange, handleSubmit, status, setMessages } = useChat({
 		api: "/api/inference",
 		body: {
 			lora: params.lora,
@@ -111,8 +102,7 @@ const App = () => {
 						Object.entries(args).map(([key, value]) => {
 							// console.log({ key, value });
 							if (
-								(mcpTool.inputSchema.properties?.[key] as any)?.type ===
-									"number" &&
+								(mcpTool.inputSchema.properties?.[key] as any)?.type === "number" &&
 								typeof value === "string"
 							) {
 								return [key, Number(value)];
@@ -284,8 +274,8 @@ const App = () => {
 							</div>
 
 							<p className="text-gray-400 text-sm mt-1 mb-4">
-								Explore different Text Generation models by drafting messages
-								and fine-tuning your responses.
+								Explore different Text Generation models by drafting messages and
+								fine-tuning your responses.
 							</p>
 
 							<div className="md:mb-4">
@@ -430,19 +420,25 @@ const App = () => {
 													<div key={i}>
 														<div className="w-full text-center italic text-xs text-gray-400 font-mono max-h-20 overflow-auto break-all px-2 whitespace-pre-line">
 															[tool] {part.toolInvocation.toolName}(
-															{JSON.stringify(part.toolInvocation.args)})
-															=&gt;&nbsp;
+															{JSON.stringify(
+																part.toolInvocation.args,
+															)}
+															) =&gt;&nbsp;
 															{part.toolInvocation.state === "call" &&
 															status === "ready"
 																? "awaiting confirmation..."
-																: part.toolInvocation.state === "call"
+																: part.toolInvocation.state ===
+																		"call"
 																	? "pending..."
-																	: part.toolInvocation.state === "result"
+																	: part.toolInvocation.state ===
+																			"result"
 																		? part.toolInvocation.result
 																		: null}
 														</div>
 														{part.toolInvocation.state === "result" &&
-														part.toolInvocation.result.match(/\[blob:.*]/) ? (
+														part.toolInvocation.result.match(
+															/\[blob:.*]/,
+														) ? (
 															<img
 																className="block max-w-md mx-auto mt-3"
 																src={
@@ -465,7 +461,8 @@ const App = () => {
 												<button
 													type="button"
 													className={`px-3 py-2 bg-orange-100 hover:bg-orange-200 rounded-lg text-sm capitalize cursor-pointer ${
-														(streaming || loading) && "pointer-events-none"
+														(streaming || loading) &&
+														"pointer-events-none"
 													}`}
 												>
 													{message.role}
@@ -474,7 +471,8 @@ const App = () => {
 											<div className="relative grow">
 												<TextareaAutosize
 													className={`rounded-md p-3 w-full resize-none mt-[-6px] hover:bg-gray-50 ${
-														(streaming || loading) && "pointer-events-none"
+														(streaming || loading) &&
+														"pointer-events-none"
 													}`}
 													value={message.content}
 													disabled={true}
@@ -535,9 +533,7 @@ const App = () => {
 
 						<div className="sticky mt-auto bottom-0 left-0 right-0 bg-white flex items-center p-5 border-t border-t-gray-200">
 							{error ? (
-								<div className="text-sm text-red-600 md:block hidden">
-									{error}
-								</div>
+								<div className="text-sm text-red-600 md:block hidden">{error}</div>
 							) : (
 								<div className="text-sm text-gray-400 md:block hidden">
 									Send messages and generate a response (⌘/Ctrl + Enter)

--- a/playground/ai/src/FinetuneSelector.tsx
+++ b/playground/ai/src/FinetuneSelector.tsx
@@ -37,10 +37,7 @@ const FinetuneSelector = ({
 	return (
 		<div className="relative">
 			{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
-			<label
-				{...getLabelProps()}
-				className="font-semibold text-sm block mb-1 md:block"
-			>
+			<label {...getLabelProps()} className="font-semibold text-sm block mb-1 md:block">
 				Finetune
 			</label>
 			<div
@@ -54,9 +51,7 @@ const FinetuneSelector = ({
 			</div>
 
 			{selectedItem && (
-				<span className="mt-2 block text-gray-400 text-sm">
-					{selectedItem.description}
-				</span>
+				<span className="mt-2 block text-gray-400 text-sm">{selectedItem.description}</span>
 			)}
 
 			<ul

--- a/playground/ai/src/McpServers.tsx
+++ b/playground/ai/src/McpServers.tsx
@@ -14,8 +14,7 @@ function McpConnection({
 	onConnectionUpdate: (data: ConnectionData) => void;
 }) {
 	// Build custom headers object
-	const customHeaders =
-		headerKey && bearerToken ? { [headerKey]: `Bearer ${bearerToken}` } : {};
+	const customHeaders = headerKey && bearerToken ? { [headerKey]: `Bearer ${bearerToken}` } : {};
 
 	// Use the MCP hook with the server URL
 	const connection = useMcp({
@@ -58,8 +57,7 @@ export function McpServers({
 		retry: () => {},
 		disconnect: () => {},
 		authenticate: () => Promise.resolve(undefined),
-		callTool: (name: string, args?: Record<string, unknown>) =>
-			Promise.resolve(undefined),
+		callTool: (name: string, args?: Record<string, unknown>) => Promise.resolve(undefined),
 		clearStorage: () => {},
 	});
 	const logRef = useRef<HTMLDivElement>(null);
@@ -73,8 +71,7 @@ export function McpServers({
 	const [showToken, setShowToken] = useState<boolean>(false);
 
 	// Extract connection properties
-	const { state, tools, error, log, authUrl, retry, disconnect, authenticate } =
-		connectionData;
+	const { state, tools, error, log, authUrl, retry, disconnect, authenticate } = connectionData;
 
 	// Notify parent component when tools change
 	useEffect(() => {
@@ -107,8 +104,7 @@ export function McpServers({
 			retry: () => {},
 			disconnect: () => {},
 			authenticate: () => Promise.resolve(undefined),
-			callTool: (name: string, args?: Record<string, unknown>) =>
-				Promise.resolve(undefined),
+			callTool: (name: string, args?: Record<string, unknown>) => Promise.resolve(undefined),
 			clearStorage: () => {},
 		});
 	};
@@ -136,9 +132,7 @@ export function McpServers({
 		switch (state) {
 			case "discovering":
 				return (
-					<span className={`${baseClasses} bg-blue-100 text-blue-800`}>
-						Discovering
-					</span>
+					<span className={`${baseClasses} bg-blue-100 text-blue-800`}>Discovering</span>
 				);
 			case "authenticating":
 				return (
@@ -154,22 +148,14 @@ export function McpServers({
 				);
 			case "loading":
 				return (
-					<span className={`${baseClasses} bg-orange-100 text-orange-800`}>
-						Loading
-					</span>
+					<span className={`${baseClasses} bg-orange-100 text-orange-800`}>Loading</span>
 				);
 			case "ready":
 				return (
-					<span className={`${baseClasses} bg-green-100 text-green-800`}>
-						Connected
-					</span>
+					<span className={`${baseClasses} bg-green-100 text-green-800`}>Connected</span>
 				);
 			case "failed":
-				return (
-					<span className={`${baseClasses} bg-red-100 text-red-800`}>
-						Failed
-					</span>
-				);
+				return <span className={`${baseClasses} bg-red-100 text-red-800`}>Failed</span>;
 
 			/* biome-ignore lint/complexity/noUselessSwitchCase: eh */
 			case "not-connected":

--- a/playground/ai/src/ModelSelector.tsx
+++ b/playground/ai/src/ModelSelector.tsx
@@ -50,9 +50,7 @@ const ModelSelector = ({
 		let filteredItems = models;
 
 		if (inputValue) {
-			filteredItems = filteredItems.filter((model) =>
-				model.name.includes(inputValue),
-			);
+			filteredItems = filteredItems.filter((model) => model.name.includes(inputValue));
 		}
 
 		// Apply tag filters
@@ -60,17 +58,9 @@ const ModelSelector = ({
 			if (state === "show") {
 				filteredItems = filteredItems.filter((model) =>
 					model.properties.some((prop) => {
-						if (
-							tag === "Beta" &&
-							prop.property_id === "beta" &&
-							prop.value === "true"
-						)
+						if (tag === "Beta" && prop.property_id === "beta" && prop.value === "true")
 							return true;
-						if (
-							tag === "LoRA" &&
-							prop.property_id === "lora" &&
-							prop.value === "true"
-						)
+						if (tag === "LoRA" && prop.property_id === "lora" && prop.value === "true")
 							return true;
 						if (
 							tag === "MCP" &&
@@ -233,11 +223,7 @@ const ModelSelector = ({
 						setInputValue("");
 					}}
 				/>
-				{inputValue || !selectedItem ? (
-					<span />
-				) : (
-					<ModelRow model={selectedItem} />
-				)}
+				{inputValue || !selectedItem ? <span /> : <ModelRow model={selectedItem} />}
 				<span className="px-2" {...getToggleButtonProps()}>
 					{isOpen ? <>&#8593;</> : <>&#8595;</>}
 				</span>
@@ -249,9 +235,7 @@ const ModelSelector = ({
 				{...getMenuProps()}
 			>
 				{isOpen && inputItems.length === 0 && (
-					<li className={"py-2 px-3 flex flex-col rounded-md"}>
-						No models found
-					</li>
+					<li className={"py-2 px-3 flex flex-col rounded-md"}>No models found</li>
 				)}
 				{isOpen &&
 					inputItems.map((item, index) => (

--- a/playground/ai/src/OAuthCallbackPage.tsx
+++ b/playground/ai/src/OAuthCallbackPage.tsx
@@ -25,9 +25,7 @@ export default function OAuthCallbackPage() {
 					message: res.error,
 				}),
 			)
-			.catch((err: Error) =>
-				setResult({ status: "error", message: err.message }),
-			);
+			.catch((err: Error) => setResult({ status: "error", message: err.message }));
 	}, [searchParams]);
 
 	return (
@@ -37,9 +35,7 @@ export default function OAuthCallbackPage() {
 			{result.status === "success" && (
 				<p>Authentication successful! You can close this window.</p>
 			)}
-			{result.status === "error" && (
-				<p>Authentication error: {result.message}</p>
-			)}
+			{result.status === "error" && <p>Authentication error: {result.message}</p>}
 		</div>
 	);
 }

--- a/playground/ai/src/index.css
+++ b/playground/ai/src/index.css
@@ -13,14 +13,7 @@ body,
 }
 
 .bg-ai-loop {
-	background-image: linear-gradient(
-		75deg,
-		#901475,
-		#ce2f55,
-		#ff6633,
-		#ce2f55,
-		#901475
-	);
+	background-image: linear-gradient(75deg, #901475, #ce2f55, #ff6633, #ce2f55, #901475);
 }
 
 button {

--- a/playground/ai/src/models.json
+++ b/playground/ai/src/models.json
@@ -1,1 +1,1006 @@
-[{"id":"7f180530-2e16-4116-9d26-f49fbed9d372","source":2,"name":"@hf/thebloke/deepseek-coder-6.7b-base-awq","description":"Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-06 18:16:27.183","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"terms","value":"https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-AWQ"}]},{"id":"60474554-f03b-4ff4-8ecc-c1b7c71d7b29","source":2,"name":"@hf/thebloke/deepseek-coder-6.7b-instruct-awq","description":"Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-06 18:18:27.462","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"terms","value":"https://huggingface.co/TheBloke/deepseek-coder-6.7B-instruct-AWQ"}]},{"id":"4c3a544e-da47-4336-9cea-c7cbfab33f16","source":1,"name":"@cf/deepseek-ai/deepseek-math-7b-instruct","description":"DeepSeekMath-Instruct 7B is a mathematically instructed tuning model derived from DeepSeekMath-Base 7B. DeepSeekMath is initialized with DeepSeek-Coder-v1.5 7B and continues pre-training on math-related tokens sourced from Common Crawl, together with natural language and code data for 500B tokens.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 17:54:17.459","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/deepseek-ai/deepseek-math-7b-instruct"},{"property_id":"terms","value":"https://github.com/deepseek-ai/DeepSeek-Math/blob/main/LICENSE-MODEL"}]},{"id":"ad01ab83-baf8-4e7b-8fed-a0a219d4eb45","source":1,"name":"@cf/deepseek-ai/deepseek-r1-distill-qwen-32b","description":"DeepSeek-R1-Distill-Qwen-32B is a model distilled from DeepSeek-R1 based on Qwen2.5. It outperforms OpenAI-o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-01-22 19:48:55.776","tags":[],"properties":[{"property_id":"context_window","value":"80000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.5,"currency":"USD"},{"unit":"per M output tokens","price":4.88,"currency":"USD"}]},{"property_id":"terms","value":"https://github.com/deepseek-ai/DeepSeek-R1/blob/main/LICENSE"}]},{"id":"9d2ab560-065e-4d0d-a789-d4bc7468d33e","source":1,"name":"@cf/thebloke/discolm-german-7b-v1-awq","description":"DiscoLM German 7b is a Mistral-based large language model with a focus on German-language applications. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:23:05.178","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/TheBloke/DiscoLM_German_7b_v1-AWQ"}]},{"id":"48dd2443-0c61-43b2-8894-22abddf1b081","source":1,"name":"@cf/tiiuae/falcon-7b-instruct","description":"Falcon-7B-Instruct is a 7B parameters causal decoder-only model built by TII based on Falcon-7B and finetuned on a mixture of chat/instruct datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:21:15.796","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/tiiuae/falcon-7b-instruct"}]},{"id":"053d5ac0-861b-4d3b-8501-e58d00417ef8","source":1,"name":"@cf/google/gemma-3-12b-it","description":"Gemma 3 models are well-suited for a variety of text generation and image understanding tasks, including question answering, summarization, and reasoning. Gemma 3 models are multimodal, handling text and image input and generating text output, with a large, 128K context window, multilingual support in over 140 languages, and is available in more sizes than previous versions.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-03-18 03:58:02.423","tags":[],"properties":[{"property_id":"context_window","value":"80000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.35,"currency":"USD"},{"unit":"per M output tokens","price":0.56,"currency":"USD"}]},{"property_id":"lora","value":"true"}]},{"id":"0f002249-7d86-4698-aabf-8529ed86cefb","source":2,"name":"@hf/google/gemma-7b-it","description":"Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-01 23:51:35.866","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"8192"},{"property_id":"info","value":"https://ai.google.dev/gemma/docs"},{"property_id":"lora","value":"true"},{"property_id":"terms","value":"https://ai.google.dev/gemma/terms"}]},{"id":"44774b85-08c8-4bb8-8d2a-b06ebc538a79","source":2,"name":"@hf/nousresearch/hermes-2-pro-mistral-7b","description":"Hermes 2 Pro on Mistral 7B is the new flagship 7B Hermes! Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-01 23:45:53.800","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"24000"},{"property_id":"function_calling","value":"true"},{"property_id":"info","value":"https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B"}]},{"id":"85c5a3c6-24b0-45e7-b23a-023182578822","source":2,"name":"@hf/thebloke/llama-2-13b-chat-awq","description":"Llama 2 13B Chat AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Llama 2 variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-11-24 00:27:15.869","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/TheBloke/Llama-2-13B-chat-AWQ"}]},{"id":"ca54bcd6-0d98-4739-9b3b-5c8b4402193d","source":1,"name":"@cf/meta/llama-2-7b-chat-fp16","description":"Full precision (fp16) generative text model with 7 billion parameters from Meta","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-11-07 11:54:20.229","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.56,"currency":"USD"},{"unit":"per M output tokens","price":6.67,"currency":"USD"}]},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://ai.meta.com/llama/"},{"property_id":"terms","value":"https://ai.meta.com/resources/models-and-libraries/llama-downloads/"}]},{"id":"9c95c39d-45b3-4163-9631-22f0c0dc3b14","source":1,"name":"@cf/meta/llama-2-7b-chat-int8","description":"Quantized (int8) generative text model with 7 billion parameters from Meta","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-09-25 19:21:11.898","tags":[],"properties":[{"property_id":"context_window","value":"8192"}]},{"id":"e11d8f45-7b08-499a-9eeb-71d4d3c8cbf9","source":1,"name":"@cf/meta/llama-3-8b-instruct","description":"Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-18 20:31:47.273","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.28,"currency":"USD"},{"unit":"per M output tokens","price":0.83,"currency":"USD"}]},{"property_id":"context_window","value":"7968"},{"property_id":"info","value":"https://llama.meta.com"},{"property_id":"terms","value":"https://llama.meta.com/llama3/license/#"}]},{"id":"31097538-a3ff-4e6e-bb56-ad0e1f428b61","source":1,"name":"@cf/meta/llama-3-8b-instruct-awq","description":"Quantized (int4) generative text model with 8 billion parameters from Meta.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-05-09 23:32:47.584","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.12,"currency":"USD"},{"unit":"per M output tokens","price":0.27,"currency":"USD"}]},{"property_id":"context_window","value":"8192"},{"property_id":"info","value":"https://llama.meta.com"},{"property_id":"terms","value":"https://llama.meta.com/llama3/license/#"}]},{"id":"3dcb4f2d-26a8-412b-b6e3-2a368beff66b","source":1,"name":"@cf/meta/llama-3.1-8b-instruct-awq","description":"Quantized (int4) generative text model with 8 billion parameters from Meta.\n","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-07-25 17:46:04.304","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.12,"currency":"USD"},{"unit":"per M output tokens","price":0.27,"currency":"USD"}]},{"property_id":"context_window","value":"8192"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"}]},{"id":"9b9c87c6-d4b7-494c-b177-87feab5904db","source":1,"name":"@cf/meta/llama-3.1-8b-instruct-fp8","description":"Llama 3.1 8B quantized to FP8 precision","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-07-25 17:28:43.328","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.15,"currency":"USD"},{"unit":"per M output tokens","price":0.29,"currency":"USD"}]},{"property_id":"context_window","value":"32000"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"}]},{"id":"2cbc033b-ded8-4e02-bbb2-47cf05d5cfe5","source":1,"name":"@cf/meta/llama-3.2-11b-vision-instruct","description":" The Llama 3.2-Vision instruction-tuned models are optimized for visual recognition, image reasoning, captioning, and answering general questions about an image.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-09-25 05:36:04.547","tags":[],"properties":[{"property_id":"context_window","value":"128000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.049,"currency":"USD"},{"unit":"per M output tokens","price":0.68,"currency":"USD"}]},{"property_id":"lora","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}]},{"id":"906a57fd-b018-4d6c-a43e-a296d4cc5839","source":1,"name":"@cf/meta/llama-3.2-1b-instruct","description":"The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-09-25 21:36:32.050","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.027,"currency":"USD"},{"unit":"per M output tokens","price":0.2,"currency":"USD"}]},{"property_id":"context_window","value":"60000"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}]},{"id":"d9dc8363-66f4-4bb0-8641-464ee7bfc131","source":1,"name":"@cf/meta/llama-3.2-3b-instruct","description":"The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-09-25 20:05:43.986","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.051,"currency":"USD"},{"unit":"per M output tokens","price":0.34,"currency":"USD"}]},{"property_id":"context_window","value":"128000"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"}]},{"id":"7a143886-c9bb-4a1c-be95-377b1973bc3b","source":1,"name":"@cf/meta/llama-3.3-70b-instruct-fp8-fast","description":"Llama 3.3 70B quantized to fp8 precision, optimized to be faster.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-12-06 17:09:18.338","tags":[],"properties":[{"property_id":"async_queue","value":"true"},{"property_id":"context_window","value":"24000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.29,"currency":"USD"},{"unit":"per M output tokens","price":2.25,"currency":"USD"}]},{"property_id":"function_calling","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE"}]},{"id":"06455e78-19f7-487b-93cd-c05a3dd07813","source":1,"name":"@cf/meta/llama-4-scout-17b-16e-instruct","description":"Meta's Llama 4 Scout is a 17 billion parameter model with 16 experts that is natively multimodal. These models leverage a mixture-of-experts architecture to offer industry-leading performance in text and image understanding.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-04-05 20:25:56.137","tags":[],"properties":[{"property_id":"context_window","value":"131000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.27,"currency":"USD"},{"unit":"per M output tokens","price":0.85,"currency":"USD"}]},{"property_id":"function_calling","value":"true"},{"property_id":"terms","value":"https://github.com/meta-llama/llama-models/blob/main/models/llama4/LICENSE"}]},{"id":"cc80437b-9a8d-4f1a-9c77-9aaf0d226922","source":1,"name":"@cf/meta/llama-guard-3-8b","description":"Llama Guard 3 is a Llama-3.1-8B pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM – it generates text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-01-22 23:26:23.495","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.48,"currency":"USD"},{"unit":"per M output tokens","price":0.03,"currency":"USD"}]},{"property_id":"lora","value":"true"}]},{"id":"d9b7a55c-cefa-4208-8ab3-11497a2b046c","source":2,"name":"@hf/thebloke/llamaguard-7b-awq","description":"Llama Guard is a model for classifying the safety of LLM prompts and responses, using a taxonomy of safety risks.\n","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-06 18:13:59.060","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"}]},{"id":"1a7b6ad6-9987-4bd3-a329-20ee8de93296","source":2,"name":"@hf/meta-llama/meta-llama-3-8b-instruct","description":"Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.\t","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-05-22 18:21:04.371","tags":[],"properties":[{"property_id":"context_window","value":"8192"}]},{"id":"c907d0f9-d69d-4e93-b501-4daeb4fd69eb","source":1,"name":"@cf/mistral/mistral-7b-instruct-v0.1","description":"Instruct fine-tuned version of the Mistral-7b generative text model with 7 billion parameters","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-11-07 11:54:20.229","tags":[],"properties":[{"property_id":"price","value":[{"unit":"per M input tokens","price":0.11,"currency":"USD"},{"unit":"per M output tokens","price":0.19,"currency":"USD"}]},{"property_id":"context_window","value":"2824"},{"property_id":"info","value":"https://mistral.ai/news/announcing-mistral-7b/"},{"property_id":"lora","value":"true"}],"finetunes":[{"id":"39fb185c-762a-4633-a2ad-7a4462940608","name":"cf-public-magicoder","description":"LoRA adapter that enables Mistral to generate code","created_at":"2024-05-08 02:23:55.897","modified_at":"2024-05-08 02:23:55.897","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"},{"id":"911a83cf-d947-4c96-b4d2-a86c2c6d2b7f","name":"cf-public-cnn-summarization","description":"LoRA adapter that enables Mistral to summarize articles. https://huggingface.co/predibase/cnn","created_at":"2024-05-09 02:11:12.386","modified_at":"2024-05-09 02:11:12.386","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"},{"id":"c0b52d28-530b-4751-b7d9-afbdb4795990","name":"cf-public-jigsaw-classification","description":"LoRA adapter that enables Mistral to detect and classify toxic comments. https://huggingface.co/predibase/jigsaw","created_at":"2024-05-09 02:19:48.750","modified_at":"2024-05-09 02:19:48.750","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"}]},{"id":"980ec5e9-33c2-483a-a2d8-cd092fdf273f","source":2,"name":"@hf/thebloke/mistral-7b-instruct-v0.1-awq","description":"Mistral 7B Instruct v0.1 AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Mistral variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-11-24 00:27:15.869","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-AWQ"}]},{"id":"b97d7069-48d9-461c-80dd-445d20a632eb","source":2,"name":"@hf/mistral/mistral-7b-instruct-v0.2","description":"The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2. Mistral-7B-v0.2 has the following changes compared to Mistral-7B-v0.1: 32k context window (vs 8k context in v0.1), rope-theta = 1e6, and no Sliding-Window Attention.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-02 13:00:59.244","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"3072"},{"property_id":"info","value":"https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2"},{"property_id":"lora","value":"true"},{"property_id":"max_batch_prefill_tokens","value":"8192"},{"property_id":"max_input_length","value":"3072"},{"property_id":"max_total_tokens","value":"4096"}],"finetunes":[{"id":"39fb185c-762a-4633-a2ad-7a4462940608","name":"cf-public-magicoder","description":"LoRA adapter that enables Mistral to generate code","created_at":"2024-05-08 02:23:55.897","modified_at":"2024-05-08 02:23:55.897","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"},{"id":"911a83cf-d947-4c96-b4d2-a86c2c6d2b7f","name":"cf-public-cnn-summarization","description":"LoRA adapter that enables Mistral to summarize articles. https://huggingface.co/predibase/cnn","created_at":"2024-05-09 02:11:12.386","modified_at":"2024-05-09 02:11:12.386","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"},{"id":"c0b52d28-530b-4751-b7d9-afbdb4795990","name":"cf-public-jigsaw-classification","description":"LoRA adapter that enables Mistral to detect and classify toxic comments. https://huggingface.co/predibase/jigsaw","created_at":"2024-05-09 02:19:48.750","modified_at":"2024-05-09 02:19:48.750","public":1,"model":"@cf/mistral/mistral-7b-instruct-v0.2-lora"}]},{"id":"31690291-ebdc-4f98-bcfc-a44844e215b7","source":1,"name":"@cf/mistralai/mistral-small-3.1-24b-instruct","description":"Building upon Mistral Small 3 (2501), Mistral Small 3.1 (2503) adds state-of-the-art vision understanding and enhances long context capabilities up to 128k tokens without compromising text performance. With 24 billion parameters, this model achieves top-tier capabilities in both text and vision tasks.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-03-18 03:28:37.890","tags":[],"properties":[{"property_id":"context_window","value":"128000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.35,"currency":"USD"},{"unit":"per M output tokens","price":0.56,"currency":"USD"}]},{"property_id":"function_calling","value":"true"}]},{"id":"d2ba5c6b-bbb7-49d6-b466-900654870cd6","source":2,"name":"@hf/thebloke/neural-chat-7b-v3-1-awq","description":"This model is a fine-tuned 7B parameter LLM on the Intel Gaudi 2 processor from the mistralai/Mistral-7B-v0.1 on the open source dataset Open-Orca/SlimOrca.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-06 18:12:30.722","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"}]},{"id":"081054cd-a254-4349-855e-6dc0996277fa","source":1,"name":"@cf/openchat/openchat-3.5-0106","description":"OpenChat is an innovative library of open-source language models, fine-tuned with C-RLFT - a strategy inspired by offline reinforcement learning.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:20:39.169","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"8192"},{"property_id":"info","value":"https://huggingface.co/openchat/openchat-3.5-0106"}]},{"id":"673c56cc-8553-49a1-b179-dd549ec9209a","source":2,"name":"@hf/thebloke/openhermes-2.5-mistral-7b-awq","description":"OpenHermes 2.5 Mistral 7B is a state of the art Mistral Fine-tune, a continuation of OpenHermes 2 model, which trained on additional code datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-06 18:04:22.846","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"}]},{"id":"1d933df3-680f-4280-940d-da87435edb07","source":1,"name":"@cf/microsoft/phi-2","description":"Phi-2 is a Transformer-based model with a next-word prediction objective, trained on 1.4T tokens from multiple passes on a mixture of Synthetic and Web datasets for NLP and coding.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:26:21.126","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"2048"},{"property_id":"info","value":"https://huggingface.co/microsoft/phi-2"}]},{"id":"f8703a00-ed54-4f98-bdc3-cd9a813286f3","source":1,"name":"@cf/qwen/qwen1.5-0.5b-chat","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:23:37.344","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"32000"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-0.5b-chat"}]},{"id":"3222ddb3-e211-4fd9-9a6d-79a80e47b3a6","source":1,"name":"@cf/qwen/qwen1.5-1.8b-chat","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:30:31.723","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"32000"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-1.8b-chat"}]},{"id":"09d113a9-03c4-420e-b6f2-52ad4b3bed45","source":1,"name":"@cf/qwen/qwen1.5-14b-chat-awq","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:24:45.316","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"7500"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-14b-chat-awq"}]},{"id":"90a20ae7-7cf4-4eb3-8672-8fc4ee580635","source":1,"name":"@cf/qwen/qwen1.5-7b-chat-awq","description":"Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:24:11.709","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"20000"},{"property_id":"info","value":"https://huggingface.co/qwen/qwen1.5-7b-chat-awq"}]},{"id":"51b71d5b-8bc0-4489-a107-95e542b69914","source":1,"name":"@cf/qwen/qwen2.5-coder-32b-instruct","description":"Qwen2.5-Coder is the latest series of Code-Specific Qwen large language models (formerly known as CodeQwen). As of now, Qwen2.5-Coder has covered six mainstream model sizes, 0.5, 1.5, 3, 7, 14, 32 billion parameters, to meet the needs of different developers. Qwen2.5-Coder brings the following improvements upon CodeQwen1.5:","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-02-27 00:31:43.829","tags":[],"properties":[{"property_id":"context_window","value":"32768"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.66,"currency":"USD"},{"unit":"per M output tokens","price":1,"currency":"USD"}]},{"property_id":"lora","value":"true"}]},{"id":"02c16efa-29f5-4304-8e6c-3d188889f875","source":1,"name":"@cf/qwen/qwq-32b","description":"QwQ is the reasoning model of the Qwen series. Compared with conventional instruction-tuned models, QwQ, which is capable of thinking and reasoning, can achieve significantly enhanced performance in downstream tasks, especially hard problems. QwQ-32B is the medium-sized reasoning model, which is capable of achieving competitive performance against state-of-the-art reasoning models, e.g., DeepSeek-R1, o1-mini.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2025-03-05 21:52:40.974","tags":[],"properties":[{"property_id":"context_window","value":"24000"},{"property_id":"price","value":[{"unit":"per M input tokens","price":0.66,"currency":"USD"},{"unit":"per M output tokens","price":1,"currency":"USD"}]},{"property_id":"lora","value":"true"}]},{"id":"1dc9e589-df6b-4e66-ac9f-ceff42d64983","source":1,"name":"@cf/defog/sqlcoder-7b-2","description":"This model is intended to be used by non-technical users to understand data inside their SQL databases. ","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:18:46.095","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"10000"},{"property_id":"info","value":"https://huggingface.co/defog/sqlcoder-7b-2"},{"property_id":"terms","value":"https://creativecommons.org/licenses/by-sa/4.0/deed.en"}]},{"id":"e5ca943b-720f-4e66-aa8f-40e3d2770933","source":2,"name":"@hf/nexusflow/starling-lm-7b-beta","description":"We introduce Starling-LM-7B-beta, an open large language model (LLM) trained by Reinforcement Learning from AI Feedback (RLAIF). Starling-LM-7B-beta is trained from Openchat-3.5-0106 with our new reward model Nexusflow/Starling-RM-34B and policy optimization method Fine-Tuning Language Models from Human Preferences (PPO).","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-01 23:49:31.797","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/Nexusflow/Starling-LM-7B-beta"},{"property_id":"max_batch_prefill_tokens","value":"8192"},{"property_id":"max_input_length","value":"3072"},{"property_id":"max_total_tokens","value":"4096"}]},{"id":"bf6ddd21-6477-4681-bbbe-24c3d5423e78","source":1,"name":"@cf/tinyllama/tinyllama-1.1b-chat-v1.0","description":"The TinyLlama project aims to pretrain a 1.1B Llama model on 3 trillion tokens. This is the chat model finetuned on top of TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-02-27 18:25:37.524","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"2048"},{"property_id":"info","value":"https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0"}]},{"id":"b7fe7ad2-aeaf-47d2-8bfa-7a5ae22a2ab4","source":1,"name":"@cf/fblgit/una-cybertron-7b-v2-bf16","description":"Cybertron 7B v2 is a 7B MistralAI based model, best on it's series. It was trained with SFT, DPO and UNA (Unified Neural Alignment) on multiple datasets.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2024-04-24 14:37:19.494","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"15000"}]},{"id":"3976bab8-3810-4ad8-8580-ab1e22de7823","source":2,"name":"@hf/thebloke/zephyr-7b-beta-awq","description":"Zephyr 7B Beta AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Zephyr model variant.","task":{"id":"c329a1f9-323d-4e91-b2aa-582dd4188d34","name":"Text Generation","description":"Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."},"created_at":"2023-11-24 00:27:15.869","tags":[],"properties":[{"property_id":"beta","value":"true"},{"property_id":"context_window","value":"4096"},{"property_id":"info","value":"https://huggingface.co/TheBloke/zephyr-7B-beta-AWQ"}]}]
+[
+	{
+		"id": "7f180530-2e16-4116-9d26-f49fbed9d372",
+		"source": 2,
+		"name": "@hf/thebloke/deepseek-coder-6.7b-base-awq",
+		"description": "Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-06 18:16:27.183",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "terms",
+				"value": "https://huggingface.co/TheBloke/deepseek-coder-6.7B-base-AWQ"
+			}
+		]
+	},
+	{
+		"id": "60474554-f03b-4ff4-8ecc-c1b7c71d7b29",
+		"source": 2,
+		"name": "@hf/thebloke/deepseek-coder-6.7b-instruct-awq",
+		"description": "Deepseek Coder is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-06 18:18:27.462",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "terms",
+				"value": "https://huggingface.co/TheBloke/deepseek-coder-6.7B-instruct-AWQ"
+			}
+		]
+	},
+	{
+		"id": "4c3a544e-da47-4336-9cea-c7cbfab33f16",
+		"source": 1,
+		"name": "@cf/deepseek-ai/deepseek-math-7b-instruct",
+		"description": "DeepSeekMath-Instruct 7B is a mathematically instructed tuning model derived from DeepSeekMath-Base 7B. DeepSeekMath is initialized with DeepSeek-Coder-v1.5 7B and continues pre-training on math-related tokens sourced from Common Crawl, together with natural language and code data for 500B tokens.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 17:54:17.459",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/deepseek-ai/deepseek-math-7b-instruct"
+			},
+			{
+				"property_id": "terms",
+				"value": "https://github.com/deepseek-ai/DeepSeek-Math/blob/main/LICENSE-MODEL"
+			}
+		]
+	},
+	{
+		"id": "ad01ab83-baf8-4e7b-8fed-a0a219d4eb45",
+		"source": 1,
+		"name": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
+		"description": "DeepSeek-R1-Distill-Qwen-32B is a model distilled from DeepSeek-R1 based on Qwen2.5. It outperforms OpenAI-o1-mini across various benchmarks, achieving new state-of-the-art results for dense models.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-01-22 19:48:55.776",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "80000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.5, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 4.88, "currency": "USD" }
+				]
+			},
+			{
+				"property_id": "terms",
+				"value": "https://github.com/deepseek-ai/DeepSeek-R1/blob/main/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "9d2ab560-065e-4d0d-a789-d4bc7468d33e",
+		"source": 1,
+		"name": "@cf/thebloke/discolm-german-7b-v1-awq",
+		"description": "DiscoLM German 7b is a Mistral-based large language model with a focus on German-language applications. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:23:05.178",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/TheBloke/DiscoLM_German_7b_v1-AWQ"
+			}
+		]
+	},
+	{
+		"id": "48dd2443-0c61-43b2-8894-22abddf1b081",
+		"source": 1,
+		"name": "@cf/tiiuae/falcon-7b-instruct",
+		"description": "Falcon-7B-Instruct is a 7B parameters causal decoder-only model built by TII based on Falcon-7B and finetuned on a mixture of chat/instruct datasets.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:21:15.796",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{ "property_id": "info", "value": "https://huggingface.co/tiiuae/falcon-7b-instruct" }
+		]
+	},
+	{
+		"id": "053d5ac0-861b-4d3b-8501-e58d00417ef8",
+		"source": 1,
+		"name": "@cf/google/gemma-3-12b-it",
+		"description": "Gemma 3 models are well-suited for a variety of text generation and image understanding tasks, including question answering, summarization, and reasoning. Gemma 3 models are multimodal, handling text and image input and generating text output, with a large, 128K context window, multilingual support in over 140 languages, and is available in more sizes than previous versions.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-03-18 03:58:02.423",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "80000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.35, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.56, "currency": "USD" }
+				]
+			},
+			{ "property_id": "lora", "value": "true" }
+		]
+	},
+	{
+		"id": "0f002249-7d86-4698-aabf-8529ed86cefb",
+		"source": 2,
+		"name": "@hf/google/gemma-7b-it",
+		"description": "Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-01 23:51:35.866",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "8192" },
+			{ "property_id": "info", "value": "https://ai.google.dev/gemma/docs" },
+			{ "property_id": "lora", "value": "true" },
+			{ "property_id": "terms", "value": "https://ai.google.dev/gemma/terms" }
+		]
+	},
+	{
+		"id": "44774b85-08c8-4bb8-8d2a-b06ebc538a79",
+		"source": 2,
+		"name": "@hf/nousresearch/hermes-2-pro-mistral-7b",
+		"description": "Hermes 2 Pro on Mistral 7B is the new flagship 7B Hermes! Hermes 2 Pro is an upgraded, retrained version of Nous Hermes 2, consisting of an updated and cleaned version of the OpenHermes 2.5 Dataset, as well as a newly introduced Function Calling and JSON Mode dataset developed in-house.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-01 23:45:53.800",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "24000" },
+			{ "property_id": "function_calling", "value": "true" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B"
+			}
+		]
+	},
+	{
+		"id": "85c5a3c6-24b0-45e7-b23a-023182578822",
+		"source": 2,
+		"name": "@hf/thebloke/llama-2-13b-chat-awq",
+		"description": "Llama 2 13B Chat AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Llama 2 variant.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-11-24 00:27:15.869",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/TheBloke/Llama-2-13B-chat-AWQ"
+			}
+		]
+	},
+	{
+		"id": "ca54bcd6-0d98-4739-9b3b-5c8b4402193d",
+		"source": 1,
+		"name": "@cf/meta/llama-2-7b-chat-fp16",
+		"description": "Full precision (fp16) generative text model with 7 billion parameters from Meta",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-11-07 11:54:20.229",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.56, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 6.67, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "4096" },
+			{ "property_id": "info", "value": "https://ai.meta.com/llama/" },
+			{
+				"property_id": "terms",
+				"value": "https://ai.meta.com/resources/models-and-libraries/llama-downloads/"
+			}
+		]
+	},
+	{
+		"id": "9c95c39d-45b3-4163-9631-22f0c0dc3b14",
+		"source": 1,
+		"name": "@cf/meta/llama-2-7b-chat-int8",
+		"description": "Quantized (int8) generative text model with 7 billion parameters from Meta",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-09-25 19:21:11.898",
+		"tags": [],
+		"properties": [{ "property_id": "context_window", "value": "8192" }]
+	},
+	{
+		"id": "e11d8f45-7b08-499a-9eeb-71d4d3c8cbf9",
+		"source": 1,
+		"name": "@cf/meta/llama-3-8b-instruct",
+		"description": "Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-18 20:31:47.273",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.28, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.83, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "7968" },
+			{ "property_id": "info", "value": "https://llama.meta.com" },
+			{ "property_id": "terms", "value": "https://llama.meta.com/llama3/license/#" }
+		]
+	},
+	{
+		"id": "31097538-a3ff-4e6e-bb56-ad0e1f428b61",
+		"source": 1,
+		"name": "@cf/meta/llama-3-8b-instruct-awq",
+		"description": "Quantized (int4) generative text model with 8 billion parameters from Meta.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-05-09 23:32:47.584",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.12, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.27, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "8192" },
+			{ "property_id": "info", "value": "https://llama.meta.com" },
+			{ "property_id": "terms", "value": "https://llama.meta.com/llama3/license/#" }
+		]
+	},
+	{
+		"id": "3dcb4f2d-26a8-412b-b6e3-2a368beff66b",
+		"source": 1,
+		"name": "@cf/meta/llama-3.1-8b-instruct-awq",
+		"description": "Quantized (int4) generative text model with 8 billion parameters from Meta.\n",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-07-25 17:46:04.304",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.12, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.27, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "8192" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "9b9c87c6-d4b7-494c-b177-87feab5904db",
+		"source": 1,
+		"name": "@cf/meta/llama-3.1-8b-instruct-fp8",
+		"description": "Llama 3.1 8B quantized to FP8 precision",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-07-25 17:28:43.328",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.15, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.29, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "32000" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "2cbc033b-ded8-4e02-bbb2-47cf05d5cfe5",
+		"source": 1,
+		"name": "@cf/meta/llama-3.2-11b-vision-instruct",
+		"description": " The Llama 3.2-Vision instruction-tuned models are optimized for visual recognition, image reasoning, captioning, and answering general questions about an image.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-09-25 05:36:04.547",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "128000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.049, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.68, "currency": "USD" }
+				]
+			},
+			{ "property_id": "lora", "value": "true" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "906a57fd-b018-4d6c-a43e-a296d4cc5839",
+		"source": 1,
+		"name": "@cf/meta/llama-3.2-1b-instruct",
+		"description": "The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-09-25 21:36:32.050",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.027, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.2, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "60000" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "d9dc8363-66f4-4bb0-8641-464ee7bfc131",
+		"source": 1,
+		"name": "@cf/meta/llama-3.2-3b-instruct",
+		"description": "The Llama 3.2 instruction-tuned text only models are optimized for multilingual dialogue use cases, including agentic retrieval and summarization tasks.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-09-25 20:05:43.986",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.051, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.34, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "128000" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "7a143886-c9bb-4a1c-be95-377b1973bc3b",
+		"source": 1,
+		"name": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+		"description": "Llama 3.3 70B quantized to fp8 precision, optimized to be faster.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-12-06 17:09:18.338",
+		"tags": [],
+		"properties": [
+			{ "property_id": "async_queue", "value": "true" },
+			{ "property_id": "context_window", "value": "24000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.29, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 2.25, "currency": "USD" }
+				]
+			},
+			{ "property_id": "function_calling", "value": "true" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_3/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "06455e78-19f7-487b-93cd-c05a3dd07813",
+		"source": 1,
+		"name": "@cf/meta/llama-4-scout-17b-16e-instruct",
+		"description": "Meta's Llama 4 Scout is a 17 billion parameter model with 16 experts that is natively multimodal. These models leverage a mixture-of-experts architecture to offer industry-leading performance in text and image understanding.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-04-05 20:25:56.137",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "131000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.27, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.85, "currency": "USD" }
+				]
+			},
+			{ "property_id": "function_calling", "value": "true" },
+			{
+				"property_id": "terms",
+				"value": "https://github.com/meta-llama/llama-models/blob/main/models/llama4/LICENSE"
+			}
+		]
+	},
+	{
+		"id": "cc80437b-9a8d-4f1a-9c77-9aaf0d226922",
+		"source": 1,
+		"name": "@cf/meta/llama-guard-3-8b",
+		"description": "Llama Guard 3 is a Llama-3.1-8B pretrained model, fine-tuned for content safety classification. Similar to previous versions, it can be used to classify content in both LLM inputs (prompt classification) and in LLM responses (response classification). It acts as an LLM – it generates text in its output that indicates whether a given prompt or response is safe or unsafe, and if unsafe, it also lists the content categories violated.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-01-22 23:26:23.495",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.48, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.03, "currency": "USD" }
+				]
+			},
+			{ "property_id": "lora", "value": "true" }
+		]
+	},
+	{
+		"id": "d9b7a55c-cefa-4208-8ab3-11497a2b046c",
+		"source": 2,
+		"name": "@hf/thebloke/llamaguard-7b-awq",
+		"description": "Llama Guard is a model for classifying the safety of LLM prompts and responses, using a taxonomy of safety risks.\n",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-06 18:13:59.060",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" }
+		]
+	},
+	{
+		"id": "1a7b6ad6-9987-4bd3-a329-20ee8de93296",
+		"source": 2,
+		"name": "@hf/meta-llama/meta-llama-3-8b-instruct",
+		"description": "Generation over generation, Meta Llama 3 demonstrates state-of-the-art performance on a wide range of industry benchmarks and offers new capabilities, including improved reasoning.\t",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-05-22 18:21:04.371",
+		"tags": [],
+		"properties": [{ "property_id": "context_window", "value": "8192" }]
+	},
+	{
+		"id": "c907d0f9-d69d-4e93-b501-4daeb4fd69eb",
+		"source": 1,
+		"name": "@cf/mistral/mistral-7b-instruct-v0.1",
+		"description": "Instruct fine-tuned version of the Mistral-7b generative text model with 7 billion parameters",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-11-07 11:54:20.229",
+		"tags": [],
+		"properties": [
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.11, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.19, "currency": "USD" }
+				]
+			},
+			{ "property_id": "context_window", "value": "2824" },
+			{ "property_id": "info", "value": "https://mistral.ai/news/announcing-mistral-7b/" },
+			{ "property_id": "lora", "value": "true" }
+		],
+		"finetunes": [
+			{
+				"id": "39fb185c-762a-4633-a2ad-7a4462940608",
+				"name": "cf-public-magicoder",
+				"description": "LoRA adapter that enables Mistral to generate code",
+				"created_at": "2024-05-08 02:23:55.897",
+				"modified_at": "2024-05-08 02:23:55.897",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			},
+			{
+				"id": "911a83cf-d947-4c96-b4d2-a86c2c6d2b7f",
+				"name": "cf-public-cnn-summarization",
+				"description": "LoRA adapter that enables Mistral to summarize articles. https://huggingface.co/predibase/cnn",
+				"created_at": "2024-05-09 02:11:12.386",
+				"modified_at": "2024-05-09 02:11:12.386",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			},
+			{
+				"id": "c0b52d28-530b-4751-b7d9-afbdb4795990",
+				"name": "cf-public-jigsaw-classification",
+				"description": "LoRA adapter that enables Mistral to detect and classify toxic comments. https://huggingface.co/predibase/jigsaw",
+				"created_at": "2024-05-09 02:19:48.750",
+				"modified_at": "2024-05-09 02:19:48.750",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			}
+		]
+	},
+	{
+		"id": "980ec5e9-33c2-483a-a2d8-cd092fdf273f",
+		"source": 2,
+		"name": "@hf/thebloke/mistral-7b-instruct-v0.1-awq",
+		"description": "Mistral 7B Instruct v0.1 AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Mistral variant.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-11-24 00:27:15.869",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-AWQ"
+			}
+		]
+	},
+	{
+		"id": "b97d7069-48d9-461c-80dd-445d20a632eb",
+		"source": 2,
+		"name": "@hf/mistral/mistral-7b-instruct-v0.2",
+		"description": "The Mistral-7B-Instruct-v0.2 Large Language Model (LLM) is an instruct fine-tuned version of the Mistral-7B-v0.2. Mistral-7B-v0.2 has the following changes compared to Mistral-7B-v0.1: 32k context window (vs 8k context in v0.1), rope-theta = 1e6, and no Sliding-Window Attention.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-02 13:00:59.244",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "3072" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2"
+			},
+			{ "property_id": "lora", "value": "true" },
+			{ "property_id": "max_batch_prefill_tokens", "value": "8192" },
+			{ "property_id": "max_input_length", "value": "3072" },
+			{ "property_id": "max_total_tokens", "value": "4096" }
+		],
+		"finetunes": [
+			{
+				"id": "39fb185c-762a-4633-a2ad-7a4462940608",
+				"name": "cf-public-magicoder",
+				"description": "LoRA adapter that enables Mistral to generate code",
+				"created_at": "2024-05-08 02:23:55.897",
+				"modified_at": "2024-05-08 02:23:55.897",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			},
+			{
+				"id": "911a83cf-d947-4c96-b4d2-a86c2c6d2b7f",
+				"name": "cf-public-cnn-summarization",
+				"description": "LoRA adapter that enables Mistral to summarize articles. https://huggingface.co/predibase/cnn",
+				"created_at": "2024-05-09 02:11:12.386",
+				"modified_at": "2024-05-09 02:11:12.386",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			},
+			{
+				"id": "c0b52d28-530b-4751-b7d9-afbdb4795990",
+				"name": "cf-public-jigsaw-classification",
+				"description": "LoRA adapter that enables Mistral to detect and classify toxic comments. https://huggingface.co/predibase/jigsaw",
+				"created_at": "2024-05-09 02:19:48.750",
+				"modified_at": "2024-05-09 02:19:48.750",
+				"public": 1,
+				"model": "@cf/mistral/mistral-7b-instruct-v0.2-lora"
+			}
+		]
+	},
+	{
+		"id": "31690291-ebdc-4f98-bcfc-a44844e215b7",
+		"source": 1,
+		"name": "@cf/mistralai/mistral-small-3.1-24b-instruct",
+		"description": "Building upon Mistral Small 3 (2501), Mistral Small 3.1 (2503) adds state-of-the-art vision understanding and enhances long context capabilities up to 128k tokens without compromising text performance. With 24 billion parameters, this model achieves top-tier capabilities in both text and vision tasks.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-03-18 03:28:37.890",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "128000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.35, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 0.56, "currency": "USD" }
+				]
+			},
+			{ "property_id": "function_calling", "value": "true" }
+		]
+	},
+	{
+		"id": "d2ba5c6b-bbb7-49d6-b466-900654870cd6",
+		"source": 2,
+		"name": "@hf/thebloke/neural-chat-7b-v3-1-awq",
+		"description": "This model is a fine-tuned 7B parameter LLM on the Intel Gaudi 2 processor from the mistralai/Mistral-7B-v0.1 on the open source dataset Open-Orca/SlimOrca.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-06 18:12:30.722",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" }
+		]
+	},
+	{
+		"id": "081054cd-a254-4349-855e-6dc0996277fa",
+		"source": 1,
+		"name": "@cf/openchat/openchat-3.5-0106",
+		"description": "OpenChat is an innovative library of open-source language models, fine-tuned with C-RLFT - a strategy inspired by offline reinforcement learning.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:20:39.169",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "8192" },
+			{ "property_id": "info", "value": "https://huggingface.co/openchat/openchat-3.5-0106" }
+		]
+	},
+	{
+		"id": "673c56cc-8553-49a1-b179-dd549ec9209a",
+		"source": 2,
+		"name": "@hf/thebloke/openhermes-2.5-mistral-7b-awq",
+		"description": "OpenHermes 2.5 Mistral 7B is a state of the art Mistral Fine-tune, a continuation of OpenHermes 2 model, which trained on additional code datasets.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-06 18:04:22.846",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" }
+		]
+	},
+	{
+		"id": "1d933df3-680f-4280-940d-da87435edb07",
+		"source": 1,
+		"name": "@cf/microsoft/phi-2",
+		"description": "Phi-2 is a Transformer-based model with a next-word prediction objective, trained on 1.4T tokens from multiple passes on a mixture of Synthetic and Web datasets for NLP and coding.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:26:21.126",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "2048" },
+			{ "property_id": "info", "value": "https://huggingface.co/microsoft/phi-2" }
+		]
+	},
+	{
+		"id": "f8703a00-ed54-4f98-bdc3-cd9a813286f3",
+		"source": 1,
+		"name": "@cf/qwen/qwen1.5-0.5b-chat",
+		"description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:23:37.344",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "32000" },
+			{ "property_id": "info", "value": "https://huggingface.co/qwen/qwen1.5-0.5b-chat" }
+		]
+	},
+	{
+		"id": "3222ddb3-e211-4fd9-9a6d-79a80e47b3a6",
+		"source": 1,
+		"name": "@cf/qwen/qwen1.5-1.8b-chat",
+		"description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:30:31.723",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "32000" },
+			{ "property_id": "info", "value": "https://huggingface.co/qwen/qwen1.5-1.8b-chat" }
+		]
+	},
+	{
+		"id": "09d113a9-03c4-420e-b6f2-52ad4b3bed45",
+		"source": 1,
+		"name": "@cf/qwen/qwen1.5-14b-chat-awq",
+		"description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:24:45.316",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "7500" },
+			{ "property_id": "info", "value": "https://huggingface.co/qwen/qwen1.5-14b-chat-awq" }
+		]
+	},
+	{
+		"id": "90a20ae7-7cf4-4eb3-8672-8fc4ee580635",
+		"source": 1,
+		"name": "@cf/qwen/qwen1.5-7b-chat-awq",
+		"description": "Qwen1.5 is the improved version of Qwen, the large language model series developed by Alibaba Cloud. AWQ is an efficient, accurate and blazing-fast low-bit weight quantization method, currently supporting 4-bit quantization.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:24:11.709",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "20000" },
+			{ "property_id": "info", "value": "https://huggingface.co/qwen/qwen1.5-7b-chat-awq" }
+		]
+	},
+	{
+		"id": "51b71d5b-8bc0-4489-a107-95e542b69914",
+		"source": 1,
+		"name": "@cf/qwen/qwen2.5-coder-32b-instruct",
+		"description": "Qwen2.5-Coder is the latest series of Code-Specific Qwen large language models (formerly known as CodeQwen). As of now, Qwen2.5-Coder has covered six mainstream model sizes, 0.5, 1.5, 3, 7, 14, 32 billion parameters, to meet the needs of different developers. Qwen2.5-Coder brings the following improvements upon CodeQwen1.5:",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-02-27 00:31:43.829",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "32768" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.66, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 1, "currency": "USD" }
+				]
+			},
+			{ "property_id": "lora", "value": "true" }
+		]
+	},
+	{
+		"id": "02c16efa-29f5-4304-8e6c-3d188889f875",
+		"source": 1,
+		"name": "@cf/qwen/qwq-32b",
+		"description": "QwQ is the reasoning model of the Qwen series. Compared with conventional instruction-tuned models, QwQ, which is capable of thinking and reasoning, can achieve significantly enhanced performance in downstream tasks, especially hard problems. QwQ-32B is the medium-sized reasoning model, which is capable of achieving competitive performance against state-of-the-art reasoning models, e.g., DeepSeek-R1, o1-mini.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2025-03-05 21:52:40.974",
+		"tags": [],
+		"properties": [
+			{ "property_id": "context_window", "value": "24000" },
+			{
+				"property_id": "price",
+				"value": [
+					{ "unit": "per M input tokens", "price": 0.66, "currency": "USD" },
+					{ "unit": "per M output tokens", "price": 1, "currency": "USD" }
+				]
+			},
+			{ "property_id": "lora", "value": "true" }
+		]
+	},
+	{
+		"id": "1dc9e589-df6b-4e66-ac9f-ceff42d64983",
+		"source": 1,
+		"name": "@cf/defog/sqlcoder-7b-2",
+		"description": "This model is intended to be used by non-technical users to understand data inside their SQL databases. ",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:18:46.095",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "10000" },
+			{ "property_id": "info", "value": "https://huggingface.co/defog/sqlcoder-7b-2" },
+			{
+				"property_id": "terms",
+				"value": "https://creativecommons.org/licenses/by-sa/4.0/deed.en"
+			}
+		]
+	},
+	{
+		"id": "e5ca943b-720f-4e66-aa8f-40e3d2770933",
+		"source": 2,
+		"name": "@hf/nexusflow/starling-lm-7b-beta",
+		"description": "We introduce Starling-LM-7B-beta, an open large language model (LLM) trained by Reinforcement Learning from AI Feedback (RLAIF). Starling-LM-7B-beta is trained from Openchat-3.5-0106 with our new reward model Nexusflow/Starling-RM-34B and policy optimization method Fine-Tuning Language Models from Human Preferences (PPO).",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-01 23:49:31.797",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/Nexusflow/Starling-LM-7B-beta"
+			},
+			{ "property_id": "max_batch_prefill_tokens", "value": "8192" },
+			{ "property_id": "max_input_length", "value": "3072" },
+			{ "property_id": "max_total_tokens", "value": "4096" }
+		]
+	},
+	{
+		"id": "bf6ddd21-6477-4681-bbbe-24c3d5423e78",
+		"source": 1,
+		"name": "@cf/tinyllama/tinyllama-1.1b-chat-v1.0",
+		"description": "The TinyLlama project aims to pretrain a 1.1B Llama model on 3 trillion tokens. This is the chat model finetuned on top of TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-02-27 18:25:37.524",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "2048" },
+			{
+				"property_id": "info",
+				"value": "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+			}
+		]
+	},
+	{
+		"id": "b7fe7ad2-aeaf-47d2-8bfa-7a5ae22a2ab4",
+		"source": 1,
+		"name": "@cf/fblgit/una-cybertron-7b-v2-bf16",
+		"description": "Cybertron 7B v2 is a 7B MistralAI based model, best on it's series. It was trained with SFT, DPO and UNA (Unified Neural Alignment) on multiple datasets.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2024-04-24 14:37:19.494",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "15000" }
+		]
+	},
+	{
+		"id": "3976bab8-3810-4ad8-8580-ab1e22de7823",
+		"source": 2,
+		"name": "@hf/thebloke/zephyr-7b-beta-awq",
+		"description": "Zephyr 7B Beta AWQ is an efficient, accurate and blazing-fast low-bit weight quantized Zephyr model variant.",
+		"task": {
+			"id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+			"name": "Text Generation",
+			"description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+		},
+		"created_at": "2023-11-24 00:27:15.869",
+		"tags": [],
+		"properties": [
+			{ "property_id": "beta", "value": "true" },
+			{ "property_id": "context_window", "value": "4096" },
+			{ "property_id": "info", "value": "https://huggingface.co/TheBloke/zephyr-7B-beta-AWQ" }
+		]
+	}
+]

--- a/playground/ai/src/server/index.ts
+++ b/playground/ai/src/server/index.ts
@@ -17,11 +17,7 @@ type PostInferenceBody = {
 	tools: Tool[];
 };
 
-async function replyToMessage(
-	request: Request,
-	env: Env,
-	_ctx: ExecutionContext,
-) {
+async function replyToMessage(request: Request, env: Env, _ctx: ExecutionContext) {
 	const modelNames = models.map((model) => model.name);
 
 	const {

--- a/playground/ai/wrangler.jsonc
+++ b/playground/ai/wrangler.jsonc
@@ -1,10 +1,10 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "workers-ai-playground",
-  "compatibility_date": "2025-05-08",
-  "compatibility_flags": ["nodejs_compat"],
-  "main": "src/server/index.ts",
-  "ai": {
-    "binding": "AI",
-  },
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "workers-ai-playground",
+	"compatibility_date": "2025-05-08",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "src/server/index.ts",
+	"ai": {
+		"binding": "AI"
+	}
 }


### PR DESCRIPTION
Lots of files (specially the ones from the ai playground) have a different format, this PR sends changes after running `pnpm format`