### PR TITLE
[fix] .dev.vars of google remote auth demo（demos/remote-mcp-google-oauth/.dev.vars.example）

### DIFF
--- a/demos/remote-mcp-google-oauth/.dev.vars.example
+++ b/demos/remote-mcp-google-oauth/.dev.vars.example
@@ -1,3 +1,4 @@
-GITHUB_CLIENT_ID=<your github client id>
-GITHUB_CLIENT_SECRET=<your github client secret>
+GOOGLE_CLIENT_ID=<your github client id>
+GOOGLE_CLIENT_SECRET=<your github client secret>
 COOKIE_ENCRYPTION_KEY=<your cookie cookie encryption key>
+HOSTED_DOMAIN=<optional: use this when restrict google account domain>


### PR DESCRIPTION
# What
Fix `.dev.vars.example` keys to align with Google OAuth requirements in accordance with `README.md`


# Test
I tested on my own mcp server cloned from the demo.