### PR TITLE
Add support for base64 images in chat messages

### DIFF
--- a/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
+++ b/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
@@ -42,6 +42,17 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV2Prompt): {
 											providerOptions: part.providerOptions,
 										});
 									}
+									// For Llama 4, images are expected to be in the input messages array in base64
+									if (typeof part.data === "string" && part.mediaType.startsWith('image/')) {
+										return {
+											image_url: {
+												url: `data:${part.mediaType};base64,${part.data}`,
+											},
+											type: "image_url",
+											mimeType: part.mediaType,
+											providerOptions: part.providerOptions,
+										}
+									}
 									return ""; // No text for the image part
 								}
 							}


### PR DESCRIPTION
Handle base64 image data for Llama 4 in chat messages.
As per the documentation found here https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/