### PR TITLE
Fix postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"format": "biome format --write",
 		"lint": "biome lint",
 		"lint:fix": "biome lint --fix",
-		"postinstall": "nx run-many --target=build --projects=packages/*",
+		"postinstall": "nx run-many --target=build --projects='packages/*'",
 		"prepare": "if [ \"$CI\" ]; then echo 'Skipping husky setup in CI'; else husky; fi",
 		"generate-npm-lockfiles": "aicli generate-npm-lockfiles",
 		"lint-npm-lockfiles": "aicli lint-npm-lockfiles"


### PR DESCRIPTION
Running `pnpm i` gets stuck for a long time because of the postinstall script is not finding any packages using my setup. 

Fixed the problem by adding single quotes to the path we want to build.