### PR TITLE
fix(tanstack-ai): forward reasoning_effort and chat_template_kwargs (#503)

### DIFF
--- a/.changeset/tanstack-ai-reasoning-passthrough.md
+++ b/.changeset/tanstack-ai-reasoning-passthrough.md
@@ -1,0 +1,24 @@
+---
+"@cloudflare/tanstack-ai": minor
+---
+
+Add passthrough for `reasoning_effort` and `chat_template_kwargs` in `createWorkersAiChat`. Pass them per-call through `modelOptions`:
+
+```ts
+const adapter = createWorkersAiChat("@cf/zai-org/glm-4.7-flash", { binding: env.AI });
+
+chat({
+  adapter,
+  messages,
+  modelOptions: {
+    reasoning_effort: "low",
+    chat_template_kwargs: { enable_thinking: false },
+  },
+});
+```
+
+Previously these fields were silently dropped, which could cause reasoning models (GLM-4.7-flash, Kimi K2.5/K2.6, GPT-OSS) to burn the entire output token budget on chain-of-thought with no visible content. They now reach `binding.run(model, inputs)` at the `inputs` level as required by Workers AI.
+
+A new `WorkersAiTextModelOptions` type is exported from `@cloudflare/tanstack-ai` and `@cloudflare/tanstack-ai/adapters/workers-ai`.
+
+Closes #503.

--- a/packages/tanstack-ai/README.md
+++ b/packages/tanstack-ai/README.md
@@ -68,6 +68,35 @@ const adapter = createWorkersAiChat("@cf/moonshotai/kimi-k2.5", {
 });
 ```
 
+### Reasoning Controls
+
+Reasoning-capable Workers AI models (GLM-4.7-flash, Kimi K2.5/K2.6, GPT-OSS, QwQ) accept `reasoning_effort` and `chat_template_kwargs` on their inputs. Pass them per-call through `modelOptions`:
+
+```typescript
+import { chat } from "@tanstack/ai";
+import { createWorkersAiChat } from "@cloudflare/tanstack-ai";
+
+const adapter = createWorkersAiChat("@cf/zai-org/glm-4.7-flash", {
+	binding: env.AI,
+});
+
+const response = chat({
+	adapter,
+	stream: true,
+	messages: [{ role: "user", content: "Summarize in one sentence." }],
+	modelOptions: {
+		// "low" | "medium" | "high" | null — null disables reasoning.
+		reasoning_effort: "low",
+		// Toggle thinking on models that expose template kwargs (GLM, Kimi).
+		chat_template_kwargs: { enable_thinking: false },
+	},
+});
+```
+
+This works in all four config modes (binding, REST, gateway binding, gateway REST). `modelOptions` keys with `undefined` values are stripped; `null` values are preserved.
+
+See the [Workers AI docs](https://developers.cloudflare.com/workers-ai/) for per-model reasoning capabilities.
+
 ### Vision (Image Inputs)
 
 Send images to vision-capable chat models:

--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -27,6 +27,55 @@ export type WorkersAiTextModel =
 	| (string & {});
 
 // ---------------------------------------------------------------------------
+// Provider-specific options forwarded to Workers AI's chat completions inputs.
+//
+// These correspond to fields on `ChatCompletionsCommonOptions` in
+// `@cloudflare/workers-types`. They are passed verbatim into the request body
+// sent to the Workers AI binding / REST endpoint / AI Gateway, and ultimately
+// land on the `inputs` object of `binding.run(model, inputs)`.
+//
+// Pass via `modelOptions` on a per-call basis:
+//
+//   await adapter.chatStream({
+//     model, messages,
+//     modelOptions: {
+//       reasoning_effort: "low",
+//       chat_template_kwargs: { enable_thinking: false },
+//     },
+//   });
+// ---------------------------------------------------------------------------
+
+export interface WorkersAiTextModelOptions {
+	/**
+	 * Controls the reasoning budget for reasoning-capable models
+	 * (e.g. `@cf/zai-org/glm-4.7-flash`, `@cf/moonshotai/kimi-k2.5`,
+	 * `@cf/openai/gpt-oss-120b`).
+	 *
+	 * `null` is a valid value and disables reasoning for models that support it.
+	 */
+	reasoning_effort?: "low" | "medium" | "high" | null;
+	/**
+	 * Chat-template overrides for reasoning-capable models that expose
+	 * thinking toggles (e.g. GLM, Kimi).
+	 */
+	chat_template_kwargs?: {
+		/** Whether to enable reasoning. Enabled by default on reasoning models. */
+		enable_thinking?: boolean;
+		/** If false, preserves reasoning context between turns. */
+		clear_thinking?: boolean;
+	};
+	/**
+	 * Escape hatch for other Workers AI inputs-level parameters.
+	 *
+	 * Keys placed here are merged into the outbound request body and forwarded
+	 * to the underlying transport (binding / REST / gateway). Only fields that
+	 * the binding shim knows about are extracted for direct `env.AI` bindings;
+	 * everything is passed through on REST and gateway paths.
+	 */
+	[key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers: build the right OpenAI client depending on config mode
 // ---------------------------------------------------------------------------
 
@@ -219,16 +268,41 @@ function generateId(prefix = "chatcmpl"): string {
 }
 
 // ---------------------------------------------------------------------------
+// modelOptions normalization
+//
+// Users pass Workers AI-specific chat params (e.g. `reasoning_effort`,
+// `chat_template_kwargs`) via `modelOptions`. We merge these into the outbound
+// request body so they reach the binding / REST / gateway transports.
+//
+// Spread order matters: these go FIRST in the request body so that TanStack-AI
+// managed fields (`model`, `messages`, `temperature`, `max_tokens`, `stream`,
+// `tools`, `response_format`, ...) always win if a user accidentally sets
+// them both at the top level and inside `modelOptions`.
+//
+// `undefined` values are stripped so that JSON.stringify (and our binding shim
+// which does `!== undefined` checks) see them as absent. `null` values are
+// preserved — they're meaningful for fields like `reasoning_effort: null`
+// which explicitly disables reasoning on some models.
+// ---------------------------------------------------------------------------
+function normalizeModelOptions(
+	modelOptions: WorkersAiTextModelOptions | undefined,
+): Record<string, unknown> {
+	if (!modelOptions) return {};
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(modelOptions)) {
+		if (value !== undefined) out[key] = value;
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
 // WorkersAiTextAdapter: chat / structured output via OpenAI Chat Completions
 // ---------------------------------------------------------------------------
 
-// TODO: Replace `any` generic params with proper types once BaseTextAdapter's
-// provider-options generics stabilize. Workers AI doesn't have provider-specific
-// options in the TanStack sense, so `any` is pragmatic for now.
 export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends BaseTextAdapter<
 	TModel,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- BaseTextAdapter generic params are opaque
-	any,
+	WorkersAiTextModelOptions,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- remaining BaseTextAdapter generics are opaque
 	any,
 	any
 > {
@@ -241,8 +315,12 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 		this.client = buildWorkersAiClient(config);
 	}
 
-	async *chatStream(options: TextOptions<any>): AsyncIterable<StreamChunk> {
-		const { systemPrompts, messages, tools, temperature, maxTokens, model } = options;
+	async *chatStream(
+		options: TextOptions<WorkersAiTextModelOptions>,
+	): AsyncIterable<StreamChunk> {
+		const { systemPrompts, messages, tools, temperature, maxTokens, model, modelOptions } =
+			options;
+		const extraBody = normalizeModelOptions(modelOptions);
 
 		const openAIMessages = buildOpenAIMessages(systemPrompts, messages);
 		const openAITools = buildOpenAITools(tools);
@@ -266,6 +344,7 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 			let stream: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>;
 			try {
 				stream = await this.client.chat.completions.create({
+					...extraBody,
 					model: model ?? this.model,
 					messages: openAIMessages,
 					tools: openAITools,
@@ -273,7 +352,7 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 					max_tokens: maxTokens,
 					stream: true,
 					stream_options: { include_usage: true },
-				});
+				} as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming);
 			} catch (streamError: unknown) {
 				// Some models (e.g. GPT-OSS) don't support streaming via the REST API.
 				// Fall back to a non-streaming call and yield the result as a single chunk.
@@ -282,12 +361,13 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 					streamError instanceof Error ? streamError.message : streamError,
 				);
 				const nonStreamResult = await this.client.chat.completions.create({
+					...extraBody,
 					model: model ?? this.model,
 					messages: openAIMessages,
 					tools: openAITools,
 					temperature,
 					max_tokens: maxTokens,
-				});
+				} as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming);
 
 				yield {
 					type: "RUN_STARTED",
@@ -634,16 +714,18 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 	}
 
 	async structuredOutput(
-		options: StructuredOutputOptions<any>,
+		options: StructuredOutputOptions<WorkersAiTextModelOptions>,
 	): Promise<StructuredOutputResult<unknown>> {
 		const { outputSchema, chatOptions } = options;
-		const { systemPrompts, messages, temperature, model } = chatOptions;
+		const { systemPrompts, messages, temperature, model, modelOptions } = chatOptions;
+		const extraBody = normalizeModelOptions(modelOptions);
 
 		const openAIMessages = buildOpenAIMessages(systemPrompts, messages, {
 			includeToolMessages: false,
 		});
 
 		const response = await this.client.chat.completions.create({
+			...extraBody,
 			model: model ?? this.model,
 			messages: openAIMessages,
 			temperature,
@@ -656,7 +738,7 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 					schema: outputSchema,
 				},
 			},
-		});
+		} as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming);
 
 		const choice = response.choices?.[0];
 

--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -287,7 +287,18 @@ function generateId(prefix = "chatcmpl"): string {
 function normalizeModelOptions(
 	modelOptions: WorkersAiTextModelOptions | undefined,
 ): Record<string, unknown> {
-	if (!modelOptions) return {};
+	// Guard against runtime misuse. TanStack AI types this as an object, but
+	// users can always bypass with `as any`. `Object.entries` on a string
+	// surprisingly returns per-character tuples (e.g. `Object.entries("ab") →
+	// [["0","a"],["1","b"]]`), which would leak spurious keys into the body.
+	// Arrays similarly become index-keyed. Only accept plain objects.
+	if (
+		modelOptions === null ||
+		typeof modelOptions !== "object" ||
+		Array.isArray(modelOptions)
+	) {
+		return {};
+	}
 	const out: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(modelOptions)) {
 		if (value !== undefined) out[key] = value;

--- a/packages/tanstack-ai/src/index.ts
+++ b/packages/tanstack-ai/src/index.ts
@@ -67,7 +67,7 @@ export type {
 } from "./adapters/openrouter";
 
 export { createWorkersAiChat } from "./adapters/workers-ai";
-export type { WorkersAiTextModel } from "./adapters/workers-ai";
+export type { WorkersAiTextModel, WorkersAiTextModelOptions } from "./adapters/workers-ai";
 
 export { createWorkersAiImage } from "./adapters/workers-ai-image";
 export type { WorkersAiImageModel } from "./adapters/workers-ai-image";

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -339,6 +339,19 @@ export function createWorkersAiBindingFetch(
 		if (body.response_format) inputs.response_format = body.response_format;
 		if (stream) inputs.stream = true;
 
+		// Workers AI-specific reasoning controls. These belong on the INPUTS object
+		// passed to binding.run(model, inputs), not on the options (3rd) arg.
+		// See https://github.com/cloudflare/ai/issues/503.
+		//
+		// `reasoning_effort: null` is a valid value (disables reasoning on models
+		// that support it), so we check `!== undefined` rather than truthiness.
+		if (body.reasoning_effort !== undefined) {
+			inputs.reasoning_effort = body.reasoning_effort;
+		}
+		if (body.chat_template_kwargs !== undefined) {
+			inputs.chat_template_kwargs = body.chat_template_kwargs;
+		}
+
 		const runOptions: Record<string, unknown> = {};
 		if (options?.extraHeaders) runOptions.extraHeaders = options.extraHeaders;
 		if (init?.signal) runOptions.signal = init.signal;

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -790,6 +790,35 @@ describe("createWorkersAiBindingFetch", () => {
 		expect(inputs.chat_template_kwargs).toEqual({});
 	});
 
+	it("should NOT forward unknown body fields to binding inputs (allowlist policy)", async () => {
+		// The binding shim uses an explicit allowlist. Fields that the Workers
+		// AI binding doesn't understand (e.g. `stream_options` from the OpenAI
+		// SDK, or an arbitrary `seed`) must be dropped so the binding's schema
+		// validation doesn't reject the whole request. REST and gateway paths
+		// forward everything; binding drops unknowns. This asymmetry is
+		// documented in `WorkersAiTextModelOptions`.
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				seed: 42,
+				stream_options: { include_usage: true },
+				some_unknown_future_field: "hello",
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		expect(inputs).not.toHaveProperty("seed");
+		expect(inputs).not.toHaveProperty("stream_options");
+		expect(inputs).not.toHaveProperty("some_unknown_future_field");
+		// Canonical fields and reasoning fields still flow
+		expect(inputs.messages).toBeDefined();
+	});
+
 	it("should forward reasoning params alongside streaming requests", async () => {
 		const encoder = new TextEncoder();
 		const stream = new ReadableStream({

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -690,6 +690,135 @@ describe("createWorkersAiBindingFetch", () => {
 		});
 	});
 
+	// ---------------------------------------------------------------------------
+	// Reasoning passthrough — reasoning_effort + chat_template_kwargs
+	// https://github.com/cloudflare/ai/issues/503
+	// ---------------------------------------------------------------------------
+
+	it("should forward reasoning_effort to binding.run inputs (not options)", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				reasoning_effort: "low",
+			}),
+		});
+
+		const [, inputs, options] = binding.run.mock.calls[0]! as [
+			unknown,
+			Record<string, unknown>,
+			Record<string, unknown> | undefined,
+		];
+		// Must land on inputs (2nd arg), not options (3rd arg)
+		expect(inputs.reasoning_effort).toBe("low");
+		if (options) {
+			expect(options).not.toHaveProperty("reasoning_effort");
+		}
+	});
+
+	it("should forward chat_template_kwargs to binding.run inputs", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				chat_template_kwargs: { enable_thinking: false },
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		expect(inputs.chat_template_kwargs).toEqual({ enable_thinking: false });
+	});
+
+	it("should preserve reasoning_effort: null (disables reasoning)", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				reasoning_effort: null,
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		// null must be preserved — it's the explicit "no reasoning" signal
+		expect(inputs).toHaveProperty("reasoning_effort");
+		expect(inputs.reasoning_effort).toBeNull();
+	});
+
+	it("should not set reasoning_effort when omitted", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [{ role: "user", content: "Hi" }],
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		expect(inputs).not.toHaveProperty("reasoning_effort");
+		expect(inputs).not.toHaveProperty("chat_template_kwargs");
+	});
+
+	it("should forward an empty chat_template_kwargs object", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				chat_template_kwargs: {},
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		expect(inputs.chat_template_kwargs).toEqual({});
+	});
+
+	it("should forward reasoning params alongside streaming requests", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode('data: {"response":"ok"}\n\n'));
+				controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+				controller.close();
+			},
+		});
+		const binding = mockBinding(vi.fn().mockResolvedValue(stream));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/zai-org/glm-4.7-flash",
+				messages: [{ role: "user", content: "Hi" }],
+				stream: true,
+				reasoning_effort: "medium",
+				chat_template_kwargs: { enable_thinking: true },
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]! as [unknown, Record<string, unknown>];
+		expect(inputs.stream).toBe(true);
+		expect(inputs.reasoning_effort).toBe("medium");
+		expect(inputs.chat_template_kwargs).toEqual({ enable_thinking: true });
+	});
+
 	it("should pass content arrays through to binding for vision models", async () => {
 		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "A red square" }));
 

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -400,6 +400,52 @@ describe("createGatewayFetch", () => {
 			const request = mockBinding.run.mock.calls[0]![0];
 			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
 		});
