### PR TITLE
Fix parameter names for Google OAuth request

### DIFF
--- a/demos/remote-mcp-google-oauth/src/utils.ts
+++ b/demos/remote-mcp-google-oauth/src/utils.ts
@@ -69,11 +69,11 @@ export async function fetchUpstreamAuthToken({
 
 	const resp = await fetch(upstreamUrl, {
 		body: new URLSearchParams({
-			clientId,
-			clientSecret,
+			client_id: clientId,
+			client_secret: clientSecret,
 			code,
-			grantType,
-			redirectUri,
+			grant_type: grantType,
+			redirect_uri: redirectUri,
 		}).toString(),
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
The Google oauth currently gives an `invalid_client` error becuase the parameter names used in the token request are wrong. This PR fixes that.