### PR TITLE
fix(workers-ai-provider): extract actual finish reason in streaming instead of hardcoded "stop"

### DIFF
--- a/.changeset/fix-streaming-finish-reason.md
+++ b/.changeset/fix-streaming-finish-reason.md
@@ -1,0 +1,13 @@
+---
+"workers-ai-provider": patch
+---
+
+fix(workers-ai-provider): extract actual finish reason in streaming instead of hardcoded "stop"
+
+Previously, the streaming implementation always returned `finishReason: "stop"` regardless of the actual completion reason. This caused:
+- Tool calling scenarios to incorrectly report "stop" instead of "tool-calls"  
+- Multi-turn tool conversations to fail because the AI SDK couldn't detect when tools were requested
+- Length limit scenarios to show "stop" instead of "length"
+- Error scenarios to show "stop" instead of "error"
+
+The fix extracts the actual `finish_reason` from streaming chunks and uses the existing `mapWorkersAIFinishReason()` function to properly map it to the AI SDK's finish reason format. This enables proper multi-turn tool calling and accurate completion status reporting.

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -1028,8 +1028,329 @@ describe("Binding - Streaming Text Tests", () => {
 			}
 		}
 
-		expect(reasoning).toEqual("Okay, the user is asking");
-		expect(content).toEqual("\n\nA cow is cool.");
+	expect(reasoning).toEqual("Okay, the user is asking");
+	expect(content).toEqual("\n\nA cow is cool.");
+});
+});
+
+describe("REST API - Finish Reason Handling", () => {
+	beforeAll(() => server.listen());
+	afterEach(() => server.resetHandlers());
+	afterAll(() => server.close());
+	
+	describe("Finish Reason Extraction", () => {
+	it("should extract 'stop' finish reason from stream", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("stop");
+	});
+
+	it("should extract 'tool-calls' finish reason from stream", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Calling weather"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("tool-calls");
+	});
+
+	it("should extract 'length' finish reason from stream", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"length"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("length");
+	});
+
+	it("should extract 'model_length' and map to 'length'", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"model_length"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("length");
+	});
+
+	it("should extract 'error' finish reason from stream", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{},"finish_reason":"error"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("error");
+	});
+
+	it("should default to 'stop' when no finish_reason in stream", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("stop");
+	});
+
+	it("should handle finish_reason from direct property (not in choices)", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"response":"Hello","finish_reason":null}\n\n`,
+							`data: {"response":" world","finish_reason":"stop"}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		expect(finishReason).toBe("stop");
+	});
+
+	it("should use last finish_reason when multiple chunks provide it", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":"length"}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "test",
+		});
+
+		await result.text;
+		const finishReason = await result.finishReason;
+
+		// Should use the last one
+		expect(finishReason).toBe("stop");
+	});
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes a critical bug in the streaming implementation where  was always hardcoded to "stop" regardless of the actual completion reason from Workers AI.

## Problem

The streaming code in `streaming.ts` line 104 always returned:
```typescript
finishReason: { unified: "stop", raw: "stop" }  // ❌ Hardcoded!
```

This caused:
- ❌ Tool calling scenarios to incorrectly report "stop" instead of "tool-calls"
- ❌ Multi-turn tool conversations to **fail** because AI SDK couldn't detect when tools were requested
- ❌ Length limit scenarios to show "stop" instead of "length"
- ❌ Error scenarios to show "stop" instead of "error"

## Solution

Extract the actual `finish_reason` from streaming chunks and use the existing `mapWorkersAIFinishReason()` function:

```typescript
// Extract finish_reason from chunk (only update if non-null to avoid overwriting)
const choiceFinishReason = chunk?.choices?.[0]?.finish_reason;
const directFinishReason = chunk?.finish_reason;

if (choiceFinishReason != null) {
  finishReason = mapWorkersAIFinishReason(choiceFinishReason);
} else if (directFinishReason != null) {
  finishReason = mapWorkersAIFinishReason(directFinishReason);
}
```

Then use the tracked value:
```typescript
finishReason: finishReason ?? { unified: "stop", raw: "stop" }  // ✅ Actual value!
```

## Testing

### Unit Tests
- ✅ Added 8 comprehensive test cases for all finish reason types
- ✅ Tests for: stop, tool-calls, length, model_length, error, null handling, direct property, multiple chunks
- ✅ All existing tests continue to pass (7/7 test files)

### Integration Testing
- ✅ Tested with GLM-4.7-Flash in production gadgets environment
- ✅ Multi-turn tool calling now works correctly
- ✅ Finish reasons properly reported: "stop" for text, "tool-calls" for tools

## Impact

**Before:**
- Multi-turn tool calling broken
- All streaming completions reported as "stop"

**After:**
- ✅ Multi-turn tool calling works
- ✅ Accurate finish reason reporting
- ✅ AI SDK can properly detect tool execution requests

## Files Changed

- `packages/workers-ai-provider/src/streaming.ts` (+13 lines, 3 modified)
- `packages/workers-ai-provider/test/stream-text.test.ts` (+325 test lines)
- `.changeset/fix-streaming-finish-reason.md` (changeset)

## Related

- Follows the same pattern as non-streaming `doGenerate` which already uses `mapWorkersAIFinishReason()` correctly
- Consistent with OpenAI and Anthropic provider implementations
- Addresses a root cause issue affecting Workers AI model reliability