### PR TITLE
fix(@cloudflare/tanstack-ai): update peerDependency @tanstack/ai from ^0.5.0 to ^0.8.0

### DIFF
--- a/packages/tanstack-ai/package.json
+++ b/packages/tanstack-ai/package.json
@@ -141,7 +141,7 @@
 		"dotenv": "^17.3.1"
 	},
 	"peerDependencies": {
-		"@tanstack/ai": "^0.5.0"
+		"@tanstack/ai": "^0.8.0"
 	},
 	"optionalDependencies": {
 		"@anthropic-ai/sdk": "^0.80.0",


### PR DESCRIPTION
Fixes #463

## Problem

`@cloudflare/tanstack-ai` declares `peerDependencies: { "@tanstack/ai": "^0.5.0" }`. Under npm semver rules for `0.x` packages, `^0.5.0` resolves to `>=0.5.0 <0.6.0` — which does not include `0.8.x` (the current stable release of `@tanstack/ai`).

This causes an `ERESOLVE` peer dependency conflict for all consumers running `npm update` or a fresh install with `@tanstack/ai@>=0.6.0`:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer @tanstack/ai@"^0.5.0" from @cloudflare/tanstack-ai@0.1.6
npm error Found: @tanstack/ai@0.8.1
```

## Root cause

The `peerDependencies` range was never updated after `devDependencies` was bumped to `@tanstack/ai@^0.8.1`. The package is already built and tested against 0.8.x — the peer dep range just doesn't reflect that.

Why npm `overrides` can't fix this on the consumer side: `overrides` redirect dependency *installation* but cannot suppress peer dep range-check `ERESOLVE` errors at resolution time during `npm update`. The only available workaround is `legacy-peer-deps=true` in `.npmrc`, which disables peer dep validation globally — undesirable.

## Change

```diff
 "peerDependencies": {
-  "@tanstack/ai": "^0.5.0"
+  "@tanstack/ai": "^0.8.0"
 }
```

One line, no behavior change — aligns the declared peer dep range with what the package already requires and tests against.