### PR TITLE
Update MCP Endpoint in README.md

### DIFF
--- a/demos/remote-mcp-cf-access/README.md
+++ b/demos/remote-mcp-cf-access/README.md
@@ -47,7 +47,7 @@ Test the remote server using [Inspector](https://modelcontextprotocol.io/docs/to
 npx @modelcontextprotocol/inspector@latest
 ```
 
-Enter `https://mcp-access-oauth.<your-subdomain>.workers.dev/sse` and hit connect. Once you go through the authentication flow, you'll see the Tools working:
+Enter `https://mcp-access-oauth.<your-subdomain>.workers.dev/mcp` and hit connect. Once you go through the authentication flow, you'll see the Tools working:
 
 <img width="640" alt="image" src="https://github.com/user-attachments/assets/7973f392-0a9d-4712-b679-6dd23f824287" />
 
@@ -77,7 +77,7 @@ Replace the content with the following configuration. Once you restart Claude De
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp-access-oauth.<your-subdomain>.workers.dev/sse"
+        "https://mcp-access-oauth.<your-subdomain>.workers.dev/mcp"
       ]
     }
   }
@@ -109,7 +109,7 @@ COOKIE_ENCRYPTION_KEY=COOKIE_ENCRYPTION_KEY
 Run the server locally to make it available at `http://localhost:8788`
 `wrangler dev`
 
-To test the local server, enter `http://localhost:8788/sse` into Inspector and hit connect. Once you follow the prompts, you'll be able to "List Tools".
+To test the local server, enter `http://localhost:8788/mcp` into Inspector and hit connect. Once you follow the prompts, you'll be able to "List Tools".
 
 #### Using Claude and other MCP Clients
 
@@ -117,7 +117,7 @@ When using Claude to connect to your remote MCP server, you may see some error m
 
 #### Using Cursor and other MCP Clients
 
-To connect Cursor with your MCP server, choose `Type`: "Command" and in the `Command` field, combine the command and args fields into one (e.g. `npx mcp-remote https://<your-worker-name>.<your-subdomain>.workers.dev/sse`).
+To connect Cursor with your MCP server, choose `Type`: "Command" and in the `Command` field, combine the command and args fields into one (e.g. `npx mcp-remote https://<your-worker-name>.<your-subdomain>.workers.dev/mcp`).
 
 Note that while Cursor supports HTTP+SSE servers, it doesn't support authentication, so you still need to use `mcp-remote` (and to use a STDIO server, not an HTTP one).
 


### PR DESCRIPTION
Updated MCP endpoint in README.md to /mcp instead of /sse as per 2273742ff4ec854695abe94910dd622c39c4ffdb

This PR fixes https://github.com/cloudflare/ai/issues/441