### PR TITLE
Re-patch google-vertex for AI SDK v6

### DIFF
--- a/.changeset/wicked-eggs-invite.md
+++ b/.changeset/wicked-eggs-invite.md
@@ -1,0 +1,5 @@
+---
+"ai-gateway-provider": patch
+---
+
+Fix google-vertex BYOK/Unified Billing support

--- a/packages/ai-gateway-provider/src/providers/google-vertex.ts
+++ b/packages/ai-gateway-provider/src/providers/google-vertex.ts
@@ -2,11 +2,13 @@ import { createVertex as createVertexOriginal } from "@ai-sdk/google-vertex/edge
 import { CF_TEMP_TOKEN } from "../auth";
 
 export const createVertex = (...args: Parameters<typeof createVertexOriginal>) => {
-	const [config] = args;
-	// In v6, apiKey is a top-level property for express mode authentication
-	const configWithApiKey = {
-		...config,
-		apiKey: config?.apiKey ?? CF_TEMP_TOKEN,
-	};
-	return createVertexOriginal(configWithApiKey);
-};
+    let [config] = args;
+    if (config === undefined) {
+        config = { googleCredentials: { cfApiKey: CF_TEMP_TOKEN } } as any;
+    }
+	// no google credentials and no express mode apikey
+    else if (config.googleCredentials === undefined && config.apiKey === undefined) {
+        config.googleCredentials = { cfApiKey: CF_TEMP_TOKEN } as any;
+    }
+    return createVertexOriginal(config);
+}

--- a/patches/@ai-sdk__google-vertex.patch
+++ b/patches/@ai-sdk__google-vertex.patch
@@ -1,50 +1,24 @@
-diff --git a/dist/edge/index.d.mts b/dist/edge/index.d.mts
-index a8fea73f05364d1b67b91d547bf76007275bea57..a4496464e0dc05eb514a6085c2e1d79849271886 100644
---- a/dist/edge/index.d.mts
-+++ b/dist/edge/index.d.mts
-@@ -100,7 +100,7 @@ interface GoogleVertexProviderSettings extends GoogleVertexProviderSettings$1 {
-      * not provided, the Google Vertex provider will use environment variables to
-      * load the credentials.
-      */
--    googleCredentials?: GoogleCredentials;
-+    googleCredentials?: GoogleCredentials | { apiKey: string };
- }
- declare function createVertex(options?: GoogleVertexProviderSettings): GoogleVertexProvider;
- /**
-diff --git a/dist/edge/index.d.ts b/dist/edge/index.d.ts
-index a8fea73f05364d1b67b91d547bf76007275bea57..a4496464e0dc05eb514a6085c2e1d79849271886 100644
---- a/dist/edge/index.d.ts
-+++ b/dist/edge/index.d.ts
-@@ -100,7 +100,7 @@ interface GoogleVertexProviderSettings extends GoogleVertexProviderSettings$1 {
-      * not provided, the Google Vertex provider will use environment variables to
-      * load the credentials.
-      */
--    googleCredentials?: GoogleCredentials;
-+    googleCredentials?: GoogleCredentials | { apiKey: string };
- }
- declare function createVertex(options?: GoogleVertexProviderSettings): GoogleVertexProvider;
- /**
 diff --git a/dist/edge/index.js b/dist/edge/index.js
-index 8d155c95c62b177e232811dab69e78ba02f406d0..988ad94b9fcf4cd1123f1bec1700b83d3e7e3e32 100644
+index 079ab83ed4518113abdc847cc2f644a654a656ec..beffbc925b35aea015d27e936cf5208bcbcc9c8b 100644
 --- a/dist/edge/index.js
 +++ b/dist/edge/index.js
-@@ -457,6 +457,7 @@ var buildJwt = async (credentials) => {
+@@ -587,6 +587,7 @@ var buildJwt = async (credentials) => {
  };
  async function generateAuthToken(credentials) {
    try {
-+    if(credentials.apiKey) return credentials.apiKey;
++    if(credentials.cfApiKey) return credentials.cfApiKey;
      const creds = credentials || await loadCredentials();
      const jwt = await buildJwt(creds);
      const response = await fetch("https://oauth2.googleapis.com/token", {
 diff --git a/dist/edge/index.mjs b/dist/edge/index.mjs
-index 330c98783ca74cb3b87e22370889a21b7a11f5dd..0fe244acc9a7381eb1c78610f17f68f12d08881a 100644
+index 89a0c0ef49b4beaa1d53fdff49f1dea93333dc8a..be6988f70fc17c058183c17da2fd9f1a9a9dee26 100644
 --- a/dist/edge/index.mjs
 +++ b/dist/edge/index.mjs
-@@ -455,6 +455,7 @@ var buildJwt = async (credentials) => {
+@@ -587,6 +587,7 @@ var buildJwt = async (credentials) => {
  };
  async function generateAuthToken(credentials) {
    try {
-+    if(credentials.apiKey) return credentials.apiKey;
++    if(credentials.cfApiKey) return credentials.cfApiKey;
      const creds = credentials || await loadCredentials();
      const jwt = await buildJwt(creds);
      const response = await fetch("https://oauth2.googleapis.com/token", {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@ai-sdk/google-vertex':
-    hash: 271963aef1bb8d69c1fbba83342f6bdf1b39f53c660e9b34659e6ce279c0a100
+    hash: 5015d8c7ff40e99b6b6d204430f0750dda43beda4beda4e6817b38cd2b057184
     path: patches/@ai-sdk__google-vertex.patch
 
 importers:
@@ -1536,7 +1536,7 @@ importers:
         version: 3.0.1(zod@4.2.1)
       '@ai-sdk/google-vertex':
         specifier: ^4.0.1
-        version: 4.0.1(patch_hash=271963aef1bb8d69c1fbba83342f6bdf1b39f53c660e9b34659e6ce279c0a100)(zod@4.2.1)
+        version: 4.0.1(patch_hash=5015d8c7ff40e99b6b6d204430f0750dda43beda4beda4e6817b38cd2b057184)(zod@4.2.1)
       '@ai-sdk/groq':
         specifier: ^3.0.1
         version: 3.0.1(zod@4.2.1)
@@ -6525,7 +6525,7 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 4.2.1
 
-  '@ai-sdk/google-vertex@4.0.1(patch_hash=271963aef1bb8d69c1fbba83342f6bdf1b39f53c660e9b34659e6ce279c0a100)(zod@4.2.1)':
+  '@ai-sdk/google-vertex@4.0.1(patch_hash=5015d8c7ff40e99b6b6d204430f0750dda43beda4beda4e6817b38cd2b057184)(zod@4.2.1)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.1(zod@4.2.1)
       '@ai-sdk/google': 3.0.1(zod@4.2.1)


### PR DESCRIPTION
The official v6 compatible @ai-sdk/google-vertex package does support API key authentication, but only when using Vertex AI [Express Mode](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview#different). Since Express Mode is completely different from standard Google Vertex, this approach does not work for regular Vertex deployments which AI Gateway supports. 

This PR [re-introduces the earlier patch](https://github.com/cloudflare/ai/pull/326) on the ai-sdk/google-vertex package, updating it for the v6 compatible version