### PR TITLE
fix: support both reasoning_content and reasoning fields

### DIFF
--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -377,7 +377,9 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 
 				// Reasoning content (used by models like QwQ, DeepSeek R1, Kimi K2.5)
 				// The OpenAI SDK doesn't type this field, but models send it as an extension.
-				const reasoningContent = (delta as Record<string, unknown>).reasoning_content as
+				const reasoningContent = ((delta as Record<string, unknown>)
+						.reasoning_content ??
+						(delta as Record<string, unknown>).reasoning) as
 					| string
 					| undefined;
 				if (reasoningContent) {

--- a/packages/tanstack-ai/test/workers-ai-adapter.test.ts
+++ b/packages/tanstack-ai/test/workers-ai-adapter.test.ts
@@ -703,6 +703,38 @@ describe("WorkersAiTextAdapter reasoning events", () => {
 		expect(stepFinished[1].stepId).toBe(stepStarted.stepId);
 	});
 
+	it("should emit STEP_STARTED and STEP_FINISHED for reasoning field (without _content suffix)", async () => {
+		const binding = createReasoningBinding([
+			'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning":"Let me think"},"finish_reason":null}],"model":"@cf/qwen/qwq-32b"}\n\n',
+			'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning":" about this"},"finish_reason":null}],"model":"@cf/qwen/qwq-32b"}\n\n',
+			'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello!"},"finish_reason":null}],"model":"@cf/qwen/qwq-32b"}\n\n',
+			'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"model":"@cf/qwen/qwq-32b"}\n\n',
+		]);
+		const adapter = new WorkersAiTextAdapter("@cf/qwen/qwq-32b" as WorkersAiTextModel, {
+			binding,
+		});
+
+		const chunks = await collectChunks(
+			adapter.chatStream({
+				model: "@cf/qwen/qwq-32b" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Think about this" }],
+			} as any),
+		);
+
+		// Should have STEP_STARTED
+		const stepStarted = chunks.find((c: any) => c.type === "STEP_STARTED");
+		expect(stepStarted).toBeDefined();
+		expect(stepStarted.stepType).toBe("thinking");
+
+		// Should have STEP_FINISHED events with incremental reasoning
+		const stepFinished = chunks.filter((c: any) => c.type === "STEP_FINISHED");
+		expect(stepFinished).toHaveLength(2);
+		expect(stepFinished[0].delta).toBe("Let me think");
+		expect(stepFinished[0].content).toBe("Let me think");
+		expect(stepFinished[1].delta).toBe(" about this");
+		expect(stepFinished[1].content).toBe("Let me think about this");
+	});
+
 	it("should emit STEP_STARTED only once for multiple reasoning tokens", async () => {
 		const binding = createReasoningBinding([
 			'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"A"},"finish_reason":null}],"model":"@cf/qwen/qwq-32b"}\n\n',

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -163,7 +163,9 @@ export function getMappedStream(
 				if (choices?.[0]?.delta) {
 					const delta = choices[0].delta;
 
-					const reasoningDelta = delta.reasoning_content as string | undefined;
+					const reasoningDelta = (delta.reasoning_content ?? delta.reasoning) as
+					| string
+					| undefined;
 					if (reasoningDelta && reasoningDelta.length > 0) {
 						if (!reasoningId) {
 							reasoningId = generateId();

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -183,9 +183,12 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 
 		const outputRecord = output as Record<string, unknown>;
 		const choices = outputRecord.choices as
-			| Array<{ message?: { reasoning_content?: string } }>
+			| Array<{
+					message?: { reasoning_content?: string; reasoning?: string };
+			  }>
 			| undefined;
-		const reasoningContent = choices?.[0]?.message?.reasoning_content;
+		const reasoningContent =
+			choices?.[0]?.message?.reasoning_content ?? choices?.[0]?.message?.reasoning;
 
 		return {
 			finishReason: mapWorkersAIFinishReason(outputRecord),
@@ -230,9 +233,12 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		// when stream:true is requested. Wrap the complete response as a stream.
 		const outputRecord = response as Record<string, unknown>;
 		const choices = outputRecord.choices as
-			| Array<{ message?: { reasoning_content?: string } }>
+			| Array<{
+					message?: { reasoning_content?: string; reasoning?: string };
+			  }>
 			| undefined;
-		const reasoningContent = choices?.[0]?.message?.reasoning_content;
+		const reasoningContent =
+			choices?.[0]?.message?.reasoning_content ?? choices?.[0]?.message?.reasoning;
 
 		let textId: string | null = null;
 		let reasoningId: string | null = null;

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -327,6 +327,59 @@ describe("REST API - Streaming Text Tests", () => {
 		expect(reasoning).toEqual("Okay, the user is asking");
 		expect(content).toEqual("A **cow is cool");
 	});
+
+	it("should handle reasoning field (without _content suffix) if present", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}\n\n`,
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[{"index":0,"delta":{"reasoning":"Think"},"logprobs":null,"finish_reason":null}]}\n\n`,
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[{"index":0,"delta":{"reasoning":"ing..."},"logprobs":null,"finish_reason":null}]}\n\n`,
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}\n\n`,
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[{"index":0,"delta":{"content":""},"logprobs":null,"finish_reason":"stop"}]}\n\n`,
+							`data: {"id":"chatcmpl-r1","object":"chat.completion.chunk","created":1751570976,"model":"${TEST_MODEL}","choices":[]}\n\n`,
+							"[DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			messages: [{ role: "user", content: "hello" }],
+		});
+
+		let reasoning = "";
+		let content = "";
+
+		for await (const chunk of result.fullStream) {
+			if (chunk.type === "reasoning-delta") {
+				reasoning += chunk.text;
+			}
+			if (chunk.type === "text-delta") {
+				content += chunk.text;
+			}
+		}
+
+		expect(reasoning).toEqual("Thinking...");
+		expect(content).toEqual("Hello");
+	});
 });
 
 describe("Binding - Streaming Text Tests", () => {
@@ -869,6 +922,101 @@ describe("Binding - Streaming Text Tests", () => {
 
 		expect(reasoning).toEqual("Okay, the user is asking");
 		expect(content).toEqual("\n\nA cow is cool.");
+	});
+
+	it("should handle reasoning field (without _content suffix) if present", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							id: "chatcmpl-r2",
+							object: "chat.completion.chunk",
+							created: 1751559514,
+							model: TEST_MODEL,
+							choices: [
+								{
+									index: 0,
+									delta: { reasoning: "Think" },
+									logprobs: null,
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							id: "chatcmpl-r2",
+							object: "chat.completion.chunk",
+							created: 1751559514,
+							model: TEST_MODEL,
+							choices: [
+								{
+									index: 0,
+									delta: { reasoning: "ing..." },
+									logprobs: null,
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							id: "chatcmpl-r2",
+							object: "chat.completion.chunk",
+							created: 1751559514,
+							model: TEST_MODEL,
+							choices: [
+								{
+									index: 0,
+									delta: { content: "Hello" },
+									logprobs: null,
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							id: "chatcmpl-r2",
+							object: "chat.completion.chunk",
+							created: 1751559514,
+							model: TEST_MODEL,
+							choices: [
+								{
+									index: 0,
+									delta: { content: "" },
+									logprobs: null,
+									finish_reason: "stop",
+								},
+							],
+						},
+						{
+							id: "chatcmpl-r2",
+							object: "chat.completion.chunk",
+							created: 1751559514,
+							model: TEST_MODEL,
+							choices: [],
+						},
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			messages: [{ role: "user", content: "hello" }],
+		});
+
+		let reasoning = "";
+		let content = "";
+
+		for await (const chunk of result.fullStream) {
+			if (chunk.type === "reasoning-delta") {
+				reasoning += chunk.text;
+			}
+			if (chunk.type === "text-delta") {
+				content += chunk.text;
+			}
+		}
+
+		expect(reasoning).toEqual("Thinking...");
+		expect(content).toEqual("Hello");
 	});
 });
 
@@ -1577,6 +1725,41 @@ describe("Graceful Degradation", () => {
 
 		expect(text).toBe("The answer is 42.");
 		expect(reasoning).toBe("Let me think about this...");
+	});
+
+	it("should handle non-streaming response with reasoning field (without _content suffix)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return {
+						choices: [
+							{
+								message: {
+									reasoning: "Let me reason about this...",
+									content: "The answer is 7.",
+								},
+								finish_reason: "stop",
+							},
+						],
+					};
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Think carefully",
+		});
+
+		let text = "";
+		let reasoning = "";
+		for await (const chunk of result.fullStream) {
+			if (chunk.type === "text-delta") text += chunk.text;
+			if (chunk.type === "reasoning-delta") reasoning += chunk.text;
+		}
+
+		expect(text).toBe("The answer is 7.");
+		expect(reasoning).toBe("Let me reason about this...");
 	});
 });
 

--- a/packages/workers-ai-provider/test/text-generation.test.ts
+++ b/packages/workers-ai-provider/test/text-generation.test.ts
@@ -335,4 +335,53 @@ describe("Binding - Text Generation Tests", () => {
 		expect(result.reasoningText).toBe("Okay, the user is asking");
 		expect(result.text).toBe("A **cow** is a domesticated, herbivorous mammal");
 	});
+
+	it("should handle reasoning field (without _content suffix)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (_modelName: string, _inputs: any, _options?: any) => {
+					return {
+						id: "chatcmpl-r3",
+						object: "chat.completion",
+						created: 1751560708,
+						model: TEST_MODEL,
+						choices: [
+							{
+								index: 0,
+								message: {
+									role: "assistant",
+									reasoning: "Let me think step by step",
+									content: "The answer is 42",
+									tool_calls: [],
+								},
+								logprobs: null,
+								finish_reason: "stop",
+								stop_reason: null,
+							},
+						],
+						usage: {
+							prompt_tokens: 1,
+							completion_tokens: 2,
+							total_tokens: 3,
+						},
+					};
+				},
+			},
+		});
+
+		const model = workersai(TEST_MODEL);
+
+		const result = await generateText({
+			model: model,
+			messages: [
+				{
+					role: "user",
+					content: "what is the meaning of life?",
+				},
+			],
+		});
+
+		expect(result.reasoningText).toBe("Let me think step by step");
+		expect(result.text).toBe("The answer is 42");
+	});
 });


### PR DESCRIPTION
## Summary

- Support both `reasoning_content` and `reasoning` fields when extracting reasoning/thinking output from the API response, with `reasoning_content` taking precedence
- Fixes the AI playground at playground.ai.cloudflare.com not displaying reasoning output from models like GLM 4.7 Flash and QwQ 32B

## Context

vLLM is deprecating `reasoning_content` in favor of `reasoning` ([vllm-project/vllm#33402 — Remove deprecated `reasoning_content` message field](https://github.com/vllm-project/vllm/pull/33402)). The Workers AI API can return either field depending on the model and vLLM version. Previously, the provider packages only checked for `reasoning_content`, so when the API returned `reasoning` instead, the reasoning output was silently dropped.

## Changes

**`workers-ai-provider`** (Vercel AI SDK provider):
- `streaming.ts` — Read `delta.reasoning_content ?? delta.reasoning` in SSE stream parser
- `workersai-chat-language-model.ts` — Read both fields in `doGenerate` (non-streaming) and `doStream` fallback paths
- Added tests for the `reasoning` field in both REST and binding streaming paths, non-streaming `generateText`, and non-streaming `doStream` fallback

**`@cloudflare/tanstack-ai`** (TanStack AI adapter):
- `workers-ai.ts` — Read `delta.reasoning_content ?? delta.reasoning` in `chatStream`
- Added test for the `reasoning` field emitting `STEP_STARTED`/`STEP_FINISHED` events