### PR TITLE
feat(workers-ai-provider)!: upgrade to AI SDK V3 specification

### DIFF
--- a/.changeset/workers-ai-v3.md
+++ b/.changeset/workers-ai-v3.md
@@ -1,0 +1,25 @@
+---
+"workers-ai-provider": major
+---
+
+Upgrade to AI SDK V3 specification
+
+## Breaking Changes
+
+- `specificationVersion` changed from `"v2"` to `"v3"`
+- Updated `@ai-sdk/provider` to `^3.0.0`
+- All `LanguageModelV2` types replaced with `LanguageModelV3`
+- `LanguageModelV3FinishReason` now returns `{ unified, raw }` object instead of string
+- `LanguageModelV3Usage` now uses nested `inputTokens` and `outputTokens` objects
+- `EmbeddingModelV3` is no longer generic
+- Warning types changed to `SharedV3Warning` with `feature` instead of `setting`
+
+## Migration
+
+This package now requires AI SDK v6. Update your `ai` dependency:
+
+```bash
+npm install ai@^6.0.0
+```
+
+No API changes are needed - the package maintains the same public interface.

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -2,7 +2,7 @@
 	"name": "workers-ai-provider",
 	"description": "Workers AI Provider for the vercel AI SDK",
 	"type": "module",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"repository": {
@@ -39,11 +39,12 @@
 		"serverless"
 	],
 	"dependencies": {
-		"@ai-sdk/provider": "^2.0.0",
+		"@ai-sdk/provider": "^3.0.0",
 		"@ai-sdk/provider-utils": "^3.0.18"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20251202.0",
+		"ai": "^6.0.0",
 		"zod": "^3.25.76"
 	}
 }

--- a/packages/workers-ai-provider/src/map-workersai-finish-reason.ts
+++ b/packages/workers-ai-provider/src/map-workersai-finish-reason.ts
@@ -1,6 +1,6 @@
-import type { LanguageModelV2FinishReason } from "@ai-sdk/provider";
+import type { LanguageModelV3FinishReason } from "@ai-sdk/provider";
 
