### PR TITLE
Fix bug on failed connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,9 @@ dist
 
 
 .DS_Store
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/playground/ai/package.json
+++ b/playground/ai/package.json
@@ -23,6 +23,7 @@
 		"@cloudflare/vite-plugin": "^1.7.0",
 		"@cloudflare/workers-types": "^4.20250618.0",
 		"@modelcontextprotocol/sdk": "^1.12.3",
+		"@playwright/test": "^1.53.0",
 		"@tailwindcss/vite": "^4.1.10",
 		"@types/react": "^19.1.8",
 		"@types/react-dom": "^19.1.6",

--- a/playground/ai/playwright.config.ts
+++ b/playground/ai/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./tests",
+	timeout: 30000,
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: "html",
+	use: {
+		baseURL: "http://localhost:5173",
+		trace: "on-first-retry",
+		screenshot: "only-on-failure",
+	},
+
+	/* Configure projects for different browsers */
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+		{
+			name: "webkit",
+			use: { ...devices["Desktop Safari"] },
+		},
+	],
+
+	webServer: {
+		command: "npm start",
+		url: "http://localhost:5173",
+		reuseExistingServer: !process.env.CI,
+	},
+});

--- a/playground/ai/src/McpServers.tsx
+++ b/playground/ai/src/McpServers.tsx
@@ -116,6 +116,11 @@ export function McpServers({ onToolsUpdate }: { onToolsUpdate?: (tools: any[]) =
 		});
 	};
 