+
+		// https://github.com/cloudflare/ai/issues/503
+		it("should forward reasoning_effort and chat_template_kwargs in the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [{ role: "user", content: "Hi" }],
+					reasoning_effort: "low",
+					chat_template_kwargs: { enable_thinking: false },
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.reasoning_effort).toBe("low");
+			expect(request.query.chat_template_kwargs).toEqual({ enable_thinking: false });
+			// model is still stripped (becomes part of endpoint)
+			expect(request.query.model).toBeUndefined();
+		});
+
+		it("should preserve reasoning_effort: null in the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [],
+					reasoning_effort: null,
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query).toHaveProperty("reasoning_effort");
+			expect(request.query.reasoning_effort).toBeNull();
+		});
 	});
 
 	describe("endpoint extraction", () => {

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -446,6 +446,31 @@ describe("createGatewayFetch", () => {
 			expect(request.query).toHaveProperty("reasoning_effort");
 			expect(request.query.reasoning_effort).toBeNull();
 		});
+
+		// Counterpart to the binding shim's allowlist: the gateway path
+		// forwards arbitrary fields. This is the escape-hatch side of the
+		// asymmetry documented on `WorkersAiTextModelOptions`.
+		it("should forward arbitrary unknown fields on the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [],
+					seed: 42,
+					some_future_field: "hello",
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.seed).toBe(42);
+			expect(request.query.some_future_field).toBe("hello");
+		});
 	});
 
 	describe("endpoint extraction", () => {

--- a/packages/tanstack-ai/test/workers-ai-adapter.test.ts
+++ b/packages/tanstack-ai/test/workers-ai-adapter.test.ts
@@ -1052,6 +1052,83 @@ describe("WorkersAiTextAdapter modelOptions passthrough", () => {
 		expect(inputs).not.toHaveProperty("reasoning_effort");
 		expect(inputs).not.toHaveProperty("chat_template_kwargs");
 	});
+
+	it("should ignore modelOptions when it is not a plain object", async () => {
+		// AI SDK types modelOptions as an object, but users can bypass with
+		// `as any`. We must not leak spurious keys into the body — e.g.
+		// Object.entries("ab") returns [["0","a"],["1","b"]] which would
+		// become inputs["0"] = "a" if we weren't careful.
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(MODEL, { binding });
+
+		await collectChunks(
+			adapter.chatStream({
+				model: MODEL,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: "not-an-object" as any,
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs).not.toHaveProperty("0");
+		expect(inputs).not.toHaveProperty("reasoning_effort");
+		// Canonical fields are still present
+		expect(inputs.messages).toBeDefined();
+	});
+
+	it("should preserve modelOptions through the non-streaming fallback path", async () => {
+		// Some models reject stream: true. The adapter falls back to a
+		// non-streaming request; modelOptions must survive the retry so that
+		// users don't lose reasoning controls on fallback-affected models.
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/openai/gpt-oss-120b" as WorkersAiTextModel,
+			{
+				// binding must be valid for the adapter to construct
+				binding: {
+					run: vi.fn(),
+					gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+				},
+			},
+		);
+
+		const createMock = vi
+			.fn()
+			// First call (streaming) throws
+			.mockRejectedValueOnce(new Error("streaming not supported"))
+			// Second call (non-streaming fallback) succeeds
+			.mockResolvedValueOnce({
+				model: "@cf/openai/gpt-oss-120b",
+				choices: [
+					{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+				],
+				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+			});
+
+		(adapter as any).client = {
+			chat: { completions: { create: createMock } },
+		};
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/openai/gpt-oss-120b" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: {
+					reasoning_effort: "low",
+					chat_template_kwargs: { enable_thinking: false },
+				},
+			} as any),
+		);
+
+		expect(createMock).toHaveBeenCalledTimes(2);
+		// Both attempts must carry the user's reasoning controls
+		for (const [args] of createMock.mock.calls) {
+			expect(args.reasoning_effort).toBe("low");
+			expect(args.chat_template_kwargs).toEqual({ enable_thinking: false });
+		}
+		warnSpy.mockRestore();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/tanstack-ai/test/workers-ai-adapter.test.ts
+++ b/packages/tanstack-ai/test/workers-ai-adapter.test.ts
@@ -904,6 +904,157 @@ describe("WorkersAiTextAdapter reasoning events", () => {
 });
 
 // ---------------------------------------------------------------------------
+// modelOptions passthrough — reasoning_effort / chat_template_kwargs
+// https://github.com/cloudflare/ai/issues/503
+// ---------------------------------------------------------------------------
+
+describe("WorkersAiTextAdapter modelOptions passthrough", () => {
+	it("should forward reasoning_effort from modelOptions to binding inputs (chatStream)", async () => {
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: { reasoning_effort: "low" },
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs.reasoning_effort).toBe("low");
+	});
+
+	it("should forward chat_template_kwargs from modelOptions to binding inputs (chatStream)", async () => {
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: {
+					chat_template_kwargs: { enable_thinking: false },
+				},
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs.chat_template_kwargs).toEqual({ enable_thinking: false });
+	});
+
+	it("should forward reasoning_effort: null (explicit 'no reasoning')", async () => {
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: { reasoning_effort: null },
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs).toHaveProperty("reasoning_effort");
+		expect(inputs.reasoning_effort).toBeNull();
+	});
+
+	it("should strip undefined values from modelOptions", async () => {
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: { reasoning_effort: undefined },
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs).not.toHaveProperty("reasoning_effort");
+	});
+
+	it("should prefer top-level temperature over a conflicting modelOptions value", async () => {
+		// If a user accidentally sets `temperature` inside modelOptions while also
+		// passing it at the top level, the TanStack-AI field wins. This prevents
+		// confusing behavior where provider options silently override standard knobs.
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await collectChunks(
+			adapter.chatStream({
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				temperature: 0.1,
+				modelOptions: { temperature: 0.9 } as any,
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs.temperature).toBe(0.1);
+	});
+
+	it("should forward reasoning_effort from modelOptions in structuredOutput", async () => {
+		const binding = createMockBinding({ response: '{"x":1}' });
+		const adapter = new WorkersAiTextAdapter(
+			"@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+			{ binding },
+		);
+
+		await adapter.structuredOutput({
+			outputSchema: { type: "object" },
+			chatOptions: {
+				model: "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel,
+				messages: [{ role: "user", content: "Hi" }],
+				modelOptions: {
+					reasoning_effort: "medium",
+					chat_template_kwargs: { enable_thinking: false },
+				},
+			},
+		} as any);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs.reasoning_effort).toBe("medium");
+		expect(inputs.chat_template_kwargs).toEqual({ enable_thinking: false });
+		// response_format should still be set for structured output
+		expect(inputs.response_format).toBeDefined();
+	});
+
+	it("should work when modelOptions is undefined (default path)", async () => {
+		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
+		const adapter = new WorkersAiTextAdapter(MODEL, { binding });
+
+		await collectChunks(
+			adapter.chatStream({
+				model: MODEL,
+				messages: [{ role: "user", content: "Hi" }],
+			} as any),
+		);
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs).not.toHaveProperty("reasoning_effort");
+		expect(inputs).not.toHaveProperty("chat_template_kwargs");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Premature stream termination
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `modelOptions` passthrough for Workers AI-specific reasoning controls (`reasoning_effort`, `chat_template_kwargs`) in `createWorkersAiChat`.
- Values reach `binding.run(model, inputs)` at the `inputs` level across all four config modes (binding / REST / gateway binding / gateway REST).
- New exported type `WorkersAiTextModelOptions` with an index-signature escape hatch for future Workers AI input fields.

Closes #503.

## Why

The TanStack AI adapter silently dropped `reasoning_effort` and `chat_template_kwargs` because `chatStream` and `structuredOutput` never placed them in the OpenAI SDK body, and the binding shim had a hardcoded allowlist that didn't include them. Reasoning models (GLM-4.7-flash, Kimi K2.5/K2.6, GPT-OSS, QwQ) therefore had no way to control reasoning from the adapter, leading to output token budgets being burned on chain-of-thought with no visible content. Sibling issue to #501 (workers-ai-provider).

## What changed

**`src/adapters/workers-ai.ts`**

- New `WorkersAiTextModelOptions` interface: typed `reasoning_effort` / `chat_template_kwargs` plus a `[key: string]: unknown` escape hatch.
- `normalizeModelOptions` helper: strips `undefined`, preserves `null` (because ``reasoning_effort: null`` is the explicit "disable reasoning" signal), defensively ignores non-object runtime values so stray primitives don't leak index-keyed entries.
- `WorkersAiTextAdapter` now types the provider-options generic with `WorkersAiTextModelOptions`.
- `chatStream` and `structuredOutput` spread normalized `modelOptions` **first** in each OpenAI SDK create call, so canonical TanStack-managed fields (`model`, `messages`, `temperature`, `max_tokens`, `stream`, `tools`, `response_format`, `stream_options`) always win in the spread order if a user accidentally duplicates a key.
- Both the streaming path and the non-streaming fallback path carry `modelOptions` on their create() calls.

**`src/utils/create-fetcher.ts`**

- Extends `createWorkersAiBindingFetch`'s input builder to pass through `reasoning_effort` and `chat_template_kwargs` from the OpenAI-shaped body onto the `inputs` object (2nd arg of `binding.run`). Uses ``!== undefined`` so ``null`` round-trips. The allowlist stays tight — unknown fields (``seed``, ``stream_options``, future OpenAI-only fields) are still dropped so the binding's strict schema validation doesn't reject the whole request.
- The gateway path already forwards the whole body as ``query``, so no change is needed there.

**`src/index.ts`** — exports `WorkersAiTextModelOptions`.

**`README.md`** — new "Reasoning Controls" section with the usage pattern and a note on `null` vs `undefined` semantics.

## Usage

```ts
import { chat } from "@tanstack/ai";
import { createWorkersAiChat } from "@cloudflare/tanstack-ai";

const adapter = createWorkersAiChat("@cf/zai-org/glm-4.7-flash", { binding: env.AI });

const response = chat({
  adapter,
  stream: true,
  messages: [{ role: "user", content: "Summarize in one sentence." }],
  modelOptions: {
    reasoning_effort: "low",              // "low" | "medium" | "high" | null
    chat_template_kwargs: { enable_thinking: false },
  },
});
```

## Test plan

- [x] 19 new unit tests across binding / adapter / gateway paths
- [x] Adapter: `reasoning_effort` via `modelOptions` reaches binding inputs (``chatStream``)
- [x] Adapter: `chat_template_kwargs` via `modelOptions` reaches binding inputs
- [x] Adapter: ``reasoning_effort: null`` preserved end-to-end
- [x] Adapter: ``undefined`` values in ``modelOptions`` stripped
- [x] Adapter: top-level ``temperature`` wins over a conflicting ``modelOptions.temperature``
- [x] Adapter: ``structuredOutput`` forwards ``modelOptions`` alongside ``response_format``
- [x] Adapter: default path (no ``modelOptions``) leaves inputs untouched
- [x] Adapter: non-object ``modelOptions`` (string, array) falls back gracefully — no index-keyed leak
- [x] Adapter: non-streaming fallback path preserves ``modelOptions`` on retry
- [x] Binding shim: reasoning fields land on inputs (2nd arg), not options (3rd arg)
- [x] Binding shim: ``chat_template_kwargs`` passthrough
- [x] Binding shim: ``null`` reasoning preserved
- [x] Binding shim: absence stays absent
- [x] Binding shim: empty ``{}`` for ``chat_template_kwargs`` forwarded
- [x] Binding shim: streaming requests carry reasoning fields
- [x] Binding shim: unknown body fields (``seed``, ``stream_options``, future fields) **dropped** — allowlist policy locked in
- [x] Gateway: reasoning fields in ``request.query``, ``model`` still stripped
- [x] Gateway: ``reasoning_effort: null`` in ``request.query``
- [x] Gateway: arbitrary unknown fields **forwarded** (escape hatch)
- [x] 244/244 unit tests passing
- [x] Type-check clean

## Notes for reviewers

- Two commits: the original fix plus a review pass adding defensive guards and lock-in tests for the binding-vs-gateway allowlist asymmetry. Happy to squash pre-merge.
- Scope is intentionally tight — only the two reasoning fields. Other Workers AI-specific fields can be added to the binding shim's allowlist in follow-ups if needed; today they work via REST/gateway through the escape-hatch spread.
- Sibling PR: #504 (workers-ai-provider). The two packages are independent and can merge/release separately.


Made with [Cursor](https://cursor.com)