### PR TITLE
fix(remote-mcp-authless): add missing peer dependencies

### DIFF
--- a/demos/remote-mcp-authless/package.json
+++ b/demos/remote-mcp-authless/package.json
@@ -12,7 +12,9 @@
 		"type-check": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.23.0",
 		"agents": "^0.3.0",
+		"ai": "^6.0.3",
 		"zod": "^4.1.8"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Problem

When using the template via:

```bash
npm create cloudflare@latest -- my-mcp-server --template=cloudflare/ai/demos/remote-mcp-authless
```

Running `pnpm dev` or `npm run dev` fails with:

```
Could not resolve "ai"
Could not resolve "@modelcontextprotocol/sdk/server/mcp.js"
```

## Root Cause

The `agents` package requires `@modelcontextprotocol/sdk` and `ai` as peer dependencies, but they were not listed in `package.json`.

## Solution

Added the missing dependencies:
- `@modelcontextprotocol/sdk`: ^1.23.0
- `ai`: ^6.0.3

## Testing

1. Created project using the template
2. Ran `pnpm install`
3. Ran `pnpm dev`
4. Server starts successfully ✅

## Environment

- OS: Windows 11
- Node: v22.x
- pnpm: 10.6.2
- wrangler: 4.54.0