+	const handleConnectionUpdate = (data: ConnectionData) => {
+		setConnectionData(data);
+		if (data.state === "failed") setIsActive(false);
+	};
+
 	// Handle authentication if popup was blocked
 	const handleManualAuth = async () => {
 		try {
@@ -559,7 +564,7 @@ export function McpServers({ onToolsUpdate }: { onToolsUpdate?: (tools: any[]) =
 					serverUrl={serverUrl}
 					headerKey={headerKey}
 					bearerToken={bearerToken}
-					onConnectionUpdate={setConnectionData}
+					onConnectionUpdate={handleConnectionUpdate}
 				/>
 			)}
 		</section>

--- a/playground/ai/src/McpServers.tsx
+++ b/playground/ai/src/McpServers.tsx
@@ -139,45 +139,47 @@ export function McpServers({ onToolsUpdate }: { onToolsUpdate?: (tools: any[]) =
 
 	// Generate status badge based on connection state
 	const getStatusBadge = () => {
-		const baseClasses = "px-2 py-1 rounded-full text-xs font-medium";
+		const states = {
+			discovering: {
+				color: "blue",
+				label: "Discovering",
+			},
+			authenticating: {
+				color: "purple",
+				label: "Authenticating",
+			},
+			connecting: {
+				color: "yellow",
+				label: "Connecting",
+			},
+			loading: {
+				color: "orange",
+				label: "Loading",
+			},
+			ready: {
+				color: "green",
+				label: "Connected",
+			},
+			failed: {
+				color: "red",
+				label: "Failed",
+			},
+			"not-connected": {
+				color: "gray",
+				label: "Not Connected",
+			},
+		};
 
-		switch (state) {
-			case "discovering":
-				return (
-					<span className={`${baseClasses} bg-blue-100 text-blue-800`}>Discovering</span>
-				);
-			case "authenticating":
-				return (
-					<span className={`${baseClasses} bg-purple-100 text-purple-800`}>
-						Authenticating
-					</span>
-				);
-			case "connecting":
-				return (
-					<span className={`${baseClasses} bg-yellow-100 text-yellow-800`}>
-						Connecting
-					</span>
-				);
-			case "loading":
-				return (
-					<span className={`${baseClasses} bg-orange-100 text-orange-800`}>Loading</span>
-				);
-			case "ready":
-				return (
-					<span className={`${baseClasses} bg-green-100 text-green-800`}>Connected</span>
-				);
-			case "failed":
-				return <span className={`${baseClasses} bg-red-100 text-red-800`}>Failed</span>;
+		const { color, label } = state ? states[state] : states["not-connected"];
 
-			/* biome-ignore lint/complexity/noUselessSwitchCase: eh */
-			case "not-connected":
-			default:
-				return (
-					<span className={`${baseClasses} bg-gray-100 text-gray-800`}>
-						Not Connected
-					</span>
-				);
-		}
+		return (
+			<span
+				data-testid="status"
+				className={`px-2 py-1 rounded-full text-xs font-medium bg-${color}-100 text-${color}-800`}
+			>
+				{label}
+			</span>
+		);
 	};
 
 	return (

--- a/playground/ai/tests/fixtures.ts
+++ b/playground/ai/tests/fixtures.ts
@@ -1,0 +1,170 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { test as baseTest } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { z } from "zod";
+
+function createAddTool(server: McpServer) {
+	server.registerTool(
+		"add",
+		{
+			description: "Add two numbers",
+			inputSchema: { a: z.number(), b: z.number() },
+		},
+		async ({ a, b }) => ({
+			content: [{ type: "text", text: String(a + b) }],
+		}),
+	);
+	server.registerTool(
+		"subtract",
+		{
+			description: "Subtract two numbers",
+			inputSchema: { a: z.number(), b: z.number() },
+		},
+		async ({ a, b }) => ({
+			content: [{ type: "text", text: String(a - b) }],
+		}),
+	);
+}
+
+export const test = baseTest.extend<{
+	createServer: (
+		initializer?: (server: McpServer) => any,
+	) => Promise<{ mcpServer: McpServer; url: string }>;
+	mcpServerUrl: string;
+}>({
+	// biome-ignore lint/correctness/noEmptyPattern: playwright requires destructuring
+	createServer: async ({}, use) => {
+		const servers: http.Server[] = [];
+
+		await use(async (initialize: (server: McpServer) => any = createAddTool) => {
+			// Create HTTP server
+			const httpServer = http.createServer();
+			servers.push(httpServer);
+
+			// Create a new MCP server instance
+			const mcpServer = new McpServer({
+				name: "test-server",
+				version: "1.0.0",
+			});
+
+			// Initialize server with tools
+			await initialize(mcpServer);
+
+			const transports: Map<string, StreamableHTTPServerTransport> = new Map();
+
+			// Set up request handling
+			httpServer.on("request", async (req, res) => {
+				res.setHeaders(
+					new Headers({
+						"access-control-allow-origin": "*",
+						"access-control-allow-methods": "GET, POST, OPTIONS",
+						"access-control-allow-headers":
+							"Content-Type, Authorization, mcp-session-id",
+						"access-control-expose-headers": "mcp-session-id",
+					}),
+				);
+
+				const handlePost = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+					// Check for existing session ID
+					const sessionId = req.headers["mcp-session-id"] as string | undefined;
+					const body = await new Promise<string>((resolve, reject) => {
+						let data = "";
+						req.on("data", (chunk) => {
+							data += chunk.toString();
+						});
+						req.on("end", () => resolve(JSON.parse(data)));
+						req.on("error", reject);
+					});
+
+					let transport: StreamableHTTPServerTransport;
+
+					if (sessionId && transports.has(sessionId)) {
+						// Reuse existing transport
+						transport = transports.get(sessionId)!;
+					} else if (!sessionId && isInitializeRequest(body)) {
+						// New initialization request
+						transport = new StreamableHTTPServerTransport({
+							sessionIdGenerator: () => randomUUID(),
+							onsessioninitialized: (sessionId) => {
+								// Store the transport by session ID
+								transports.set(sessionId, transport);
+							},
+						});
+
+						// Clean up transport when closed
+						transport.onclose = () => {
+							if (transport.sessionId) {
+								transports.delete(transport.sessionId);
+							}
+						};
+						const server = new McpServer({
+							name: "example-server",
+							version: "1.0.0",
+						});
+
+						initialize(server);
+
+						// Connect to the MCP server
+						await server.connect(transport);
+					} else {
+						// Invalid request
+						res.writeHead(400, {
+							"content-type": "application/json",
+						}).end(
+							JSON.stringify({
+								jsonrpc: "2.0",
+								error: {
+									code: -32000,
+									message: "Bad Request: No valid session ID provided",
+								},
+								id: null,
+							}),
+						);
+						return;
+					}
+
+					await transport.handleRequest(req, res, body);
+				};
+				httpServer.on("close", () => {
+					Promise.all(
+						Object.values(transports).map((transport) => transport.close()),
+					).catch(() => {});
+				});
+
+				switch (`${req.method} ${req.url}`) {
+					case "POST /mcp":
+						return await handlePost(req, res);
+					case "OPTIONS /mcp":
+						return res.writeHead(204).end();
+					case "GET /mcp":
+					case "DELETE /mcp":
+						return res.writeHead(405).end("Invalid Method");
+					default:
+						return res.writeHead(404).end("Not Found");
+				}
+			});
+
+			// Start server
+			await new Promise<void>((resolve) => {
+				httpServer.listen(0, "localhost", resolve);
+			});
+
+			const address = httpServer.address() as AddressInfo;
+			const url = `http://localhost:${address.port}/mcp`;
+
+			return { mcpServer, url };
+		});
+
+		// Cleanup servers after tests
+		await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+	},
+
+	mcpServerUrl: async ({ createServer }, use) => {
+		const { url } = await createServer();
+		await use(url);
+	},
+});

--- a/playground/ai/tests/mcp-servers.spec.ts
+++ b/playground/ai/tests/mcp-servers.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test.beforeEach(async ({ baseURL, page }) => {
+	await page.goto(baseURL!);
+});
+
+test("should load tools", async ({ page, mcpServerUrl }) => {
+	await page.getByRole("textbox", { name: "Enter MCP server URL" }).fill(mcpServerUrl);
+	await page.getByRole("button", { name: "Connect" }).click();
+	await expect(page.getByTestId("status")).toHaveText("Connected");
+	await expect(page.getByRole("heading")).toContainText("Available Tools (2)");
+});
+
+test("should disable mcp server textbox while and after connecting", async ({
+	page,
+	mcpServerUrl,
+}) => {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	await page.route("**/mcp", async (route) => {
+		// Simulate a delay to keep the textbox disabled
+		await promise;
+		await route.continue();
+	});
+
+	await page.getByRole("textbox", { name: "Enter MCP server URL" }).fill(mcpServerUrl);
+	await Promise.all([
+		page.waitForRequest(mcpServerUrl),
+		page.getByRole("button", { name: "Connect" }).click(),
+	]);
+
+	await expect(page.getByTestId("status")).toHaveText("Connecting");
+	await expect(page.getByRole("textbox", { name: "Enter MCP server URL" })).toBeDisabled();
+
+	// now connection can be established
+	resolve();
+
+	await expect(page.getByTestId("status")).toHaveText("Connected");
+	// textbox should still be disabled
+	await expect(page.getByRole("textbox", { name: "Enter MCP server URL" })).toBeDisabled();
+});
+
+test("should not trigger new connection after a failed connection while typing mcp server textbox", async ({
+	page,
+	mcpServerUrl,
+}) => {
+	// simulate a connection failure
+	await page
+		.getByRole("textbox", { name: "Enter MCP server URL" })
+		.fill(mcpServerUrl.replace("/mcp", "/invalid"));
+	await page.getByRole("button", { name: "Connect" }).click();
+	await expect(page.getByTestId("status")).toHaveText("Failed");
+
+	// now typing in the textbox should not trigger a new connection
+	await page.getByRole("textbox", { name: "Enter MCP server URL" }).fill(mcpServerUrl);
+
+	await page.waitForTimeout(500); // wait to ensure no new request is made
+
+	await expect(page.getByTestId("status")).not.toHaveText(/^(Connecting|Connected)$/);
+});
+
+test("should trigger new connection after a failed connection when connect button is clicked", async ({
+	page,
+	mcpServerUrl,
+}) => {
+	// simulate a connection failure
+	await page
+		.getByRole("textbox", { name: "Enter MCP server URL" })
+		.fill(mcpServerUrl.replace("mcp", "invalid"));
+	await page.getByRole("button", { name: "Connect" }).click();
+	await expect(page.getByTestId("status")).toHaveText("Failed");
+
+	// now typing in the textbox and click connect should establish a new connection
+	await page.getByRole("textbox", { name: "Enter MCP server URL" }).fill(mcpServerUrl);
+	await page.getByRole("button", { name: "Connect" }).click();
+	await expect(page.getByTestId("status")).toHaveText("Connected");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1681,6 +1681,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.3
         version: 1.12.3
+      '@playwright/test':
+        specifier: ^1.53.0
+        version: 1.53.0
       '@tailwindcss/vite':
         specifier: ^4.1.10
         version: 4.1.10(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(sugarss@4.0.1(postcss@8.5.6))(tsx@4.20.3)(yaml@2.7.1))
@@ -2988,6 +2991,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.53.0':
+    resolution: {integrity: sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.11':
     resolution: {integrity: sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==}
@@ -4499,6 +4507,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5652,6 +5665,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.53.0:
+    resolution: {integrity: sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.0:
+    resolution: {integrity: sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -8068,6 +8091,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.53.0':
+    dependencies:
+      playwright: 1.53.0
+
   '@rolldown/pluginutils@1.0.0-beta.11': {}
 
   '@rollup/plugin-replace@6.0.2(rollup@4.39.0)':
@@ -9719,6 +9746,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10826,6 +10856,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  playwright-core@1.53.0: {}
+
+  playwright@1.53.0:
+    dependencies:
+      playwright-core: 1.53.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
9219bf6f1402bfecfb03be71fe518009fdfb011b fixes a bug when a user tries to connect to a failing MCP server:

- it tries to connect but fails as expected
- however, if we try to fix the MCP server URL, it will try to connect again for each update event, instead of only connecting when **Connect** button is pressed. This also causes the focus to be lost after each keystroke as seen in this video:

https://github.com/user-attachments/assets/9466cffc-80dd-401d-ab58-1b72b35fe7d3

I also added some playwright tests on 25dbfd9c679cd35393353481ac89c3b1ef0932e8 to test that scenario, but I understand that this requires some infra changes to run those tests, so if you think it's not worth it, it's a matter of dropping that commit.