### PR TITLE
chore: downgrade reasoning passthrough changesets to patch

### DIFF
--- a/.changeset/tanstack-ai-reasoning-passthrough.md
+++ b/.changeset/tanstack-ai-reasoning-passthrough.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/tanstack-ai": minor
+"@cloudflare/tanstack-ai": patch
 ---
 
 Add passthrough for `reasoning_effort` and `chat_template_kwargs` in `createWorkersAiChat`. Pass them per-call through `modelOptions`:

--- a/.changeset/workers-ai-provider-reasoning-passthrough.md
+++ b/.changeset/workers-ai-provider-reasoning-passthrough.md
@@ -1,5 +1,5 @@
 ---
-"workers-ai-provider": minor
+"workers-ai-provider": patch
 ---
 
 Forward `reasoning_effort` and `chat_template_kwargs` onto `binding.run(model, inputs)`'s `inputs` object instead of silently dropping them into the options arg / REST query string. This fixes reasoning models (GLM-4.7-flash, Kimi K2.5/K2.6, GPT-OSS, QwQ) burning the entire output token budget on chain-of-thought with no visible content.


### PR DESCRIPTION
## Summary

Downgrade the two changesets from #504 and #505 from `minor` → `patch`. These were bug fixes (reasoning fields were silently dropped with no working public API), so `patch` is the correct semver classification.

## Test plan

- [x] Both changeset files parse correctly (changesets only look at the first frontmatter line)
- No code changes — safe to merge as-is


Made with [Cursor](https://cursor.com)