### PR TITLE
widen @tanstack/ai peer + adapter ranges in @cloudflare/tanstack-ai

### DIFF
--- a/.changeset/widen-tanstack-ai-peers.md
+++ b/.changeset/widen-tanstack-ai-peers.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+Widen `@tanstack/ai` peer dependency and optional adapter ranges to accept newer 0.x releases (up to but not including 1.0.0). Previously the caret ranges on pre-1.0 versions resolved to a single minor (e.g. `^0.8.0` only allowed `>=0.8.0 <0.9.0`), causing unmet-peer warnings when consumers installed `@tanstack/ai@0.14.0` and matching adapter versions.

--- a/demos/mcp-server-bearer-auth/src/utils.ts
+++ b/demos/mcp-server-bearer-auth/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																																																	? "bg-green-100 text-green-800"
-																																																	: "bg-red-100 text-red-800"} rounded-full">
+																																																			? "bg-green-100 text-green-800"
+																																																			: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/demos/remote-mcp-server-autorag/src/utils.ts
+++ b/demos/remote-mcp-server-autorag/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																																																	? "bg-green-100 text-green-800"
-																																																	: "bg-red-100 text-red-800"} rounded-full">
+																																																			? "bg-green-100 text-green-800"
+																																																			: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/demos/remote-mcp-server/src/utils.ts
+++ b/demos/remote-mcp-server/src/utils.ts
@@ -314,8 +314,8 @@ export const renderApproveContent = async (
 		<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md text-center">
 			<div class="mb-4">
 				<span class="inline-block p-3 ${status === "success"
-																																																	? "bg-green-100 text-green-800"
-																																																	: "bg-red-100 text-red-800"} rounded-full">
+																																																			? "bg-green-100 text-green-800"
+																																																			: "bg-red-100 text-red-800"} rounded-full">
 					${status === "success" ? "✓" : "✗"}
 				</span>
 			</div>

--- a/packages/tanstack-ai/package.json
+++ b/packages/tanstack-ai/package.json
@@ -141,17 +141,17 @@
 		"dotenv": "^17.4.0"
 	},
 	"peerDependencies": {
-		"@tanstack/ai": "^0.8.0"
+		"@tanstack/ai": ">=0.8.0 <1.0.0"
 	},
 	"optionalDependencies": {
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@google/genai": "^1.48.0",
 		"@openrouter/sdk": "^0.10.2",
-		"@tanstack/ai-anthropic": "^0.7.1",
-		"@tanstack/ai-gemini": "^0.8.4",
-		"@tanstack/ai-grok": "^0.6.3",
-		"@tanstack/ai-openai": "^0.7.2",
-		"@tanstack/ai-openrouter": "^0.7.0"
+		"@tanstack/ai-anthropic": ">=0.7.1 <1.0.0",
+		"@tanstack/ai-gemini": ">=0.8.4 <1.0.0",
+		"@tanstack/ai-grok": ">=0.6.3 <1.0.0",
+		"@tanstack/ai-openai": ">=0.7.2 <1.0.0",
+		"@tanstack/ai-openrouter": ">=0.7.0 <1.0.0"
 	},
 	"packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1763,19 +1763,19 @@ importers:
         specifier: ^0.10.2
         version: 0.10.2
       '@tanstack/ai-anthropic':
-        specifier: ^0.7.1
+        specifier: '>=0.7.1 <1.0.0'
         version: 0.7.1(@tanstack/ai@0.9.2)(zod@4.3.6)
       '@tanstack/ai-gemini':
-        specifier: ^0.8.4
+        specifier: '>=0.8.4 <1.0.0'
         version: 0.8.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.9.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@tanstack/ai-grok':
-        specifier: ^0.6.3
+        specifier: '>=0.6.3 <1.0.0'
         version: 0.6.3(@tanstack/ai@0.9.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       '@tanstack/ai-openai':
-        specifier: ^0.7.2
+        specifier: '>=0.7.2 <1.0.0'
         version: 0.7.2(@tanstack/ai-client@0.7.6)(@tanstack/ai@0.9.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.3.6)
       '@tanstack/ai-openrouter':
-        specifier: ^0.7.0
+        specifier: '>=0.7.0 <1.0.0'
         version: 0.7.0(@tanstack/ai@0.9.2)
 
   packages/workers-ai-provider:


### PR DESCRIPTION
Pre-1.0 carets resolve to a single minor (e.g. ^0.8.0 → >=0.8.0 <0.9.0), so consumers on @tanstack/ai 0.14.x hit unmet-peer warnings. Switch the peer + optional adapter ranges to >=x.y.z <1.0.0 to accept the full 0.x line.