### PR TITLE
Fixes oauth/callback route

### DIFF
--- a/playground/ai/src/OAuthCallbackPage.tsx
+++ b/playground/ai/src/OAuthCallbackPage.tsx
@@ -1,41 +1,18 @@
-import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
-import { onMcpAuthorization } from "use-mcp";
+import { useEffect } from 'react'
+import { onMcpAuthorization } from 'use-mcp'
 
 export default function OAuthCallbackPage() {
-	const [searchParams] = useSearchParams();
-	const [result, setResult] = useState<{
-		status: "processing" | "success" | "error";
-		message?: string;
-	}>({ status: "processing" });
+  useEffect(() => {
+    onMcpAuthorization()
+  }, [])
 
-	useEffect(() => {
-		const query: Record<string, string> = {};
-		searchParams.forEach((value, key) => {
-			query[key] = value;
-		});
-
-		// @ts-expect-error need to fix this
-		onMcpAuthorization(query)
-			.then((res) =>
-				setResult({
-					// @ts-expect-error need to fix this
-					message: res.error,
-					// @ts-expect-error need to fix this
-					status: res.success ? "success" : "error",
-				}),
-			)
-			.catch((err: Error) => setResult({ message: err.message, status: "error" }));
-	}, [searchParams]);
-
-	return (
-		<div>
-			<h1>Authentication {result.status}</h1>
-			{result.status === "processing" && <p>Processing authentication...</p>}
-			{result.status === "success" && (
-				<p>Authentication successful! You can close this window.</p>
-			)}
-			{result.status === "error" && <p>Authentication error: {result.message}</p>}
-		</div>
-	);
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Authenticating...</h1>
+        <p className="text-gray-600 mb-2">Please wait while we complete your authentication.</p>
+        <p className="text-sm text-gray-500">This window should close automatically.</p>
+      </div>
+    </div>
+  )
 }

--- a/playground/ai/wrangler.jsonc
+++ b/playground/ai/wrangler.jsonc
@@ -8,7 +8,13 @@
   "ai": {
     "binding": "AI",
   },
+  "assets": {
+    "directory": "./dist/",
+    "not_found_handling": "single-page-application",
+    "binding": "ASSETS",
+    "run_worker_first": ["/api/*"]
+  },
   "routes": [
     { "pattern": "playground.ai.cloudflare.com", "custom_domain": true },
-  ],
+  ]
 }


### PR DESCRIPTION
Partially fixes #228 (it also requires https://github.com/modelcontextprotocol/use-mcp/pull/15 to land and `use-mcp` version to be upgraded)

- changed OAuthCallbackPage according to https://github.com/modelcontextprotocol/use-mcp?tab=readme-ov-file#with-react-router
- configure app as an SPA (https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/#configuration)