### PR TITLE
Validate Workers AI config & widen model types

### DIFF
--- a/.changeset/config-validation-and-model-types.md
+++ b/.changeset/config-validation-and-model-types.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Add early config validation to `createWorkersAI` that throws a clear error when neither a binding nor credentials (accountId + apiKey) are provided. Widen all model type parameters (TextGenerationModels, ImageGenerationModels, EmbeddingModels, TranscriptionModels, SpeechModels, RerankingModels) to accept arbitrary strings while preserving autocomplete for known models.

--- a/.changeset/tanstack-config-validation-and-model-types.md
+++ b/.changeset/tanstack-config-validation-and-model-types.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+Add config validation to all Workers AI adapter constructors that throws a clear error when neither a binding, credentials (accountId + apiKey), nor a gateway configuration is provided. Widen all model type parameters (WorkersAiTextModel, WorkersAiImageModel, WorkersAiEmbeddingModel, WorkersAiTranscriptionModel, WorkersAiTTSModel, WorkersAiSummarizeModel) to accept arbitrary strings while preserving autocomplete for known models.

--- a/packages/tanstack-ai/src/adapters/workers-ai-embedding.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-embedding.ts
@@ -11,6 +11,7 @@ import {
 	createGatewayFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 
@@ -18,9 +19,11 @@ import { workersAiRestFetch } from "../utils/workers-ai-rest";
 // Model type derived from @cloudflare/workers-types
 // ---------------------------------------------------------------------------
 
-export type WorkersAiEmbeddingModel = {
-	[K in keyof AiModels]: AiModels[K] extends BaseAiTextEmbeddings ? K : never;
-}[keyof AiModels];
+export type WorkersAiEmbeddingModel =
+	| {
+			[K in keyof AiModels]: AiModels[K] extends BaseAiTextEmbeddings ? K : never;
+	  }[keyof AiModels]
+	| (string & {});
 
 // ---------------------------------------------------------------------------
 // WorkersAiEmbeddingAdapter: embeddings via Workers AI
@@ -36,6 +39,7 @@ export class WorkersAiEmbeddingAdapter {
 	private config: WorkersAiAdapterConfig;
 
 	constructor(config: WorkersAiAdapterConfig, model: WorkersAiEmbeddingModel) {
+		validateWorkersAiConfig(config);
 		this.model = model;
 		this.config = config;
 	}

--- a/packages/tanstack-ai/src/adapters/workers-ai-image.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-image.ts
@@ -8,6 +8,7 @@ import {
 	createGatewayFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 import { binaryToBase64, uint8ArrayToBase64 } from "../utils/binary";
@@ -17,9 +18,9 @@ import type { WorkersAiDirectCredentialsConfig } from "../utils/create-fetcher";
 // Model type derived from @cloudflare/workers-types
 // ---------------------------------------------------------------------------
 
-export type WorkersAiImageModel = {
-	[K in keyof AiModels]: AiModels[K] extends BaseAiTextToImage ? K : never;
-}[keyof AiModels];
+export type WorkersAiImageModel =
+	| { [K in keyof AiModels]: AiModels[K] extends BaseAiTextToImage ? K : never }[keyof AiModels]
+	| (string & {});
 
 // ---------------------------------------------------------------------------
 // WorkersAiImageAdapter: image generation via Workers AI
@@ -32,6 +33,7 @@ export class WorkersAiImageAdapter extends BaseImageAdapter<WorkersAiImageModel>
 
 	constructor(config: WorkersAiAdapterConfig, model: WorkersAiImageModel) {
 		super({}, model);
+		validateWorkersAiConfig(config);
 		this.adapterConfig = config;
 	}
 

--- a/packages/tanstack-ai/src/adapters/workers-ai-summarize.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-summarize.ts
@@ -8,6 +8,7 @@ import {
 	createGatewayFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 
@@ -18,7 +19,7 @@ import { workersAiRestFetch } from "../utils/workers-ai-rest";
 /**
  * Workers AI models that support summarization.
  */
-export type WorkersAiSummarizeModel = "@cf/facebook/bart-large-cnn";
+export type WorkersAiSummarizeModel = "@cf/facebook/bart-large-cnn" | (string & {});
 
 // ---------------------------------------------------------------------------
 // WorkersAiSummarizeAdapter
@@ -30,6 +31,7 @@ export class WorkersAiSummarizeAdapter extends BaseSummarizeAdapter<WorkersAiSum
 
 	constructor(config: WorkersAiAdapterConfig, model: WorkersAiSummarizeModel) {
 		super({}, model);
+		validateWorkersAiConfig(config);
 		this.adapterConfig = config;
 	}
 

--- a/packages/tanstack-ai/src/adapters/workers-ai-transcription.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-transcription.ts
@@ -8,6 +8,7 @@ import {
 	createGatewayFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch, workersAiRestFetchBinary } from "../utils/workers-ai-rest";
 import { uint8ArrayToBase64 } from "../utils/binary";
@@ -31,7 +32,8 @@ export type WorkersAiTranscriptionModel =
 	| "@cf/openai/whisper"
 	| "@cf/openai/whisper-tiny-en"
 	| "@cf/openai/whisper-large-v3-turbo"
-	| "@cf/deepgram/nova-3";
+	| "@cf/deepgram/nova-3"
+	| (string & {});
 
 // ---------------------------------------------------------------------------
 // WorkersAiTranscriptionAdapter
@@ -43,6 +45,7 @@ export class WorkersAiTranscriptionAdapter extends BaseTranscriptionAdapter<Work
 
 	constructor(config: WorkersAiAdapterConfig, model: WorkersAiTranscriptionModel) {
 		super({}, model);
+		validateWorkersAiConfig(config);
 		this.adapterConfig = config;
 	}
 

--- a/packages/tanstack-ai/src/adapters/workers-ai-tts.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-tts.ts
@@ -8,6 +8,7 @@ import {
 	createGatewayFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 import { binaryToBase64, uint8ArrayToBase64 } from "../utils/binary";
@@ -26,7 +27,8 @@ import { binaryToBase64, uint8ArrayToBase64 } from "../utils/binary";
 export type WorkersAiTTSModel =
 	| "@cf/deepgram/aura-1"
 	| "@cf/deepgram/aura-2-en"
-	| "@cf/deepgram/aura-2-es";
+	| "@cf/deepgram/aura-2-es"
+	| (string & {});
 
 // ---------------------------------------------------------------------------
 // WorkersAiTTSAdapter
@@ -38,6 +40,7 @@ export class WorkersAiTTSAdapter extends BaseTTSAdapter<WorkersAiTTSModel> {
 
 	constructor(config: WorkersAiAdapterConfig, model: WorkersAiTTSModel) {
 		super({}, model);
+		validateWorkersAiConfig(config);
 		this.adapterConfig = config;
 	}
 

--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -13,21 +13,26 @@ import {
 	createWorkersAiBindingFetch,
 	isDirectBindingConfig,
 	isDirectCredentialsConfig,
+	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 
 // ---------------------------------------------------------------------------
 // Model types derived from @cloudflare/workers-types
 // ---------------------------------------------------------------------------
 
-export type WorkersAiTextModel = {
-	[K in keyof AiModels]: AiModels[K] extends BaseAiTextGeneration ? K : never;
-}[keyof AiModels];
+export type WorkersAiTextModel =
+	| {
+			[K in keyof AiModels]: AiModels[K] extends BaseAiTextGeneration ? K : never;
+	  }[keyof AiModels]
+	| (string & {});
 
 // ---------------------------------------------------------------------------
 // Helpers: build the right OpenAI client depending on config mode
 // ---------------------------------------------------------------------------
 
 function buildWorkersAiClient(config: WorkersAiAdapterConfig): OpenAI {
+	validateWorkersAiConfig(config);
+
 	if (isDirectBindingConfig(config)) {
 		// Plain binding mode: shim translates OpenAI fetch calls to env.AI.run()
 		return new OpenAI({

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -137,6 +137,29 @@ export function isGatewayConfig(config: WorkersAiAdapterConfig): config is AiGat
 }
 
 // ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that a WorkersAiAdapterConfig contains a valid configuration.
+ * Throws an error if neither a binding, credentials (accountId + apiKey),
+ * nor a gateway configuration is provided.
+ */
+export function validateWorkersAiConfig(config: WorkersAiAdapterConfig): void {
+	if (
+		!isDirectBindingConfig(config) &&
+		!isDirectCredentialsConfig(config) &&
+		!isGatewayConfig(config)
+	) {
+		throw new Error(
+			"Invalid Workers AI configuration: you must provide either a binding (e.g. { binding: env.AI }), " +
+				"credentials ({ accountId, apiKey }), or a gateway configuration ({ binding: env.AI.gateway(id) } " +
+				"or { accountId, gatewayId }).",
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
 // createGatewayFetch -- for routing through AI Gateway
 // ---------------------------------------------------------------------------
 

--- a/packages/tanstack-ai/test/embedding-adapter.test.ts
+++ b/packages/tanstack-ai/test/embedding-adapter.test.ts
@@ -72,4 +72,28 @@ describe("WorkersAiEmbeddingAdapter", () => {
 			globalThis.fetch = originalFetch;
 		}
 	});
+
+	// -----------------------------------------------------------------------
+	// Config validation
+	// -----------------------------------------------------------------------
+
+	it("throws for empty config (no binding, no credentials)", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		expect(
+			() => new WorkersAiEmbeddingAdapter({} as any, "@cf/baai/bge-base-en-v1.5" as any),
+		).toThrow(/Invalid Workers AI configuration/);
+	});
+
+	it("accepts an arbitrary model string", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue({ shape: [1, 768], data: [[0.1]] }),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiEmbeddingAdapter(
+			{ binding: mockBinding },
+			"@cf/my-org/custom-embedding-model",
+		);
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/tanstack-ai/test/image-adapter.test.ts
+++ b/packages/tanstack-ai/test/image-adapter.test.ts
@@ -327,4 +327,32 @@ describe("WorkersAiImageAdapter", () => {
 		expect(callArgs.num_steps).toBe(4);
 		expect(callArgs.guidance).toBe(7.5);
 	});
+
+	// -----------------------------------------------------------------------
+	// Config validation
+	// -----------------------------------------------------------------------
+
+	it("throws for empty config (no binding, no credentials)", async () => {
+		const { WorkersAiImageAdapter } = await import("../src/adapters/workers-ai-image");
+		expect(
+			() =>
+				new WorkersAiImageAdapter(
+					{} as any,
+					"@cf/stabilityai/stable-diffusion-xl-base-1.0" as any,
+				),
+		).toThrow(/Invalid Workers AI configuration/);
+	});
+
+	it("accepts an arbitrary model string", async () => {
+		const { WorkersAiImageAdapter } = await import("../src/adapters/workers-ai-image");
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(new Uint8Array([0])),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiImageAdapter(
+			{ binding: mockBinding },
+			"@cf/my-org/custom-image-model",
+		);
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/tanstack-ai/test/summarize-adapter.test.ts
+++ b/packages/tanstack-ai/test/summarize-adapter.test.ts
@@ -292,4 +292,28 @@ describe("WorkersAiSummarizeAdapter", () => {
 		expect(adapter.kind).toBe("summarize");
 		expect(adapter.model).toBe("@cf/facebook/bart-large-cnn");
 	});
+
+	// -----------------------------------------------------------------------
+	// Config validation
+	// -----------------------------------------------------------------------
+
+	it("throws for empty config (no binding, no credentials)", async () => {
+		const { WorkersAiSummarizeAdapter } = await import("../src/adapters/workers-ai-summarize");
+		expect(
+			() => new WorkersAiSummarizeAdapter({} as any, "@cf/facebook/bart-large-cnn"),
+		).toThrow(/Invalid Workers AI configuration/);
+	});
+
+	it("accepts an arbitrary model string", async () => {
+		const { WorkersAiSummarizeAdapter } = await import("../src/adapters/workers-ai-summarize");
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue({ summary: "ok" }),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiSummarizeAdapter(
+			{ binding: mockBinding },
+			"@cf/my-org/custom-summarizer",
+		);
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/tanstack-ai/test/transcription-adapter.test.ts
+++ b/packages/tanstack-ai/test/transcription-adapter.test.ts
@@ -354,4 +354,30 @@ describe("WorkersAiTranscriptionAdapter", () => {
 		expect(adapter.kind).toBe("transcription");
 		expect(adapter.model).toBe("@cf/deepgram/nova-3");
 	});
+
+	// -----------------------------------------------------------------------
+	// Config validation
+	// -----------------------------------------------------------------------
+
+	it("throws for empty config (no binding, no credentials)", async () => {
+		const { WorkersAiTranscriptionAdapter } =
+			await import("../src/adapters/workers-ai-transcription");
+		expect(() => new WorkersAiTranscriptionAdapter({} as any, "@cf/openai/whisper")).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("accepts an arbitrary model string", async () => {
+		const { WorkersAiTranscriptionAdapter } =
+			await import("../src/adapters/workers-ai-transcription");
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue({ text: "hello" }),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiTranscriptionAdapter(
+			{ binding: mockBinding },
+			"@cf/my-org/custom-whisper",
+		);
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/tanstack-ai/test/tts-adapter.test.ts
+++ b/packages/tanstack-ai/test/tts-adapter.test.ts
@@ -349,4 +349,28 @@ describe("WorkersAiTTSAdapter", () => {
 		expect(adapter.kind).toBe("tts");
 		expect(adapter.model).toBe("@cf/deepgram/aura-1");
 	});
+
+	// -----------------------------------------------------------------------
+	// Config validation
+	// -----------------------------------------------------------------------
+
+	it("throws for empty config (no binding, no credentials)", async () => {
+		const { WorkersAiTTSAdapter } = await import("../src/adapters/workers-ai-tts");
+		expect(() => new WorkersAiTTSAdapter({} as any, "@cf/deepgram/aura-1")).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("accepts an arbitrary model string", async () => {
+		const { WorkersAiTTSAdapter } = await import("../src/adapters/workers-ai-tts");
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(new Uint8Array([0])),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiTTSAdapter(
+			{ binding: mockBinding },
+			"@cf/my-org/custom-tts-model",
+		);
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/tanstack-ai/test/workers-ai-adapter.test.ts
+++ b/packages/tanstack-ai/test/workers-ai-adapter.test.ts
@@ -901,4 +901,22 @@ describe("WorkersAiTextAdapter config modes", () => {
 
 		expect(adapter).toBeDefined();
 	});
+
+	it("should throw for empty config (no binding, no credentials)", () => {
+		expect(() => new WorkersAiTextAdapter(MODEL, {} as any)).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("should throw for config with only accountId (missing apiKey)", () => {
+		expect(() => new WorkersAiTextAdapter(MODEL, { accountId: "abc" } as any)).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("should accept an arbitrary model string", () => {
+		const binding = createMockBinding({ response: "ok" });
+		const adapter = new WorkersAiTextAdapter("@cf/my-org/custom-model-v1", { binding });
+		expect(adapter).toBeDefined();
+	});
 });

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -167,7 +167,11 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		const inputs = this.buildRunInputs(args, messages, images);
 		const runOptions = this.getRunOptions();
 
-		const output = await this.config.binding.run(args.model, inputs, runOptions);
+		const output = await this.config.binding.run(
+			args.model as keyof AiModels,
+			inputs,
+			runOptions,
+		);
 
 		if (output instanceof ReadableStream) {
 			throw new Error(
@@ -193,7 +197,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 				},
 				...processToolCalls(outputRecord),
 			],
-			usage: mapWorkersAIUsage(output),
+			usage: mapWorkersAIUsage(output as Record<string, unknown>),
 			warnings,
 		};
 	}
@@ -207,7 +211,11 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		const inputs = this.buildRunInputs(args, messages, images, { stream: true });
 		const runOptions = this.getRunOptions();
 
-		const response = await this.config.binding.run(args.model, inputs, runOptions);
+		const response = await this.config.binding.run(
+			args.model as keyof AiModels,
+			inputs,
+			runOptions,
+		);
 
 		// If the binding returned a stream, pipe it through the SSE mapper
 		if (response instanceof ReadableStream) {
@@ -261,7 +269,7 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 					controller.enqueue({
 						type: "finish",
 						finishReason: mapWorkersAIFinishReason(outputRecord),
-						usage: mapWorkersAIUsage(response),
+						usage: mapWorkersAIUsage(response as Record<string, unknown>),
 					});
 					controller.close();
 				},

--- a/packages/workers-ai-provider/src/workersai-embedding-model.ts
+++ b/packages/workers-ai-provider/src/workersai-embedding-model.ts
@@ -70,7 +70,7 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV3 {
 		} = this.settings;
 
 		const response = await this.config.binding.run(
-			this.modelId,
+			this.modelId as keyof AiModels,
 			{
 				text: values,
 			},
@@ -81,7 +81,7 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV3 {
 		);
 
 		return {
-			embeddings: response.data,
+			embeddings: (response as { data: number[][] }).data,
 			warnings: [],
 		};
 	}

--- a/packages/workers-ai-provider/src/workersai-image-model.ts
+++ b/packages/workers-ai-provider/src/workersai-image-model.ts
@@ -47,7 +47,7 @@ export class WorkersAIImageModel implements ImageModelV3 {
 		}
 
 		const generateImage = async () => {
-			const output = (await this.config.binding.run(this.modelId, {
+			const output = (await this.config.binding.run(this.modelId as keyof AiModels, {
 				height,
 				prompt: prompt ?? "",
 				seed,

--- a/packages/workers-ai-provider/src/workersai-models.ts
+++ b/packages/workers-ai-provider/src/workersai-models.ts
@@ -1,46 +1,60 @@
 /**
  * The names of the BaseAiTextGeneration models.
+ *
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
-export type TextGenerationModels = Exclude<
-	value2key<AiModels, BaseAiTextGeneration>,
-	value2key<AiModels, BaseAiTextToImage>
->; // This needs to be fixed to allow more models
+export type TextGenerationModels =
+	| Exclude<value2key<AiModels, BaseAiTextGeneration>, value2key<AiModels, BaseAiTextToImage>>
+	| (string & {});
 
 /*
  * The names of the BaseAiTextToImage models.
+ *
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
-export type ImageGenerationModels = value2key<AiModels, BaseAiTextToImage>;
+export type ImageGenerationModels = value2key<AiModels, BaseAiTextToImage> | (string & {});
 
 /**
  * The names of the BaseAiTextToEmbeddings models.
+ *
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
-export type EmbeddingModels = value2key<AiModels, BaseAiTextEmbeddings>;
+export type EmbeddingModels = value2key<AiModels, BaseAiTextEmbeddings> | (string & {});
 
 /**
  * Workers AI models that support speech-to-text transcription.
  *
  * Includes Whisper variants from `@cloudflare/workers-types` plus
  * Deepgram partner models that may not be in the typed interface yet.
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
 export type TranscriptionModels =
 	| value2key<AiModels, BaseAiAutomaticSpeechRecognition>
-	| "@cf/deepgram/nova-3";
+	| "@cf/deepgram/nova-3"
+	| (string & {});
 
 /**
  * Workers AI models that support text-to-speech.
  *
  * Includes models from `@cloudflare/workers-types` plus Deepgram partner
  * models that may not be in the typed interface yet.
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
 export type SpeechModels =
 	| value2key<AiModels, BaseAiTextToSpeech>
 	| "@cf/deepgram/aura-1"
 	| "@cf/deepgram/aura-2-en"
-	| "@cf/deepgram/aura-2-es";
+	| "@cf/deepgram/aura-2-es"
+	| (string & {});
 
 /**
  * Workers AI models that support reranking.
+ *
+ * Accepts any string at runtime, but provides autocomplete for known models.
  */
-export type RerankingModels = "@cf/baai/bge-reranker-base" | "@cf/baai/bge-reranker-v2-m3";
+export type RerankingModels =
+	| "@cf/baai/bge-reranker-base"
+	| "@cf/baai/bge-reranker-v2-m3"
+	| (string & {});
 
 type value2key<T, V> = { [K in keyof T]: T[K] extends V ? K : never }[keyof T];

--- a/packages/workers-ai-provider/test/create-workers-ai.test.ts
+++ b/packages/workers-ai-provider/test/create-workers-ai.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWorkersAI } from "../src/index";
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+describe("createWorkersAI config validation", () => {
+	it("accepts a binding config", () => {
+		const binding = {
+			run: vi.fn().mockResolvedValue({ response: "ok" }),
+		};
+		const provider = createWorkersAI({ binding } as any);
+		expect(provider).toBeDefined();
+		expect(typeof provider).toBe("function");
+	});
+
+	it("accepts credentials config (accountId + apiKey)", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		expect(provider).toBeDefined();
+		expect(typeof provider).toBe("function");
+	});
+
+	it("throws for empty config (no binding, no credentials)", () => {
+		expect(() => createWorkersAI({} as any)).toThrow(/Invalid Workers AI configuration/);
+	});
+
+	it("throws for config with only accountId (missing apiKey)", () => {
+		expect(() => createWorkersAI({ accountId: "abc" } as any)).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("throws for config with only apiKey (missing accountId)", () => {
+		expect(() => createWorkersAI({ apiKey: "key" } as any)).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("throws for config with unrelated properties", () => {
+		expect(() => createWorkersAI({ foo: "bar" } as any)).toThrow(
+			/Invalid Workers AI configuration/,
+		);
+	});
+
+	it("error message mentions binding and credentials", () => {
+		try {
+			createWorkersAI({} as any);
+		} catch (e) {
+			expect((e as Error).message).toContain("binding");
+			expect((e as Error).message).toContain("credentials");
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Arbitrary model strings (string & {} widening)
+// ---------------------------------------------------------------------------
+
+describe("createWorkersAI model type flexibility", () => {
+	it("accepts a known model name", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider("@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+	});
+
+	it("accepts an arbitrary (non-listed) model string for chat", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider("@cf/my-org/custom-model-v1");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-model-v1");
+	});
+
+	it("accepts an arbitrary model string for provider.chat()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.chat("@cf/my-org/custom-chat-model");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-chat-model");
+	});
+
+	it("accepts an arbitrary model string for provider.image()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.image("@cf/my-org/custom-image-model");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-image-model");
+	});
+
+	it("accepts an arbitrary model string for provider.embedding()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.embedding("@cf/my-org/custom-embedding-model");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-embedding-model");
+	});
+
+	it("accepts an arbitrary model string for provider.transcription()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.transcription("@cf/my-org/custom-whisper");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-whisper");
+	});
+
+	it("accepts an arbitrary model string for provider.speech()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.speech("@cf/my-org/custom-tts");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-tts");
+	});
+
+	it("accepts an arbitrary model string for provider.reranking()", () => {
+		const provider = createWorkersAI({
+			accountId: "test-account",
+			apiKey: "test-key",
+		});
+		const model = provider.reranking("@cf/my-org/custom-reranker");
+		expect(model).toBeDefined();
+		expect(model.modelId).toBe("@cf/my-org/custom-reranker");
+	});
+});


### PR DESCRIPTION
Add early config validation for Workers AI (validateWorkersAiConfig) that throws a clear error when neither a binding nor credentials/gateway are provided, and wire it into adapter constructors and client builders. Widen many Workers AI model type unions to accept arbitrary string values (while preserving autocomplete for known models). Apply small runtime type casts for binding.run calls and response shapes in workers-ai-provider. Add unit tests for config detection, validation, and arbitrary model strings, plus .changeset notes.