-export function mapWorkersAIFinishReason(finishReasonOrResponse: any): LanguageModelV2FinishReason {
+export function mapWorkersAIFinishReason(finishReasonOrResponse: any): LanguageModelV3FinishReason {
 	let finishReason: string | null | undefined;
 
 	// If it's a string/null/undefined, use it directly (original behavior)
@@ -28,20 +28,21 @@ export function mapWorkersAIFinishReason(finishReasonOrResponse: any): LanguageM
 
 	switch (finishReason) {
 		case "stop":
-			return "stop";
+			return { unified: "stop", raw: finishReason };
 		case "length":
 		case "model_length":
-			return "length";
+			return { unified: "length", raw: finishReason };
 		case "tool_calls":
-			return "tool-calls";
+			return { unified: "tool-calls", raw: finishReason };
+		case "content_filter":
+			return { unified: "content-filter", raw: finishReason };
 		case "error":
-			return "error";
+			return { unified: "error", raw: finishReason };
 		case "other":
-			return "other";
 		case "unknown":
-			return "unknown";
+			return { unified: "other", raw: finishReason };
 		default:
 			// Default to `stop` for backwards compatibility
-			return "stop";
+			return { unified: "stop", raw: finishReason ?? undefined };
 	}
 }

--- a/packages/workers-ai-provider/src/map-workersai-usage.ts
+++ b/packages/workers-ai-provider/src/map-workersai-usage.ts
@@ -1,4 +1,6 @@
-export function mapWorkersAIUsage(output: AiTextGenerationOutput | AiTextToImageOutput) {
+import type { LanguageModelV3Usage } from "@ai-sdk/provider";
+
+export function mapWorkersAIUsage(output: AiTextGenerationOutput | AiTextToImageOutput): LanguageModelV3Usage {
 	const usage = (
 		output as {
 			usage: { prompt_tokens: number; completion_tokens: number };
@@ -9,8 +11,16 @@ export function mapWorkersAIUsage(output: AiTextGenerationOutput | AiTextToImage
 	};
 
 	return {
-		outputTokens: usage.completion_tokens,
-		inputTokens: usage.prompt_tokens,
-		totalTokens: usage.prompt_tokens + usage.completion_tokens,
+		inputTokens: {
+			total: usage.prompt_tokens,
+			noCache: undefined,
+			cacheRead: undefined,
+			cacheWrite: undefined,
+		},
+		outputTokens: {
+			total: usage.completion_tokens,
+			text: undefined,
+			reasoning: undefined,
+		},
 	};
 }

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2StreamPart } from "@ai-sdk/provider";
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from "@ai-sdk/provider";
 import { generateId } from "ai";
 import { events } from "fetch-event-stream";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
@@ -6,14 +6,17 @@ import { processPartialToolCalls } from "./utils";
 
 export function getMappedStream(response: Response) {
 	const chunkEvent = events(response);
-	let usage = { outputTokens: 0, inputTokens: 0, totalTokens: 0 };
+	let usage: LanguageModelV3Usage = {
+		inputTokens: { total: 0, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+		outputTokens: { total: 0, text: undefined, reasoning: undefined },
+	};
 	const partialToolCalls: any[] = [];
 
 	// Track start/delta/end IDs per v5 streaming protocol
 	let textId: string | null = null;
 	let reasoningId: string | null = null;
 
-	return new ReadableStream<LanguageModelV2StreamPart>({
+	return new ReadableStream<LanguageModelV3StreamPart>({
 		async start(controller) {
 			for await (const event of chunkEvent) {
 				if (!event.data) {
@@ -90,7 +93,7 @@ export function getMappedStream(response: Response) {
 			}
 
 			controller.enqueue({
-				finishReason: "stop",
+				finishReason: { unified: "stop", raw: "stop" },
 				type: "finish",
 				usage: usage,
 			});

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2, LanguageModelV2ToolCall } from "@ai-sdk/provider";
+import type { LanguageModelV3, LanguageModelV3ToolCall } from "@ai-sdk/provider";
 import { generateId } from "ai";
 
 /**
@@ -128,8 +128,8 @@ export function createRun(config: CreateRunConfig): AiRun {
 }
 
 export function prepareToolsAndToolChoice(
-	tools: Parameters<LanguageModelV2["doGenerate"]>[0]["tools"],
-	toolChoice: Parameters<LanguageModelV2["doGenerate"]>[0]["toolChoice"],
+	tools: Parameters<LanguageModelV3["doGenerate"]>[0]["tools"],
+	toolChoice: Parameters<LanguageModelV3["doGenerate"]>[0]["toolChoice"],
 ) {
 	if (tools == null) {
 		return { tool_choice: undefined, tools: undefined };
@@ -213,7 +213,7 @@ function mergePartialToolCalls(partialCalls: any[]) {
 	return Object.values(mergedCallsByIndex);
 }
 
-function processToolCall(toolCall: any): LanguageModelV2ToolCall {
+function processToolCall(toolCall: any): LanguageModelV3ToolCall {
 	// Check for OpenAI format tool calls first
 	if (toolCall.function && toolCall.id) {
 		return {
@@ -237,7 +237,7 @@ function processToolCall(toolCall: any): LanguageModelV2ToolCall {
 	};
 }
 
-export function processToolCalls(output: any): LanguageModelV2ToolCall[] {
+export function processToolCalls(output: any): LanguageModelV3ToolCall[] {
 	if (output.tool_calls && Array.isArray(output.tool_calls)) {
 		return output.tool_calls.map((toolCall: any) => {
 			const processedToolCall = processToolCall(toolCall);

--- a/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
+++ b/packages/workers-ai-provider/src/workers-ai-embedding-model.ts
@@ -1,4 +1,5 @@
-import { type EmbeddingModelV2, TooManyEmbeddingValuesForCallError } from "@ai-sdk/provider";
+import type { EmbeddingModelV3, EmbeddingModelV3CallOptions, EmbeddingModelV3Result } from "@ai-sdk/provider";
+import { TooManyEmbeddingValuesForCallError } from "@ai-sdk/provider";
 import type { StringLike } from "./utils";
 import type { EmbeddingModels } from "./workersai-models";
 
@@ -19,12 +20,12 @@ export type WorkersAIEmbeddingSettings = {
 	[key: string]: StringLike;
 };
 
-export class WorkersAIEmbeddingModel implements EmbeddingModelV2<string> {
+export class WorkersAIEmbeddingModel implements EmbeddingModelV3 {
 	/**
-	 * Semantic version of the {@link EmbeddingModelV1} specification implemented
+	 * Semantic version of the {@link EmbeddingModelV3} specification implemented
 	 * by this class. It never changes.
 	 */
-	readonly specificationVersion = "v2";
+	readonly specificationVersion = "v3";
 	readonly modelId: EmbeddingModels;
 	private readonly config: WorkersAIEmbeddingConfig;
 	private readonly settings: WorkersAIEmbeddingSettings;
@@ -56,11 +57,9 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV2<string> {
 		this.config = config;
 	}
 
-	async doEmbed({
-		values,
-	}: Parameters<EmbeddingModelV2<string>["doEmbed"]>[0]): Promise<
-		Awaited<ReturnType<EmbeddingModelV2<string>["doEmbed"]>>
-	> {
+	async doEmbed(options: EmbeddingModelV3CallOptions): Promise<EmbeddingModelV3Result> {
+		const { values } = options;
+
 		if (values.length > this.maxEmbeddingsPerCall) {
 			throw new TooManyEmbeddingValuesForCallError({
 				maxEmbeddingsPerCall: this.maxEmbeddingsPerCall,
@@ -86,6 +85,7 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV2<string> {
 
 		return {
 			embeddings: response.data,
+			warnings: [],
 		};
 	}
 }

--- a/packages/workers-ai-provider/src/workersai-image-model.ts
+++ b/packages/workers-ai-provider/src/workersai-image-model.ts
@@ -1,10 +1,10 @@
-import type { ImageModelV2, ImageModelV2CallWarning } from "@ai-sdk/provider";
+import type { ImageModelV3, SharedV3Warning } from "@ai-sdk/provider";
 import type { WorkersAIImageConfig } from "./workersai-image-config";
 import type { WorkersAIImageSettings } from "./workersai-image-settings";
 import type { ImageGenerationModels } from "./workersai-models";
 
-export class WorkersAIImageModel implements ImageModelV2 {
-	readonly specificationVersion = "v2";
+export class WorkersAIImageModel implements ImageModelV3 {
+	readonly specificationVersion = "v3";
 
 	get maxImagesPerCall(): number {
 		return this.settings.maxImagesPerCall ?? 1;
@@ -27,18 +27,18 @@ export class WorkersAIImageModel implements ImageModelV2 {
 		seed,
 		// headers,
 		// abortSignal,
-	}: Parameters<ImageModelV2["doGenerate"]>[0]): Promise<
-		Awaited<ReturnType<ImageModelV2["doGenerate"]>>
+	}: Parameters<ImageModelV3["doGenerate"]>[0]): Promise<
+		Awaited<ReturnType<ImageModelV3["doGenerate"]>>
 	> {
 		const { width, height } = getDimensionsFromSizeString(size);
 
-		const warnings: Array<ImageModelV2CallWarning> = [];
+		const warnings: Array<SharedV3Warning> = [];
 
 		if (aspectRatio != null) {
 			warnings.push({
 				details: "This model does not support aspect ratio. Use `size` instead.",
-				setting: "aspectRatio",
-				type: "unsupported-setting",
+				feature: "aspectRatio",
+				type: "unsupported",
 			});
 		}
 
@@ -47,7 +47,7 @@ export class WorkersAIImageModel implements ImageModelV2 {
 				this.modelId,
 				{
 					height,
-					prompt,
+					prompt: prompt ?? "",
 					seed,
 					width,
 				},

--- a/packages/workers-ai-provider/test/map-workersai-finish-reason.test.ts
+++ b/packages/workers-ai-provider/test/map-workersai-finish-reason.test.ts
@@ -1,108 +1,102 @@
-import type { LanguageModelV2FinishReason } from "@ai-sdk/provider";
+import type { LanguageModelV3FinishReason } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
 import { mapWorkersAIFinishReason } from "../src/map-workersai-finish-reason";
 
 describe("mapWorkersAIFinishReason", () => {
 	describe("direct mappings", () => {
-		it('should map "stop" to "stop"', () => {
+		it('should map "stop" to unified "stop"', () => {
 			const result = mapWorkersAIFinishReason("stop");
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: "stop" });
 		});
 
-		it('should map "length" to "length"', () => {
+		it('should map "length" to unified "length"', () => {
 			const result = mapWorkersAIFinishReason("length");
-			expect(result).toBe("length");
+			expect(result).toEqual({ unified: "length", raw: "length" });
 		});
 
-		it('should map "model_length" to "length"', () => {
+		it('should map "model_length" to unified "length"', () => {
 			const result = mapWorkersAIFinishReason("model_length");
-			expect(result).toBe("length");
+			expect(result).toEqual({ unified: "length", raw: "model_length" });
 		});
 
-		it('should map "tool_calls" to "tool-calls"', () => {
+		it('should map "tool_calls" to unified "tool-calls"', () => {
 			const result = mapWorkersAIFinishReason("tool_calls");
-			expect(result).toBe("tool-calls");
+			expect(result).toEqual({ unified: "tool-calls", raw: "tool_calls" });
 		});
 
-		it('should map "error" to "error"', () => {
+		it('should map "error" to unified "error"', () => {
 			const result = mapWorkersAIFinishReason("error");
-			expect(result).toBe("error");
+			expect(result).toEqual({ unified: "error", raw: "error" });
 		});
 
-		it('should map "other" to "other"', () => {
+		it('should map "other" to unified "other"', () => {
 			const result = mapWorkersAIFinishReason("other");
-			expect(result).toBe("other");
+			expect(result).toEqual({ unified: "other", raw: "other" });
 		});
 
-		it('should map "unknown" to "unknown"', () => {
+		it('should map "unknown" to unified "other"', () => {
 			const result = mapWorkersAIFinishReason("unknown");
-			expect(result).toBe("unknown");
+			expect(result).toEqual({ unified: "other", raw: "unknown" });
 		});
 	});
 
 	describe("default case handling", () => {
-		it('should default to "stop" for null input', () => {
+		it('should default to unified "stop" for null input', () => {
 			const result = mapWorkersAIFinishReason(null);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" for undefined input', () => {
+		it('should default to unified "stop" for undefined input', () => {
 			const result = mapWorkersAIFinishReason(undefined);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" for unrecognized string values', () => {
+		it('should default to unified "stop" for unrecognized string values', () => {
 			const result = mapWorkersAIFinishReason("unrecognized_value");
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: "unrecognized_value" });
 		});
 
-		it('should default to "stop" for empty string', () => {
+		it('should default to unified "stop" for empty string', () => {
 			const result = mapWorkersAIFinishReason("");
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: "" });
 		});
 	});
 
 	describe("return type validation", () => {
-		it("should return a valid LanguageModelV1FinishReason type", () => {
-			const validReasons: LanguageModelV2FinishReason[] = [
-				"stop",
-				"length",
-				"tool-calls",
-				"error",
-				"other",
-				"unknown",
-			];
+		it("should return a valid LanguageModelV3FinishReason type", () => {
+			const validUnifiedReasons = ["stop", "length", "tool-calls", "error", "other", "unknown"];
 
-			// Test that all our mapped values are valid
-			expect(validReasons).toContain(mapWorkersAIFinishReason("stop"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("length"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("model_length"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("tool_calls"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("error"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("other"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason("unknown"));
-			expect(validReasons).toContain(mapWorkersAIFinishReason(null));
+			// Test that all our mapped values have valid unified reasons
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("stop").unified);
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("length").unified);
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("model_length").unified);
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("tool_calls").unified);
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("error").unified);
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason("other").unified);
+			// "unknown" maps to "other" in the implementation
+			expect(mapWorkersAIFinishReason("unknown").unified).toBe("other");
+			expect(validUnifiedReasons).toContain(mapWorkersAIFinishReason(null).unified);
 		});
 	});
 
 	describe("comprehensive mapping test", () => {
 		it("should handle all expected inputs correctly", () => {
-			const testCases: Array<[string | null | undefined, LanguageModelV2FinishReason]> = [
-				["stop", "stop"],
-				["length", "length"],
-				["model_length", "length"],
-				["tool_calls", "tool-calls"],
-				["error", "error"],
-				["other", "other"],
-				["unknown", "unknown"],
-				[null, "stop"],
-				[undefined, "stop"],
-				["invalid", "stop"],
-				["", "stop"],
+			const testCases: Array<[string | null | undefined, LanguageModelV3FinishReason]> = [
+				["stop", { unified: "stop", raw: "stop" }],
+				["length", { unified: "length", raw: "length" }],
+				["model_length", { unified: "length", raw: "model_length" }],
+				["tool_calls", { unified: "tool-calls", raw: "tool_calls" }],
+				["error", { unified: "error", raw: "error" }],
+				["other", { unified: "other", raw: "other" }],
+				["unknown", { unified: "other", raw: "unknown" }],
+				[null, { unified: "stop", raw: undefined }],
+				[undefined, { unified: "stop", raw: undefined }],
+				["invalid", { unified: "stop", raw: "invalid" }],
+				["", { unified: "stop", raw: "" }],
 			];
 
 			for (const [input, expected] of testCases) {
-				expect(mapWorkersAIFinishReason(input)).toBe(expected);
+				expect(mapWorkersAIFinishReason(input)).toEqual(expected);
 			}
 		});
 	});
@@ -113,59 +107,59 @@ describe("mapWorkersAIFinishReason", () => {
 				choices: [{ finish_reason: "stop" }],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: "stop" });
 		});
 
 		it("should handle all finish reasons from choices[0]", () => {
 			const testCases = [
-				{ expected: "stop", input: "stop" },
-				{ expected: "length", input: "length" },
-				{ expected: "length", input: "model_length" },
-				{ expected: "tool-calls", input: "tool_calls" },
-				{ expected: "error", input: "error" },
-				{ expected: "other", input: "other" },
-				{ expected: "unknown", input: "unknown" },
-				{ expected: "stop", input: "invalid_reason" },
+				{ expected: { unified: "stop", raw: "stop" }, input: "stop" },
+				{ expected: { unified: "length", raw: "length" }, input: "length" },
+				{ expected: { unified: "length", raw: "model_length" }, input: "model_length" },
+				{ expected: { unified: "tool-calls", raw: "tool_calls" }, input: "tool_calls" },
+				{ expected: { unified: "error", raw: "error" }, input: "error" },
+				{ expected: { unified: "other", raw: "other" }, input: "other" },
+				{ expected: { unified: "other", raw: "unknown" }, input: "unknown" },
+				{ expected: { unified: "stop", raw: "invalid_reason" }, input: "invalid_reason" },
 			];
 
 			for (const { input, expected } of testCases) {
 				const response = {
 					choices: [{ finish_reason: input }],
 				};
-				expect(mapWorkersAIFinishReason(response)).toBe(expected);
+				expect(mapWorkersAIFinishReason(response)).toEqual(expected);
 			}
 		});
 
-		it('should default to "stop" when choices[0].finish_reason is null', () => {
+		it('should default to unified "stop" when choices[0].finish_reason is null', () => {
 			const response = {
 				choices: [{ finish_reason: null }],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" when choices[0].finish_reason is undefined', () => {
+		it('should default to unified "stop" when choices[0].finish_reason is undefined', () => {
 			const response = {
 				choices: [{ finish_reason: undefined }],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" when choices[0] has no finish_reason property', () => {
+		it('should default to unified "stop" when choices[0] has no finish_reason property', () => {
 			const response = {
 				choices: [{ some_other_property: "value" }],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" when choices array is empty', () => {
+		it('should default to unified "stop" when choices array is empty', () => {
 			const response = {
 				choices: [],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
 		it("should only use first choice when multiple choices exist", () => {
@@ -173,7 +167,7 @@ describe("mapWorkersAIFinishReason", () => {
 				choices: [{ finish_reason: "stop" }, { finish_reason: "length" }],
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: "stop" });
 		});
 	});
 
@@ -183,41 +177,41 @@ describe("mapWorkersAIFinishReason", () => {
 				finish_reason: "length",
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("length");
+			expect(result).toEqual({ unified: "length", raw: "length" });
 		});
 
 		it("should handle all finish reasons from direct property", () => {
 			const testCases = [
-				{ expected: "stop", input: "stop" },
-				{ expected: "length", input: "length" },
-				{ expected: "length", input: "model_length" },
-				{ expected: "tool-calls", input: "tool_calls" },
-				{ expected: "error", input: "error" },
-				{ expected: "other", input: "other" },
-				{ expected: "unknown", input: "unknown" },
-				{ expected: "stop", input: "invalid_reason" },
+				{ expected: { unified: "stop", raw: "stop" }, input: "stop" },
+				{ expected: { unified: "length", raw: "length" }, input: "length" },
+				{ expected: { unified: "length", raw: "model_length" }, input: "model_length" },
+				{ expected: { unified: "tool-calls", raw: "tool_calls" }, input: "tool_calls" },
+				{ expected: { unified: "error", raw: "error" }, input: "error" },
+				{ expected: { unified: "other", raw: "other" }, input: "other" },
+				{ expected: { unified: "other", raw: "unknown" }, input: "unknown" },
+				{ expected: { unified: "stop", raw: "invalid_reason" }, input: "invalid_reason" },
 			];
 
 			for (const { input, expected } of testCases) {
 				const response = { finish_reason: input };
-				expect(mapWorkersAIFinishReason(response)).toBe(expected);
+				expect(mapWorkersAIFinishReason(response)).toEqual(expected);
 			}
 		});
 
-		it('should default to "stop" when finish_reason is null', () => {
+		it('should default to unified "stop" when finish_reason is null', () => {
 			const response = {
 				finish_reason: null,
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
-		it('should default to "stop" when finish_reason is undefined', () => {
+		it('should default to unified "stop" when finish_reason is undefined', () => {
 			const response = {
 				finish_reason: undefined,
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 	});
 
@@ -228,7 +222,7 @@ describe("mapWorkersAIFinishReason", () => {
 				finish_reason: "stop",
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("length");
+			expect(result).toEqual({ unified: "length", raw: "length" });
 		});
 
 		it("should fall back to direct finish_reason when choices is not an array", () => {
@@ -237,7 +231,7 @@ describe("mapWorkersAIFinishReason", () => {
 				finish_reason: "error",
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("error");
+			expect(result).toEqual({ unified: "error", raw: "error" });
 		});
 
 		it("should fall back to direct finish_reason when choices is null", () => {
@@ -246,21 +240,21 @@ describe("mapWorkersAIFinishReason", () => {
 				finish_reason: "other",
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("other");
+			expect(result).toEqual({ unified: "other", raw: "other" });
 		});
 
-		it('should default to "stop" when object has neither choices nor finish_reason', () => {
+		it('should default to unified "stop" when object has neither choices nor finish_reason', () => {
 			const response = {
 				some_other_property: "value",
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
 		it("should handle empty object", () => {
 			const response = {};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
 		it("should handle complex nested objects without expected properties", () => {
@@ -273,24 +267,24 @@ describe("mapWorkersAIFinishReason", () => {
 				},
 			};
 			const result = mapWorkersAIFinishReason(response);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 	});
 
 	describe("type flexibility", () => {
 		it("should handle array input", () => {
 			const result = mapWorkersAIFinishReason([]);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
 		it("should handle number input", () => {
 			const result = mapWorkersAIFinishReason(42);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 
 		it("should handle boolean input", () => {
 			const result = mapWorkersAIFinishReason(true);
-			expect(result).toBe("stop");
+			expect(result).toEqual({ unified: "stop", raw: undefined });
 		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1551,8 +1551,8 @@ importers:
   packages/workers-ai-provider:
     dependencies:
       '@ai-sdk/provider':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.4
       '@ai-sdk/provider-utils':
         specifier: ^3.0.18
         version: 3.0.18(zod@3.25.76)
@@ -1560,6 +1560,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20251202.0
         version: 4.20251202.0
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.42(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1660,6 +1663,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.17':
+    resolution: {integrity: sha512-mCz50GlBPyBV96Wcll1Mpaz56MVFuHL+bwRWGkIsCJwKAKIfdgUZecFzS3gckpHGaqP5+BYnmyJocIMzUhTQ2A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google-vertex@3.0.86':
     resolution: {integrity: sha512-rdXVXURmmb8A6ma8aud0xqVujbZ9E7Gt68xj6sMw9erZ+HXpBZHJRcx+LYuoLvLoWw9bSLwQJ0QbaXFM68xG4g==}
     engines: {node: '>=18'}
@@ -1726,8 +1735,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/provider-utils@4.0.8':
+    resolution: {integrity: sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.4':
+    resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@2.0.106':
@@ -3409,6 +3428,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -3655,6 +3677,10 @@ packages:
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@5.1.1':
     resolution: {integrity: sha512-WQfkSw0QbQ5aJ2CHYw23ZGkqnRwqKHD/KYsMeTkZzPT4Jcf0DcBxBtwMJxnu6E7oxw5+JC6ZAiePgh28uJ1HBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3783,6 +3809,12 @@ packages:
 
   ai@5.0.106:
     resolution: {integrity: sha512-M5obwavxSJJ3tGlAFqI6eltYNJB0D20X6gIBCFx/KVorb/X1fxVVfiZZpZb+Gslu4340droSOjT0aKQFCarNVg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.42:
+    resolution: {integrity: sha512-o+MVN7HBE4HEnhtN7nBt9WO1iISI6svyWNoOuY6WiXCdHuZfSGN4MUQ3QwjWz1Ue5gtBEcvwX5XFhgAwlPAxxw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6656,6 +6688,13 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.17(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.4
+      '@ai-sdk/provider-utils': 4.0.8(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/google-vertex@3.0.86(zod@3.25.76)':
     dependencies:
       '@ai-sdk/anthropic': 2.0.53(zod@3.25.76)
@@ -6732,11 +6771,22 @@ snapshots:
   '@ai-sdk/provider-utils@3.0.7(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.4
+      '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.4':
     dependencies:
       json-schema: 0.4.0
 
@@ -8232,7 +8282,7 @@ snapshots:
 
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1))(react@19.2.1)':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
       immer: 10.1.1
       redux: 5.0.1
@@ -8406,6 +8456,8 @@ snapshots:
   '@speed-highlight/core@1.2.7': {}
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -8711,6 +8763,8 @@ snapshots:
 
   '@vercel/oidc@3.0.5': {}
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitejs/plugin-react@5.1.1(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.1)(sugarss@5.0.0(postcss@8.5.6))(tsx@4.21.0)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.28.5
@@ -8865,6 +8919,14 @@ snapshots:
       '@ai-sdk/gateway': 2.0.18(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.18(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
+
+  ai@6.0.42(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.17(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.4
+      '@ai-sdk/provider-utils': 4.0.8(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
@@ -10026,7 +10088,7 @@ snapshots:
       '@hapi/pinpoint': 2.0.1
       '@hapi/tlds': 1.1.3
       '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
 
   jose@5.10.0: {}
 


### PR DESCRIPTION
## Summary

- Update `specificationVersion` from `"v2"` to `"v3"`
- Update `@ai-sdk/provider` to `^3.0.0`
- Add `ai@6.0.0` to devDependencies for testing
- Replace all `LanguageModelV2` types with `LanguageModelV3`
- Update finish reason to return `{ unified, raw }` object
- Update usage to return nested `inputTokens`/`outputTokens` objects
- Update warning types to use `SharedV3Warning`
- Update `EmbeddingModelV3` (no longer generic)
- Update tests for V3 format

## Breaking Changes

- `LanguageModelV3FinishReason` now returns `{ unified, raw }` object instead of string
- `LanguageModelV3Usage` now uses nested `inputTokens` and `outputTokens` objects
- Warning types changed to `SharedV3Warning` with `feature` instead of `setting`

This package now requires AI SDK v6. Users need to update their `ai` dependency:

```bash
npm install ai@^6.0.0
```

No API changes are needed - the package maintains the same public interface.

## Test plan

- [x] All existing tests pass (65/66, 1 pre-existing todo)
- [x] Type checking passes
- [x] Updated `map-workersai-finish-reason.test.ts` for V3 object format
- [x] Changeset included

🤖 Generated with [Claude Code](https://claude.ai/code)