### PR TITLE
Remove blank tags array from options object

### DIFF
--- a/.changeset/poor-dots-laugh.md
+++ b/.changeset/poor-dots-laugh.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+remove blank tags array

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -159,7 +159,6 @@ export class WorkersAIChatLanguageModel implements LanguageModelV2 {
 			{
 				gateway: this.config.gateway ?? gateway,
 				...passthroughOptions,
-				tags: [],
 			},
 		);
 
@@ -307,7 +306,6 @@ export class WorkersAIChatLanguageModel implements LanguageModelV2 {
 			{
 				gateway: this.config.gateway ?? gateway,
 				...passthroughOptions,
-				tags: [],
 			},
 		);
 


### PR DESCRIPTION
Eliminated unnecessary empty 'tags' arrays from the options object in WorkersAIChatLanguageModel. This simplifies the code and avoids passing redundant data.