### PR TITLE
fix: emit tool-input-end eagerly for sequential tool calls

### DIFF
--- a/.changeset/eager-tool-input-end.md
+++ b/.changeset/eager-tool-input-end.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Emit `tool-input-end` and `tool-call` events eagerly when streaming multiple tool calls, instead of deferring all of them to stream close. Previously, all tool calls appeared "in progress" simultaneously because `tool-input-end` was only emitted in `flush()`. Now each tool call is closed as soon as the next one starts or a null finalization chunk is received, matching the behavior of other AI SDK providers.

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -93,8 +93,11 @@ export function getMappedStream(
 	// Track tool call streaming state per index.
 	// When we see the first chunk for a tool call index, we emit tool-input-start.
 	// Subsequent argument deltas emit tool-input-delta.
-	// All open tool calls are closed with tool-input-end in flush().
+	// tool-input-end is emitted eagerly when a new tool index starts or a null
+	// finalization chunk arrives; any remaining open calls are closed in flush().
 	const activeToolCalls = new Map<number, { id: string; toolName: string; args: string }>();
+	const closedToolCalls = new Set<number>();
+	let lastActiveToolIndex: number | null = null;
 
 	// Step 1: Decode bytes into SSE lines
 	const sseStream = rawStream.pipeThrough(new SSEDecoder());
@@ -224,18 +227,10 @@ export function getMappedStream(
 			},
 
 			flush(controller) {
-				// Close all open tool call inputs and emit complete tool-call events
-				for (const [, tc] of activeToolCalls) {
-					controller.enqueue({ type: "tool-input-end", id: tc.id });
-					// Emit the complete tool-call event — the AI SDK expects both
-					// incremental tool-input-* events AND a final tool-call event,
-					// matching how @ai-sdk/openai-compatible works.
-					controller.enqueue({
-						type: "tool-call",
-						toolCallId: tc.id,
-						toolName: tc.toolName,
-						input: tc.args,
-					});
+				// Close any tool calls that weren't already closed during streaming
+				for (const [idx] of activeToolCalls) {
+					if (closedToolCalls.has(idx)) continue;
+					closeToolCall(idx, controller);
 				}
 
 				// Close open text/reasoning blocks
@@ -265,23 +260,50 @@ export function getMappedStream(
 	);
 
 	/**
+	 * Emit tool-input-end + tool-call for a tool call that is complete.
+	 */
+	function closeToolCall(
+		index: number,
+		controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+	) {
+		const tc = activeToolCalls.get(index);
+		if (!tc || closedToolCalls.has(index)) return;
+		closedToolCalls.add(index);
+		controller.enqueue({ type: "tool-input-end", id: tc.id });
+		controller.enqueue({
+			type: "tool-call",
+			toolCallId: tc.id,
+			toolName: tc.toolName,
+			input: tc.args,
+		});
+	}
+
+	/**
 	 * Emit incremental tool call events from streaming chunks.
 	 *
 	 * Workers AI streams tool calls as:
 	 *   Chunk A: { id, type, index, function: { name } }                — start
 	 *   Chunk B: { index, function: { arguments: "partial..." } }       — args delta
 	 *   Chunk C: { index, function: { arguments: "rest..." } }          — args delta
-	 *   Chunk D: { id: null, type: null, function: { name: null } }     — finalize (skip)
+	 *   Chunk D: { id: null, type: null, function: { name: null } }     — finalize
 	 *
 	 * We emit tool-input-start on first sight, tool-input-delta for each
-	 * argument chunk, and tool-input-end in flush().
+	 * argument chunk, and tool-input-end eagerly — either when a new tool
+	 * index starts (closing the previous one) or on a null finalization
+	 * chunk. Any remaining open calls are closed in flush().
 	 */
 	function emitToolCallDeltas(
 		toolCalls: Record<string, unknown>[],
 		controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
 	) {
 		for (const tc of toolCalls) {
-			if (isNullFinalizationChunk(tc)) continue;
+			if (isNullFinalizationChunk(tc)) {
+				// Null finalization sentinel — close the last active tool call
+				if (lastActiveToolIndex != null) {
+					closeToolCall(lastActiveToolIndex, controller);
+				}
+				continue;
+			}
 
 			const tcIndex = (tc.index as number) ?? 0;
 			const fn = tc.function as Record<string, unknown> | undefined;
@@ -290,10 +312,15 @@ export function getMappedStream(
 			const tcId = tc.id as string | null;
 
 			if (!activeToolCalls.has(tcIndex)) {
-				// First chunk for this tool call — emit tool-input-start
+				// A new tool call is starting — close the previous one first
+				if (lastActiveToolIndex != null && lastActiveToolIndex !== tcIndex) {
+					closeToolCall(lastActiveToolIndex, controller);
+				}
+
 				const id = tcId || generateId();
 				const toolName = tcName || "";
 				activeToolCalls.set(tcIndex, { id, toolName, args: "" });
+				lastActiveToolIndex = tcIndex;
 
 				controller.enqueue({
 					type: "tool-input-start",
@@ -301,7 +328,6 @@ export function getMappedStream(
 					toolName,
 				});
 
-				// If arguments arrived in the same chunk as the start, emit them
 				if (tcArgs != null && tcArgs !== "") {
 					const delta = typeof tcArgs === "string" ? tcArgs : JSON.stringify(tcArgs);
 					activeToolCalls.get(tcIndex)!.args += delta;
@@ -312,8 +338,8 @@ export function getMappedStream(
 					});
 				}
 			} else {
-				// Subsequent chunks — emit argument deltas
 				const active = activeToolCalls.get(tcIndex)!;
+				lastActiveToolIndex = tcIndex;
 				if (tcArgs != null && tcArgs !== "") {
 					const delta = typeof tcArgs === "string" ? tcArgs : JSON.stringify(tcArgs);
 					active.args += delta;

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -1900,6 +1900,871 @@ describe("Graceful Degradation", () => {
 	});
 });
 
+describe("Eager tool-input-end streaming (issue #488)", () => {
+	it("should emit tool-input-end for first tool BEFORE tool-input-start for second tool", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: { name: "writeFile", arguments: '{"path": "a.txt"' },
+								},
+							],
+						},
+						{
+							tool_calls: [
+								{ index: 0, function: { arguments: ', "content": "hello"}' } },
+							],
+						},
+						{
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "writeFile",
+										arguments: '{"path": "b.txt", "content": "world"}',
+									},
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Write two files",
+			tools: {
+				writeFile: {
+					description: "Write a file",
+					inputSchema: z.object({
+						path: z.string(),
+						content: z.string(),
+					}),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+		}
+
+		const firstEnd = events.indexOf("tool-input-end");
+		const secondStart = events.lastIndexOf("tool-input-start");
+		expect(firstEnd).toBeGreaterThan(-1);
+		expect(secondStart).toBeGreaterThan(-1);
+		expect(firstEnd).toBeLessThan(secondStart);
+	});
+
+	it("should emit tool-call for first tool before second tool starts", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "get_weather",
+										arguments: '{"location": "London"}',
+									},
+								},
+							],
+						},
+						{
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "get_weather",
+										arguments: '{"location": "Paris"}',
+									},
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Get weather for London and Paris",
+			tools: {
+				get_weather: {
+					description: "Get weather",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+		});
+
+		const events: { type: string; id?: string }[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push({ type: chunk.type, id: (chunk as any).toolCallId ?? (chunk as any).id });
+		}
+
+		const toolCalls = events.filter((e) => e.type === "tool-call");
+		const toolInputStarts = events.filter((e) => e.type === "tool-input-start");
+		expect(toolCalls).toHaveLength(2);
+		expect(toolInputStarts).toHaveLength(2);
+
+		const allToolEvents = events
+			.map((e, i) => ({ ...e, idx: i }))
+			.filter((e) =>
+				["tool-input-start", "tool-input-end", "tool-call"].includes(e.type),
+			);
+
+		// Expected order: start(0), end(0), call(0), start(1), end(1), call(1)
+		expect(allToolEvents.map((e) => e.type)).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+	});
+
+	it("should handle null finalization chunk to close tool call", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "get_weather",
+										arguments: '{"location": "London"}',
+									},
+								},
+							],
+						},
+						// Null finalization chunk — explicit signal tool is done
+						{
+							tool_calls: [
+								{
+									id: null,
+									type: null,
+									function: { name: null, arguments: "" },
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Get weather",
+			tools: {
+				get_weather: {
+					description: "Get weather",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		// tool-input-end should appear (triggered by finalization chunk, not just flush)
+		expect(toolEvents).toEqual(["tool-input-start", "tool-input-end", "tool-call"]);
+
+		// Verify tool-input-end comes BEFORE finish
+		const endIdx = events.indexOf("tool-input-end");
+		const finishIdx = events.indexOf("finish");
+		expect(endIdx).toBeLessThan(finishIdx);
+	});
+
+	it("should handle three sequential tool calls with incremental args", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						// Tool 0 start
+						{
+							tool_calls: [
+								{
+									id: "call_a",
+									type: "function",
+									index: 0,
+									function: { name: "writeFile", arguments: '{"p' },
+								},
+							],
+						},
+						// Tool 0 args
+						{
+							tool_calls: [
+								{ index: 0, function: { arguments: 'ath":"a.txt"}' } },
+							],
+						},
+						// Tool 1 start (should close tool 0)
+						{
+							tool_calls: [
+								{
+									id: "call_b",
+									type: "function",
+									index: 1,
+									function: { name: "writeFile", arguments: '{"path":"b.txt"}' },
+								},
+							],
+						},
+						// Tool 2 start (should close tool 1)
+						{
+							tool_calls: [
+								{
+									id: "call_c",
+									type: "function",
+									index: 2,
+									function: { name: "writeFile", arguments: '{"path":"c.txt"}' },
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Write three files",
+			tools: {
+				writeFile: {
+					description: "Write a file",
+					inputSchema: z.object({ path: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		// Each tool should be fully closed before the next starts
+		expect(toolEvents).toEqual([
+			"tool-input-start", // tool 0
+			"tool-input-end", // tool 0
+			"tool-call", // tool 0
+			"tool-input-start", // tool 1
+			"tool-input-end", // tool 1
+			"tool-call", // tool 1
+			"tool-input-start", // tool 2
+			"tool-input-end", // tool 2 (closed in flush)
+			"tool-call", // tool 2
+		]);
+	});
+
+	it("should still work correctly for a single tool call (closed in flush)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "solo",
+									type: "function",
+									index: 0,
+									function: { name: "get_weather", arguments: '{"loc' },
+								},
+							],
+						},
+						{
+							tool_calls: [
+								{ index: 0, function: { arguments: 'ation":"NYC"}' } },
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Weather?",
+			tools: {
+				get_weather: {
+					description: "Get weather",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		const toolCallData: any[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+			if (chunk.type === "tool-call") toolCallData.push(chunk);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-delta", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-delta",
+			"tool-input-delta",
+			"tool-input-end",
+			"tool-call",
+		]);
+		expect(toolCallData[0].toolCallId).toBe("solo");
+		expect(toolCallData[0].toolName).toBe("get_weather");
+	});
+
+	it("should handle OpenAI-format sequential tool calls with eager close", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												id: "oai_1",
+												type: "function",
+												index: 0,
+												function: {
+													name: "search",
+													arguments: '{"query":"cats"}',
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												id: "oai_2",
+												type: "function",
+												index: 1,
+												function: {
+													name: "search",
+													arguments: '{"query":"dogs"}',
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							choices: [{ delta: {}, finish_reason: "tool_calls" }],
+						},
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Search for cats and dogs",
+			tools: {
+				search: {
+					description: "Search",
+					inputSchema: z.object({ query: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+	});
+
+	it("should handle text followed by tool calls", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{ response: "Let me check " },
+						{ response: "the weather." },
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "get_weather",
+										arguments: '{"location":"London"}',
+									},
+								},
+							],
+						},
+						{
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "get_weather",
+										arguments: '{"location":"Paris"}',
+									},
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Weather in London and Paris",
+			tools: {
+				get_weather: {
+					description: "Get weather",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		let text = "";
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+			if (chunk.type === "text-delta") text += chunk.text;
+		}
+
+		expect(text).toBe("Let me check the weather.");
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+
+		// Text events should come before tool events
+		const lastTextDelta = events.lastIndexOf("text-delta");
+		const firstToolStart = events.indexOf("tool-input-start");
+		expect(lastTextDelta).toBeLessThan(firstToolStart);
+	});
+
+	it("should handle null finalization between sequential tools", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "read",
+										arguments: '{"file":"a.txt"}',
+									},
+								},
+							],
+						},
+						// Explicit finalization for tool 0
+						{
+							tool_calls: [
+								{
+									id: null,
+									type: null,
+									function: { name: null, arguments: "" },
+								},
+							],
+						},
+						{
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "read",
+										arguments: '{"file":"b.txt"}',
+									},
+								},
+							],
+						},
+						// Explicit finalization for tool 1
+						{
+							tool_calls: [
+								{
+									id: null,
+									type: null,
+									function: { name: null, arguments: "" },
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Read two files",
+			tools: {
+				read: {
+					description: "Read a file",
+					inputSchema: z.object({ file: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		const toolCalls: any[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+			if (chunk.type === "tool-call") toolCalls.push(chunk);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+
+		expect(toolCalls[0].toolCallId).toBe("call_1");
+		expect(toolCalls[1].toolCallId).toBe("call_2");
+	});
+
+	it("should not double-close a tool call (finalization + new index)", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "read",
+										arguments: '{"file":"a.txt"}',
+									},
+								},
+							],
+						},
+						// Finalization closes tool 0
+						{
+							tool_calls: [
+								{
+									id: null,
+									type: null,
+									function: { name: null, arguments: "" },
+								},
+							],
+						},
+						// New tool 1 starts — tool 0 is already closed, should not double-close
+						{
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "read",
+										arguments: '{"file":"b.txt"}',
+									},
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Read two files",
+			tools: {
+				read: {
+					description: "Read a file",
+					inputSchema: z.object({ file: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+		}
+
+		// Count tool-input-end and tool-call — should be exactly 2 of each
+		const endCount = events.filter((e) => e === "tool-input-end").length;
+		const callCount = events.filter((e) => e === "tool-call").length;
+		expect(endCount).toBe(2);
+		expect(callCount).toBe(2);
+	});
+
+	it("should handle multiple tool calls in a single SSE chunk", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									index: 0,
+									function: {
+										name: "get_weather",
+										arguments: '{"location":"London"}',
+									},
+								},
+								{
+									id: "call_2",
+									type: "function",
+									index: 1,
+									function: {
+										name: "get_weather",
+										arguments: '{"location":"Paris"}',
+									},
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Weather in London and Paris",
+			tools: {
+				get_weather: {
+					description: "Get weather",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+		});
+
+		const events: string[] = [];
+		const toolCalls: any[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+			if (chunk.type === "tool-call") toolCalls.push(chunk);
+		}
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		// Even in a single chunk, first tool should be closed before second starts
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+		expect(toolCalls[0].toolCallId).toBe("call_1");
+		expect(toolCalls[1].toolCallId).toBe("call_2");
+	});
+
+	it("should handle three sequential OpenAI-format tool calls with eager close", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					return mockStream([
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												id: "call_1",
+												type: "function",
+												index: 0,
+												function: {
+													name: "get_data",
+													arguments: '{"id": 1}',
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												id: "call_2",
+												type: "function",
+												index: 1,
+												function: {
+													name: "get_data",
+													arguments: '{"id": 2}',
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							choices: [
+								{
+									delta: {
+										tool_calls: [
+											{
+												id: "call_3",
+												type: "function",
+												index: 2,
+												function: {
+													name: "get_data",
+													arguments: '{"id": 3}',
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						},
+						{
+							choices: [{ delta: {}, finish_reason: "tool_calls" }],
+						},
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Get data for IDs 1, 2, 3",
+			tools: {
+				get_data: {
+					description: "Get data",
+					inputSchema: z.object({ id: z.number() }),
+				},
+			},
+		});
+
+		const toolCalls: any[] = [];
+		const events: string[] = [];
+		for await (const chunk of result.fullStream) {
+			events.push(chunk.type);
+			if (chunk.type === "tool-call") toolCalls.push(chunk);
+		}
+
+		expect(toolCalls).toHaveLength(3);
+		expect(toolCalls[0].toolCallId).toBe("call_1");
+		expect(toolCalls[1].toolCallId).toBe("call_2");
+		expect(toolCalls[2].toolCallId).toBe("call_3");
+
+		const toolEvents = events.filter((e) =>
+			["tool-input-start", "tool-input-end", "tool-call"].includes(e),
+		);
+
+		// Each tool is fully closed before the next starts
+		expect(toolEvents).toEqual([
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+			"tool-input-start",
+			"tool-input-end",
+			"tool-call",
+		]);
+	});
+});
+
 /**
  * Helper to produce SSE lines in a Node ReadableStream.
  */


### PR DESCRIPTION
## Summary

Fixes #488.

- **Emit `tool-input-end` + `tool-call` eagerly** when a new tool call index starts streaming, instead of batching all of them at stream close in `flush()`. This matches the behavior of other AI SDK providers like `@ai-sdk/openai-compatible`.
- **Use the null finalization chunk** as an explicit close signal. Previously this sentinel was detected and discarded; now it triggers `tool-input-end` for the active tool call.
- **Guard against double-close** via a `closedToolCalls` set — if both a finalization chunk and a new-index-start would close the same tool, only the first one emits events.

### Before

All `tool-input-end` events emitted simultaneously at stream close:
```
tool-input-start(0) → deltas → tool-input-start(1) → deltas → [stream ends] → tool-input-end(0), tool-call(0), tool-input-end(1), tool-call(1)
```

### After

Each tool call is closed before the next one starts:
```
tool-input-start(0) → deltas → tool-input-end(0) → tool-call(0) → tool-input-start(1) → deltas → tool-input-end(1) → tool-call(1)
```

## Test plan

- [x] 11 new tests covering: sequential tool calls (2 and 3 tools), null finalization chunks, double-close prevention, batch tool calls in a single SSE event, OpenAI format, text + tool call interleaving, single tool call (regression)
- [x] All 236 existing unit tests pass with no modifications

Made with [Cursor](https://cursor.com)