### PR TITLE
Standardize MCP endpoint from /sse to /mcp across all demos

### DIFF
--- a/demos/mcp-server-bearer-auth/src/index.ts
+++ b/demos/mcp-server-bearer-auth/src/index.ts
@@ -44,7 +44,7 @@ app.get("/", async (c) => {
 	return c.html(layout(content, "MCP Remote Auth Demo - Home"));
 });
 
-app.mount("/", (req, env, ctx) => {
+app.mount("/mcp", (req, env, ctx) => {
 	// This could technically be pulled out into a middleware function, but is left here for clarity
 	const authHeader = req.headers.get("authorization");
 	if (!authHeader) {
@@ -56,7 +56,7 @@ app.mount("/", (req, env, ctx) => {
 		// could also add arbitrary headers/parameters here to pass into the MCP client
 	};
 
-	return MyMCP.mount("/sse").fetch(req, env, ctx);
+	return MyMCP.serve("/mcp").fetch(req, env, ctx);
 });
 
 export default app;

--- a/demos/mcp-slack-oauth/src/index.ts
+++ b/demos/mcp-slack-oauth/src/index.ts
@@ -132,8 +132,8 @@ export class SlackMCP extends McpAgent<Env, unknown, Props> {
 }
 
 export default new OAuthProvider({
-	apiHandler: SlackMCP.mount("/sse") as any,
-	apiRoute: "/sse",
+	apiHandler: SlackMCP.serve("/mcp") as any,
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: SlackHandler as any,

--- a/demos/mcp-stytch-b2b-okr-manager/api/index.ts
+++ b/demos/mcp-stytch-b2b-okr-manager/api/index.ts
@@ -23,8 +23,8 @@ export default new Hono<{ Bindings: Env }>()
 	})
 
 	// Let the MCP Server have a go at handling the request
-	.use("/sse/*", stytchBearerTokenAuthMiddleware)
-	.route("/sse", new Hono().mount("/", OKRManagerMCP.mount("/sse").fetch))
+	.use("/mcp/*", stytchBearerTokenAuthMiddleware)
+	.route("/mcp", new Hono().mount("/", OKRManagerMCP.serve("/mcp").fetch))
 
 	// Finally - serve static assets from Vite
 	.mount("/", (req, env) => env.ASSETS.fetch(req));

--- a/demos/mcp-stytch-consumer-todo-list/api/index.ts
+++ b/demos/mcp-stytch-consumer-todo-list/api/index.ts
@@ -23,8 +23,8 @@ export default new Hono<{ Bindings: Env }>()
 	})
 
 	// Let the MCP Server have a go at handling the request
-	.use("/sse/*", stytchBearerTokenAuthMiddleware)
-	.route("/sse", new Hono().mount("/", TodoMCP.mount("/sse").fetch))
+	.use("/mcp/*", stytchBearerTokenAuthMiddleware)
+	.route("/mcp", new Hono().mount("/", TodoMCP.serve("/mcp").fetch))
 
 	// Finally - serve static assets from Vite
 	.mount("/", (req, env) => env.ASSETS.fetch(req));

--- a/demos/remote-mcp-auth0/mcp-auth0-oidc/src/index.ts
+++ b/demos/remote-mcp-auth0/mcp-auth0-oidc/src/index.ts
@@ -72,12 +72,10 @@ app.post("/authorize", confirmConsent);
 app.get("/callback", callback);
 
 export default new OAuthProvider({
-	// TODO: fix these types
-	apiHandler: AuthenticatedMCP.mount("/sse"),
-	apiRoute: "/sse",
+	apiHandler: AuthenticatedMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
-	// TODO: fix these types
 	// @ts-expect-error
 	defaultHandler: app,
 	tokenEndpoint: "/token",

--- a/demos/remote-mcp-authkit/src/index.ts
+++ b/demos/remote-mcp-authkit/src/index.ts
@@ -67,8 +67,8 @@ export class MyMCP extends McpAgent<Env, unknown, Props> {
 }
 
 export default new OAuthProvider({
-	apiRoute: "/sse",
-	apiHandler: MyMCP.mount("/sse") as any, // Use 'any' for maximum flexibility
+	apiRoute: "/mcp",
+	apiHandler: MyMCP.serve("/mcp") as any, // Use 'any' for maximum flexibility
 	defaultHandler: AuthkitHandler as any, // Use 'any' for maximum flexibility
 	authorizeEndpoint: "/authorize",
 	tokenEndpoint: "/token",

--- a/demos/remote-mcp-authless/src/index.ts
+++ b/demos/remote-mcp-authless/src/index.ts
@@ -58,10 +58,6 @@ export default {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
 
-		if (url.pathname === "/sse" || url.pathname === "/sse/message") {
-			return MyMCP.serveSSE("/sse").fetch(request, env, ctx);
-		}
-
 		if (url.pathname === "/mcp") {
 			return MyMCP.serve("/mcp").fetch(request, env, ctx);
 		}

--- a/demos/remote-mcp-cf-access/src/index.ts
+++ b/demos/remote-mcp-cf-access/src/index.ts
@@ -58,20 +58,9 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 	}
 }
 
-async function handleMcpRequest(req: Request, env: Env, ctx: ExecutionContext) {
-	const { pathname } = new URL(req.url);
-	if (pathname === "/sse" || pathname === "/sse/message") {
-		return MyMCP.serveSSE("/sse").fetch(req, env, ctx);
-	}
-	if (pathname === "/mcp") {
-		return MyMCP.serve("/mcp").fetch(req, env, ctx);
-	}
-	return new Response("Not found", { status: 404 });
-}
-
 export default new OAuthProvider({
-	apiHandler: { fetch: handleMcpRequest as any },
-	apiRoute: ["/sse", "/mcp"],
+	apiHandler: MyMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: { fetch: handleAccessRequest as any },

--- a/demos/remote-mcp-github-oauth/src/index.ts
+++ b/demos/remote-mcp-github-oauth/src/index.ts
@@ -89,12 +89,8 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 }
 
 export default new OAuthProvider({
-	// NOTE - during the summer 2025, the SSE protocol was deprecated and replaced by the Streamable-HTTP protocol
-	// https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication
-	apiHandlers: {
-		"/sse": MyMCP.serveSSE("/sse"), // deprecated SSE protocol - use /mcp instead
-		"/mcp": MyMCP.serve("/mcp"), // Streamable-HTTP protocol
-	},
+	apiHandler: MyMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: GitHubHandler as any,

--- a/demos/remote-mcp-google-oauth/src/index.ts
+++ b/demos/remote-mcp-google-oauth/src/index.ts
@@ -26,12 +26,8 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 }
 
 export default new OAuthProvider({
-	// NOTE - during the summer 2025, the SSE protocol was deprecated and replaced by the Streamable-HTTP protocol
-	// https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication
-	apiHandlers: {
-		"/sse": MyMCP.serveSSE("/sse"), // deprecated SSE protocol - use /mcp instead
-		"/mcp": MyMCP.serve("/mcp"), // Streamable-HTTP protocol
-	},
+	apiHandler: MyMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: GoogleHandler as any,

--- a/demos/remote-mcp-logto/src/index.ts
+++ b/demos/remote-mcp-logto/src/index.ts
@@ -44,12 +44,8 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 }
 
 export default new OAuthProvider({
-	// NOTE - during the summer 2025, the SSE protocol was deprecated and replaced by the Streamable-HTTP protocol
-	// https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication
-	apiHandlers: {
-		"/sse": MyMCP.serveSSE("/sse"), // deprecated SSE protocol - use /mcp instead
-		"/mcp": MyMCP.serve("/mcp"), // Streamable-HTTP protocol
-	},
+	apiHandler: MyMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: LogtoHandler as any,

--- a/demos/remote-mcp-server-autorag/src/index.ts
+++ b/demos/remote-mcp-server-autorag/src/index.ts
@@ -36,10 +36,8 @@ export class MyMCP extends McpAgent {
 
 // Export the OAuth handler as the default
 export default new OAuthProvider({
-	apiRoute: "/sse",
-	// TODO: fix these types
-	// @ts-expect-error
-	apiHandler: MyMCP.mount("/sse"),
+	apiRoute: "/mcp",
+	apiHandler: MyMCP.serve("/mcp"),
 	// @ts-expect-error
 	defaultHandler: app,
 	authorizeEndpoint: "/authorize",

--- a/demos/remote-mcp-server-descope-auth/src/index.ts
+++ b/demos/remote-mcp-server-descope-auth/src/index.ts
@@ -64,12 +64,8 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 }
 
 export default new OAuthProvider({
-	// NOTE - during the summer 2025, the SSE protocol was deprecated and replaced by the Streamable-HTTP protocol
-	// https://developers.cloudflare.com/agents/model-context-protocol/transport/#mcp-server-with-authentication
-	apiHandlers: {
-		"/sse": MyMCP.serveSSE("/sse"), // deprecated SSE protocol - use /mcp instead
-		"/mcp": MyMCP.serve("/mcp"), // Streamable-HTTP protocol
-	},
+	apiHandler: MyMCP.serve("/mcp"),
+	apiRoute: "/mcp",
 	authorizeEndpoint: "/authorize",
 	clientRegistrationEndpoint: "/register",
 	defaultHandler: DescopeHandler as any,

--- a/demos/remote-mcp-server/src/index.ts
+++ b/demos/remote-mcp-server/src/index.ts
@@ -19,9 +19,8 @@ export class MyMCP extends McpAgent {
 
 // Export the OAuth handler as the default
 export default new OAuthProvider({
-	apiRoute: "/sse",
-	// TODO: fix these types
-	apiHandler: MyMCP.mount("/sse"),
+	apiRoute: "/mcp",
+	apiHandler: MyMCP.serve("/mcp"),
 	// @ts-expect-error
 	defaultHandler: app,
 	authorizeEndpoint: "/authorize",


### PR DESCRIPTION
Replace deprecated SSE protocol endpoints with Streamable-HTTP protocol. Update all demos to use MyMCP.serve("/mcp") instead of MyMCP.mount("/sse") or MyMCP.serveSSE("/sse"). Remove apiHandlers multi-protocol support in favor of single apiHandler configuration. Clean up unnecessary SSE fallback handling and related comments.