### PR TITLE
fix(tanstack-ai): update @tanstack/* dependencies to latest versions

### DIFF
--- a/packages/tanstack-ai/package.json
+++ b/packages/tanstack-ai/package.json
@@ -103,21 +103,21 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260227.0",
 		"@microsoft/api-extractor": "^7.57.1",
-		"@tanstack/ai": "^0.5.1",
+		"@tanstack/ai": "^0.6.0",
 		"dotenv": "^17.3.1"
 	},
 	"peerDependencies": {
-		"@tanstack/ai": "^0.5.0"
+		"@tanstack/ai": "^0.6.0"
 	},
 	"optionalDependencies": {
 		"@anthropic-ai/sdk": "^0.78.0",
 		"@google/genai": "^1.42.0",
 		"@openrouter/sdk": "^0.8.0",
-		"@tanstack/ai-anthropic": "^0.5.0",
-		"@tanstack/ai-gemini": "^0.5.0",
-		"@tanstack/ai-grok": "^0.5.0",
-		"@tanstack/ai-openai": "^0.5.0",
-		"@tanstack/ai-openrouter": "^0.5.1"
+		"@tanstack/ai-anthropic": "^0.6.0",
+		"@tanstack/ai-gemini": "^0.7.0",
+		"@tanstack/ai-grok": "^0.6.0",
+		"@tanstack/ai-openai": "^0.6.0",
+		"@tanstack/ai-openrouter": "^0.6.0"
 	},
 	"packageManager": "pnpm@10.30.1"
 }


### PR DESCRIPTION
## Summary

- Updates all `@tanstack/*` dependencies in `@cloudflare/tanstack-ai` from `^0.5.x` to their latest minor versions
- Since these are **0.x semver packages**, `^0.5.0` resolves to `>=0.5.0 <0.6.0`, preventing consumers from getting newer minor versions with critical fixes

### Changes

| Package | Before | After |
|---------|--------|-------|
| `@tanstack/ai` | `^0.5.0` | `^0.6.0` |
| `@tanstack/ai-anthropic` | `^0.5.0` | `^0.6.0` |
| `@tanstack/ai-gemini` | `^0.5.0` | `^0.7.0` |
| `@tanstack/ai-grok` | `^0.5.0` | `^0.6.0` |
| `@tanstack/ai-openai` | `^0.5.0` | `^0.6.0` |
| `@tanstack/ai-openrouter` | `^0.5.1` | `^0.6.0` |

### Motivation

`@tanstack/ai-gemini@0.7.0` added an `isGeminiImageModel()` check that routes Gemini native image models (like `gemini-3-pro-image-preview`) to `:generateContent` instead of `:predict`. Without this fix, `createGeminiImage()` with these models fails with:

```
models/gemini-3-pro-image-preview is not found for API version v1beta, or is not supported for predict
```

Because `@cloudflare/tanstack-ai` declares `"@tanstack/ai-gemini": "^0.5.0"` in `optionalDependencies`, package managers install `0.5.x` in a nested `node_modules/` even when the consumer has `0.7.0` at root — the semver range for 0.x doesn't allow crossing minor versions.

The workaround is adding `overrides`/`resolutions` in the consumer project, but the proper fix is updating the ranges here.

## Test plan

- [ ] Verify `pnpm install` resolves all packages correctly
- [ ] Run existing tests: `pnpm test:ci`
- [ ] Test `createGeminiImage("gemini-3-pro-image-preview", ...)` + `generateImage()` calls `:generateContent` (not `:predict`)