### PR TITLE
fix(workers-ai-provider): remove tool_call_id sanitization

### DIFF
--- a/.changeset/remove-sanitize-tool-call-id.md
+++ b/.changeset/remove-sanitize-tool-call-id.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Remove tool_call_id sanitization that truncated IDs to 9 alphanumeric chars, which caused all tool call IDs to collide after round-trip

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -7,30 +7,10 @@ import type { WorkersAIChatPrompt } from "./workersai-chat-prompt";
 // ---------------------------------------------------------------------------
 
 /**
- * Strip non-alphanumeric characters and ensure the ID is exactly 9 chars,
- * matching Workers AI binding's `[a-zA-Z0-9]{9}` validation pattern.
- *
- * The Workers AI binding validates `tool_call_id` with a strict regex, but
- * generates IDs like `chatcmpl-tool-875d3ec6179676ae` (with dashes, >9 chars).
- * Those IDs are rejected when sent back in a follow-up request.
- *
- * Once Workers AI fixes the validation, this becomes an idempotent no-op for
- * IDs that already match the pattern.
- */
-export function sanitizeToolCallId(id: string): string {
-	const alphanumeric = id.replace(/[^a-zA-Z0-9]/g, "");
-	return alphanumeric.slice(0, 9).padEnd(9, "0");
-}
-
-/**
  * Normalize messages before passing to the Workers AI binding.
  *
  * The binding has strict schema validation that differs from the OpenAI API:
  * - `content` must be a string (not null)
- * - `tool_call_id` must match `[a-zA-Z0-9]{9}` pattern
- *
- * This patches fields so the full tool-call round-trip works even though
- * the binding's own generated IDs may not pass its own validation.
  */
 export function normalizeMessagesForBinding(messages: WorkersAIChatPrompt): WorkersAIChatPrompt {
 	return messages.map((msg) => {
@@ -39,19 +19,6 @@ export function normalizeMessagesForBinding(messages: WorkersAIChatPrompt): Work
 		// content: null → content: ""
 		if (normalized.content === null || normalized.content === undefined) {
 			(normalized as { content: string }).content = "";
-		}
-
-		// Normalize tool_call_id on tool messages
-		if ("tool_call_id" in normalized && typeof normalized.tool_call_id === "string") {
-			normalized.tool_call_id = sanitizeToolCallId(normalized.tool_call_id);
-		}
-
-		// Normalize tool_calls[].id on assistant messages
-		if ("tool_calls" in normalized && Array.isArray(normalized.tool_calls)) {
-			normalized.tool_calls = normalized.tool_calls.map((tc) => ({
-				...tc,
-				id: sanitizeToolCallId(tc.id),
-			}));
 		}
 
 		return normalized;

--- a/packages/workers-ai-provider/test/utils.test.ts
+++ b/packages/workers-ai-provider/test/utils.test.ts
@@ -3,41 +3,10 @@ import {
 	processPartialToolCalls,
 	processToolCalls,
 	processText,
-	sanitizeToolCallId,
 	normalizeMessagesForBinding,
 	prepareToolsAndToolChoice,
 	createRun,
 } from "../src/utils";
-
-// ---------------------------------------------------------------------------
-// sanitizeToolCallId
-// ---------------------------------------------------------------------------
-
-describe("sanitizeToolCallId", () => {
-	it("should strip non-alphanumeric characters and truncate to 9 chars", () => {
-		expect(sanitizeToolCallId("chatcmpl-tool-875d3ec6179676ae")).toBe("chatcmplt");
-	});
-
-	it("should pad short IDs with zeros", () => {
-		expect(sanitizeToolCallId("abc")).toBe("abc000000");
-	});
-
-	it("should pass through already-valid 9-char alphanumeric IDs", () => {
-		expect(sanitizeToolCallId("abcdef123")).toBe("abcdef123");
-	});
-
-	it("should handle empty string", () => {
-		expect(sanitizeToolCallId("")).toBe("000000000");
-	});
-
-	it("should handle IDs with only special characters", () => {
-		expect(sanitizeToolCallId("---!!!---")).toBe("000000000");
-	});
-
-	it("should handle mixed content", () => {
-		expect(sanitizeToolCallId("call_abc_123")).toBe("callabc12");
-	});
-});
 
 // ---------------------------------------------------------------------------
 // normalizeMessagesForBinding
@@ -53,7 +22,18 @@ describe("normalizeMessagesForBinding", () => {
 		expect(result).toEqual(messages);
 	});
 
-	it("should sanitize tool_call_id on tool messages", () => {
+	it("should convert null content to empty string", () => {
+		const messages = [
+			{
+				role: "assistant" as const,
+				content: null as unknown as string,
+			},
+		];
+		const result = normalizeMessagesForBinding(messages);
+		expect(result[0]).toHaveProperty("content", "");
+	});
+
+	it("should pass through tool_call_id unchanged", () => {
 		const messages = [
 			{
 				role: "tool" as const,
@@ -63,10 +43,10 @@ describe("normalizeMessagesForBinding", () => {
 			},
 		];
 		const result = normalizeMessagesForBinding(messages);
-		expect(result[0]).toHaveProperty("tool_call_id", "chatcmplt");
+		expect(result[0]).toHaveProperty("tool_call_id", "chatcmpl-tool-875d3ec6179676ae");
 	});
 
-	it("should sanitize tool_calls[].id on assistant messages", () => {
+	it("should pass through tool_calls[].id unchanged", () => {
 		const messages = [
 			{
 				role: "assistant" as const,
@@ -84,21 +64,18 @@ describe("normalizeMessagesForBinding", () => {
 		const assistant = result[0] as {
 			tool_calls?: Array<{ id: string }>;
 		};
-		expect(assistant.tool_calls?.[0].id).toBe("chatcmplt");
+		expect(assistant.tool_calls?.[0].id).toBe("chatcmpl-tool-abc123def456");
 	});
 
 	it("should not mutate the original messages array", () => {
 		const original = [
 			{
-				role: "tool" as const,
-				name: "fn",
-				content: "result",
-				tool_call_id: "chatcmpl-tool-abc",
+				role: "assistant" as const,
+				content: null as unknown as string,
 			},
 		];
-		const originalId = original[0].tool_call_id;
 		normalizeMessagesForBinding(original);
-		expect(original[0].tool_call_id).toBe(originalId);
+		expect(original[0].content).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary

- Remove `sanitizeToolCallId()` which truncated all tool call IDs to 9 alphanumeric chars, causing every tool call ID to collide to `chatcmplt` after round-trip
- Simplify `normalizeMessagesForBinding()` to only handle `content: null → ""` normalization
- Update tests to verify IDs pass through unchanged

This mirrors the same fix applied to `@cloudflare/tanstack-ai` in #424. The binding's `[a-zA-Z0-9]{9}` validation has been relaxed upstream, confirmed by e2e tool round-trip tests passing across all 10 models without sanitization.

## Test plan

- [x] 204 unit tests pass
- [x] 133/134 e2e tests pass (1 unrelated Mistral Small structured output timeout)
- [x] All tool call and tool round-trip e2e tests pass across all models (binding + REST)


Made with [Cursor](https://cursor.com)