### PR TITLE
feat(workers-ai-provider): add custom fetch option for credentials mode

### DIFF
--- a/.changeset/add-custom-fetch.md
+++ b/.changeset/add-custom-fetch.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Add optional `fetch` parameter to credentials mode for request interception and testing. Available when using `accountId + apiKey` (not with bindings). Matches the pattern used by `@ai-sdk/openai` and `@ai-sdk/anthropic`.

--- a/demos/mcp-server-bearer-auth/src/utils.ts
+++ b/demos/mcp-server-bearer-auth/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																									? "bg-green-100 text-green-800"
-																									: "bg-red-100 text-red-800"} rounded-full">
+																											? "bg-green-100 text-green-800"
+																											: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/demos/remote-mcp-cf-access/src/access-handler.ts
+++ b/demos/remote-mcp-cf-access/src/access-handler.ts
@@ -117,7 +117,11 @@ export async function handleAccessRequest(
 		let codeVerifier: string;
 
 		try {
-			const result = await validateOAuthState(request, env.OAUTH_KV, env.COOKIE_ENCRYPTION_KEY);
+			const result = await validateOAuthState(
+				request,
+				env.OAUTH_KV,
+				env.COOKIE_ENCRYPTION_KEY,
+			);
 			oauthReqInfo = result.oauthReqInfo;
 			codeVerifier = result.codeVerifier;
 		} catch (error: any) {

--- a/demos/remote-mcp-cf-access/src/workers-oauth-utils.ts
+++ b/demos/remote-mcp-cf-access/src/workers-oauth-utils.ts
@@ -751,7 +751,6 @@ async function generatePKCE(): Promise<{ codeVerifier: string; codeChallenge: st
 	return { codeVerifier, codeChallenge };
 }
 
-
 async function getApprovedClientsFromCookie(
 	request: Request,
 	cookieSecret: string,

--- a/demos/remote-mcp-server-autorag/src/utils.ts
+++ b/demos/remote-mcp-server-autorag/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																									? "bg-green-100 text-green-800"
-																									: "bg-red-100 text-red-800"} rounded-full">
+																											? "bg-green-100 text-green-800"
+																											: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/demos/remote-mcp-server/src/utils.ts
+++ b/demos/remote-mcp-server/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																									? "bg-green-100 text-green-800"
-																									: "bg-red-100 text-red-800"} rounded-full">
+																											? "bg-green-100 text-green-800"
+																											: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -67,6 +67,13 @@ export type WorkersAISettings = (
 			 * Both binding must be absent if credentials are used directly.
 			 */
 			binding?: never;
+
+			/**
+			 * Custom fetch implementation. You can use it as a middleware to
+			 * intercept requests, or to provide a custom fetch implementation
+			 * for e.g. testing. Only available in credentials mode.
+			 */
+			fetch?: typeof globalThis.fetch;
 	  }
 ) & {
 	/**
@@ -159,7 +166,7 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 	} else {
 		const { accountId, apiKey } = options;
 		binding = {
-			run: createRun({ accountId, apiKey }),
+			run: createRun({ accountId, apiKey, fetch: options.fetch }),
 		} as Ai;
 	}
 

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -60,6 +60,8 @@ export interface CreateRunConfig {
 	accountId: string;
 	/** Cloudflare API token/key with appropriate permissions. */
 	apiKey: string;
+	/** Custom fetch implementation for intercepting requests. */
+	fetch?: typeof globalThis.fetch;
 }
 
 /**
@@ -68,6 +70,7 @@ export interface CreateRunConfig {
  */
 export function createRun(config: CreateRunConfig): AiRun {
 	const { accountId, apiKey } = config;
+	const fetchFn = config.fetch ?? globalThis.fetch;
 
 	return async function run<Name extends keyof AiModels>(
 		model: Name,
@@ -141,7 +144,7 @@ export function createRun(config: CreateRunConfig): AiRun {
 
 		const body = JSON.stringify(inputs);
 
-		const response = await fetch(url, {
+		const response = await fetchFn(url, {
 			body,
 			headers,
 			method: "POST",
@@ -180,7 +183,7 @@ export function createRun(config: CreateRunConfig): AiRun {
 			// Retry without streaming so doStream's graceful degradation path can
 			// wrap the complete response as a synthetic stream.
 			// Use the same URL (gateway or direct) as the original request.
-			const retryResponse = await fetch(url, {
+			const retryResponse = await fetchFn(url, {
 				body: JSON.stringify({
 					...(inputs as Record<string, unknown>),
 					stream: false,

--- a/packages/workers-ai-provider/test/utils.test.ts
+++ b/packages/workers-ai-provider/test/utils.test.ts
@@ -639,4 +639,53 @@ describe("createRun", () => {
 			}),
 		);
 	});
+
+	it("should use custom fetch when provided", async () => {
+		const customFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({ result: { response: "Hello" } }),
+			headers: new Headers({ "content-type": "application/json" }),
+		});
+
+		const run = createRun({
+			accountId: "test-account",
+			apiKey: "test-key",
+			fetch: customFetch as typeof globalThis.fetch,
+		});
+		await run("@cf/meta/llama-3.1-8b-instruct" as any, { prompt: "Hi" });
+
+		expect(customFetch).toHaveBeenCalledWith(
+			"https://api.cloudflare.com/client/v4/accounts/test-account/ai/run/@cf/meta/llama-3.1-8b-instruct",
+			expect.objectContaining({ method: "POST" }),
+		);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("should use custom fetch for streaming retry fallback", async () => {
+		const customFetch = vi
+			.fn()
+			// First call: streaming request returns JSON instead of SSE (triggers retry)
+			.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				body: null,
+				json: vi.fn().mockResolvedValue({ result: { response: "" } }),
+			})
+			// Second call: non-streaming retry
+			.mockResolvedValueOnce({
+				ok: true,
+				headers: new Headers({ "content-type": "application/json" }),
+				json: vi.fn().mockResolvedValue({ result: { response: "Hello" } }),
+			});
+
+		const run = createRun({
+			accountId: "test-account",
+			apiKey: "test-key",
+			fetch: customFetch as typeof globalThis.fetch,
+		});
+		await run("@cf/meta/llama-3.1-8b-instruct" as any, { prompt: "Hi", stream: true } as any);
+
+		expect(customFetch).toHaveBeenCalledTimes(2);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary

Adds an optional `fetch` parameter to `workers-ai-provider` when using credentials mode (`accountId + apiKey`). This matches the pattern used by `@ai-sdk/openai` and `@ai-sdk/anthropic`, enabling request interception for testing, middleware, and advanced use cases like [durable response buffering](https://github.com/cloudflare/agents/issues/1257).

## Motivation

The Agents SDK is building a durable response buffer that survives DO eviction during long-running inference calls ([RFC #1257](https://github.com/cloudflare/agents/issues/1257)). The buffer works by intercepting the provider's HTTP call and routing it through a proxy that persists the streaming response. For OpenAI and Anthropic, this is done via their `fetch` option. Workers AI lacked this option, requiring a workaround (fake AI binding whose `run()` routes to the buffer).

With this change, Workers AI in credentials mode supports the same clean pattern:

```typescript
const model = createWorkersAI({
  accountId: "...",
  apiKey: "...",
  fetch: myCustomFetch  // intercepts all HTTP calls
})("@cf/moonshotai/kimi-k2.5");
```

## Changes

**`src/index.ts`**
- Added `fetch?: typeof globalThis.fetch` to the credentials branch of `WorkersAISettings` (not the binding branch — bindings don't use HTTP)
- Passed `fetch` through to `createRun()`
- TypeScript enforces that `fetch` can only be used with credentials, not with bindings

**`src/utils.ts`**
- Added `fetch?` to `CreateRunConfig`
- `createRun` resolves `fetchFn = config.fetch ?? globalThis.fetch` and uses it for both the main request and the streaming retry fallback
- `createRunBinary` is unchanged (used for transcription, separate concern)

**`test/utils.test.ts`**
- Added test: custom fetch is called instead of global fetch
- Added test: custom fetch is used for the streaming retry fallback path (when a model returns JSON instead of SSE, `createRun` retries with `stream: false` — both calls go through the custom fetch)

## Type safety

The `fetch` option is in the credentials branch of the discriminated union, so TypeScript rejects `{ binding: env.AI, fetch: myFetch }` at the type level. This prevents confusion — bindings bypass HTTP entirely, so a custom fetch would have no effect.

## Test plan

- [x] All 38 existing + new tests pass (`npx vitest run test/utils.test.ts`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Custom fetch test verifies `globalThis.fetch` is NOT called
- [x] Streaming retry test verifies custom fetch is used for both attempts

Made with [Cursor](https://cursor.com)