### PR TITLE
feat(examples, remote-mcp-google-oauth): upgrade to use Streamable HTTP

### DIFF
--- a/demos/remote-mcp-google-oauth/README.md
+++ b/demos/remote-mcp-google-oauth/README.md
@@ -41,7 +41,7 @@ Test the remote server using [Inspector](https://modelcontextprotocol.io/docs/to
 ```
 npx @modelcontextprotocol/inspector@latest
 ```
-Enter `https://mcp-google-oauth.<your-subdomain>.workers.dev/sse` and hit connect. Once you go through the authentication flow, you'll see the Tools working: 
+Enter `https://mcp-google-oauth.<your-subdomain>.workers.dev/mcp` and hit connect. Once you go through the authentication flow, you'll see the Tools working: 
 
 <img width="640" alt="image" src="https://github.com/user-attachments/assets/7973f392-0a9d-4712-b679-6dd23f824287" />
 
@@ -64,7 +64,7 @@ Replace the content with the following configuration. Once you restart Claude De
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp-google-oauth.<your-subdomain>.workers.dev/sse"
+        "https://mcp-google-oauth.<your-subdomain>.workers.dev/mcp"
       ]
     }
   }
@@ -88,7 +88,7 @@ GOOGLE_CLIENT_SECRET=your_development_google_cloud_oauth_client_secret
 Run the server locally to make it available at `http://localhost:8788`
 `wrangler dev`
 
-To test the local server, enter `http://localhost:8788/sse` into Inspector and hit connect. Once you follow the prompts, you'll be able to "List Tools". 
+To test the local server, enter `http://localhost:8788/mcp` into Inspector and hit connect. Once you follow the prompts, you'll be able to "List Tools". 
 
 #### Using Claude and other MCP Clients
 
@@ -96,7 +96,7 @@ When using Claude to connect to your remote MCP server, you may see some error m
 
 #### Using Cursor and other MCP Clients
 
-To connect Cursor with your MCP server, choose `Type`: "Command" and in the `Command` field, combine the command and args fields into one (e.g. `npx mcp-remote https://<your-worker-name>.<your-subdomain>.workers.dev/sse`).
+To connect Cursor with your MCP server, choose `Type`: "Command" and in the `Command` field, combine the command and args fields into one (e.g. `npx mcp-remote https://<your-worker-name>.<your-subdomain>.workers.dev/mcp`).
 
 Note that while Cursor supports HTTP+SSE servers, it doesn't support authentication, so you still need to use `mcp-remote` (and to use a STDIO server, not an HTTP one).
 
@@ -123,4 +123,13 @@ The MCP Remote library enables your server to expose tools that can be invoked b
 - Defines the protocol for communication between clients and your server
 - Provides a structured way to define tools
 - Handles serialization and deserialization of requests and responses
-- Maintains the Server-Sent Events (SSE) connection between clients and your server
+- Supports both Streamable HTTP (recommended) and Server-Sent Events (SSE) protocols for client communication
+
+## Transport Protocol Migration
+
+This example has been updated to support the new **Streamable HTTP** transport protocol, which replaces the deprecated Server-Sent Events (SSE) protocol. The server now exposes both endpoints:
+
+- `/mcp` - **Recommended**: Uses the new Streamable HTTP protocol
+- `/sse` - **Deprecated**: Legacy SSE protocol (maintained for backward compatibility)
+
+All new integrations should use the `/mcp` endpoint. The SSE endpoint will be removed in a future version.

--- a/demos/remote-mcp-google-oauth/package-lock.json
+++ b/demos/remote-mcp-google-oauth/package-lock.json
@@ -8,7 +8,7 @@
       "name": "remote-mcp-google-oauth",
       "version": "0.0.1",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.0.5",
+        "@cloudflare/workers-oauth-provider": "^0.0.6",
         "@modelcontextprotocol/sdk": "1.17.1",
         "agents": "^0.0.109",
         "hono": "^4.8.12",
@@ -314,13 +314,10 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.5.tgz",
-      "integrity": "sha512-t1x5KAzsubCvb4APnJ93z407X1x7SGj/ga5ziRnwIb/iLy4PMkT/hgd1y5z7Bbsdy5Fy6mywhCP4lym24bX66w==",
-      "license": "MIT",
-      "dependencies": {
-        "@cloudflare/workers-types": "^4.20250311.0"
-      }
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.0.6.tgz",
+      "integrity": "sha512-im/uBqiBtP5YHAs09yBEzHxSZDJkUnB3gQh7awps+dQSN3tC/OMr29nOppRep4/NFSlAsXpDUpNB7unEjts+Xw==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20250803.0",

--- a/demos/remote-mcp-google-oauth/package.json
+++ b/demos/remote-mcp-google-oauth/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.0.5",
+    "@cloudflare/workers-oauth-provider": "^0.0.6",
     "@modelcontextprotocol/sdk": "1.17.1",
     "agents": "^0.0.109",
     "hono": "^4.8.12",

--- a/demos/remote-mcp-google-oauth/src/index.ts
+++ b/demos/remote-mcp-google-oauth/src/index.ts
@@ -26,8 +26,12 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 }
 
 export default new OAuthProvider({
-	apiHandler: MyMCP.mount("/sse") as any,
-	apiRoute: "/sse",
+	// NOTE - during the summer 2025, the SSE protocol was deprecated and replaced by the Streamable-HTTP protocol
+	// https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication
+	apiHandlers: {
+		"/sse": MyMCP.serveSSE("/sse"), // deprecated SSE protocol - use /mcp instead
+		"/mcp": MyMCP.serve("/mcp"),    // Streamable-HTTP protocol
+	},
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: GoogleHandler as any,


### PR DESCRIPTION
Changes I made,
- Followed suggested changes in Cloudflare's [http streamable announcement](https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication),
  - Upgrade `@cloudflare/workers-oauth-provider` from `v0.0.5` to `v0.0.6`  
  - Added support `/mcp` endpoint for Streamable HTTP. 
  - Keep the existing `/sse` endpoint, but tell users it's legacy
- Update README documentation to recommend `/mcp` endpoint usage
- I deployed and confirmed the example worked for me