### PR TITLE
fix(ai-gateway-provider): add createGoogle alias for createGoogleGenerativeAI

### DIFF
--- a/.changeset/add-create-google-alias.md
+++ b/.changeset/add-create-google-alias.md
@@ -1,0 +1,5 @@
+---
+"ai-gateway-provider": patch
+---
+
+Add `createGoogle` as an alias for `createGoogleGenerativeAI` in the Google provider. This fixes the mismatch between the Cloudflare dashboard example (which uses `createGoogle()`) and the package export. Both names now work interchangeably.

--- a/packages/ai-gateway-provider/README.md
+++ b/packages/ai-gateway-provider/README.md
@@ -180,6 +180,26 @@ const aigateway = createAiGateway({
     - `retryDelayMs`: Delay between retries
     - `backoff`: Retry backoff strategy ('constant', 'linear', 'exponential')
 
+### Google AI Studio Example
+
+```typescript
+import { createAiGateway } from "ai-gateway-provider";
+import { createGoogle } from "ai-gateway-provider/providers/google";
+import { generateText } from "ai";
+
+const aigateway = createAiGateway({
+	accountId: "{CLOUDFLARE_ACCOUNT_ID}",
+	gateway: "{GATEWAY_NAME}",
+});
+
+const google = createGoogle({ apiKey: "{GOOGLE_API_KEY}" });
+
+const { text } = await generateText({
+	model: aigateway(google("gemini-1.5-pro")),
+	prompt: "Write a vegetarian lasagna recipe for 4 people.",
+});
+```
+
 ## Supported Providers
 
 - OpenAI

--- a/packages/ai-gateway-provider/src/providers/google.ts
+++ b/packages/ai-gateway-provider/src/providers/google.ts
@@ -4,3 +4,5 @@ import { authWrapper } from "../auth";
 export const createGoogleGenerativeAI = (
 	...args: Parameters<typeof createGoogleGenerativeAIOriginal>
 ) => authWrapper(createGoogleGenerativeAIOriginal)(...args);
+
+export const createGoogle = createGoogleGenerativeAI;

--- a/packages/ai-gateway-provider/src/providers/index.ts
+++ b/packages/ai-gateway-provider/src/providers/index.ts
@@ -7,7 +7,7 @@ export { createDeepgram } from "./deepgram";
 export { createDeepSeek } from "./deepseek";
 export { createElevenLabs } from "./elevenlabs";
 export { createFireworks } from "./fireworks";
-export { createGoogleGenerativeAI } from "./google";
+export { createGoogle, createGoogleGenerativeAI } from "./google";
 export { createVertex } from "./google-vertex";
 export { createGroq } from "./groq";
 export { createMistral } from "./mistral";


### PR DESCRIPTION
## Summary

- Adds `createGoogle` as a convenience alias for `createGoogleGenerativeAI` in the Google provider
- Exports `createGoogle` from `providers/index.ts` alongside the existing export
- Adds a Google AI Studio usage example to the README

## Problem

The Cloudflare dashboard shows example code using `createGoogle()`, but the package only exported `createGoogleGenerativeAI()`. Users following the dashboard example got a runtime error.

## Solution

Both names now work interchangeably:

```ts
import { createGoogle } from "ai-gateway-provider/providers/google";
// or
import { createGoogleGenerativeAI } from "ai-gateway-provider/providers/google";
```

Closes #392

## Test plan

- [x] `pnpm build` passes
- [x] All 13 existing tests pass (`pnpm test`)
- [x] `createGoogle` appears in built `.d.mts` type definitions