### PR TITLE
Add AWS Bedrock support to ai-gateway-provider

### DIFF
--- a/packages/ai-gateway-provider/src/index.ts
+++ b/packages/ai-gateway-provider/src/index.ts
@@ -118,6 +118,17 @@ export class AiGatewayChatLanguageModel implements LanguageModelV3 {
 					} else {
 						delete req.request.headers[authHeader];
 					}
+
+					// Strip companion auth headers (e.g. AWS SigV4 headers for Bedrock)
+					if (providerConfig.extraStripHeaders) {
+						for (const header of providerConfig.extraStripHeaders) {
+							if ("delete" in req.request.headers) {
+								req.request.headers.delete(header);
+							} else {
+								delete req.request.headers[header];
+							}
+						}
+					}
 				}
 
 				return {

--- a/packages/ai-gateway-provider/src/providers.ts
+++ b/packages/ai-gateway-provider/src/providers.ts
@@ -1,4 +1,12 @@
-export const providers = [
+type ProviderConfig = {
+	name: string;
+	regex: RegExp;
+	transformEndpoint: (url: string) => string;
+	headerKey?: string;
+	extraStripHeaders?: string[];
+};
+
+export const providers: ProviderConfig[] = [
 	{
 		name: "openai",
 		regex: /^https:\/\/api\.openai\.com\//,
@@ -81,6 +89,20 @@ export const providers = [
 		name: "openrouter",
 		regex: /^https:\/\/openrouter\.ai\/api\//,
 		transformEndpoint: (url: string) => url.replace(/^https:\/\/openrouter\.ai\/api\//, ""),
+	},
+	{
+		name: "aws-bedrock",
+		regex: /^https:\/\/bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com\//,
+		transformEndpoint: (url: string) => {
+			const match = url.match(
+				/^https:\/\/bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com\/(.*)/,
+			);
+			if (!match || !match[1] || !match[2]) {
+				throw new Error("Failed to parse AWS Bedrock endpoint URL.");
+			}
+			return `bedrock-runtime/${match[1]}/${match[2]}`;
+		},
+		extraStripHeaders: ["x-amz-date", "x-amz-security-token", "x-amz-content-sha256"],
 	},
 	{
 		name: "compat",

--- a/packages/ai-gateway-provider/src/providers/amazon-bedrock.ts
+++ b/packages/ai-gateway-provider/src/providers/amazon-bedrock.ts
@@ -1,5 +1,20 @@
 import { createAmazonBedrock as createAmazonBedrockOriginal } from "@ai-sdk/amazon-bedrock";
-import { authWrapper } from "../auth";
+import { CF_TEMP_TOKEN } from "../auth";
 
-export const createAmazonBedrock = (...args: Parameters<typeof createAmazonBedrockOriginal>) =>
-	authWrapper(createAmazonBedrockOriginal)(...args);
+export const createAmazonBedrock = (...args: Parameters<typeof createAmazonBedrockOriginal>) => {
+	let [config] = args;
+	if (config === undefined) {
+		config = { region: "us-east-1", accessKeyId: CF_TEMP_TOKEN, secretAccessKey: CF_TEMP_TOKEN };
+	} else {
+		if (config.region === undefined) {
+			config.region = "us-east-1";
+		}
+		if (config.accessKeyId === undefined) {
+			config.accessKeyId = CF_TEMP_TOKEN;
+		}
+		if (config.secretAccessKey === undefined) {
+			config.secretAccessKey = CF_TEMP_TOKEN;
+		}
+	}
+	return createAmazonBedrockOriginal(config);
+};

--- a/packages/ai-gateway-provider/test/endpoint.test.ts
+++ b/packages/ai-gateway-provider/test/endpoint.test.ts
@@ -52,6 +52,16 @@ const testCases = [
 		name: "azure-openai",
 		url: "https://myresource.openai.azure.com/openai/deployments/mydeployment/chat/completions?api-version=2024-02-15-preview",
 	},
+	{
+		expected: "bedrock-runtime/us-east-1/model/anthropic.claude-sonnet-4-5-20250929-v1:0/invoke",
+		name: "aws-bedrock",
+		url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-20250929-v1:0/invoke",
+	},
+	{
+		expected: "bedrock-runtime/us-east-1/model/anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+		name: "aws-bedrock",
+		url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-sonnet-4-5-20250929-v1%3A0/converse",
+	},
 ];
 
 describe("ProvidersConfigs endpoint parsing", () => {


### PR DESCRIPTION
## Summary

- Add AWS Bedrock as a supported provider in the `ai-gateway-provider` package
- Register URL pattern for `bedrock-runtime.{region}.amazonaws.com` with endpoint transform producing `bedrock-runtime/{region}/{path}` (matching Cloudflare AI Gateway's expected format)
- Fix `amazon-bedrock.ts` provider wrapper to handle Bedrock's AWS SigV4 auth model (`accessKeyId`/`secretAccessKey`) instead of the generic `authWrapper` which only supports `apiKey`
- Strip AWS SigV4 companion headers (`x-amz-date`, `x-amz-security-token`, `x-amz-content-sha256`) **only** in BYOK mode (when `CF_TEMP_TOKEN` is detected) — user-provided credentials are preserved
- Add `ProviderConfig` type for type safety across the provider registry
- Add endpoint transform tests including URL-encoded model IDs (`v1%3A0`)

## Context

The Bedrock provider wrapper existed (`providers/amazon-bedrock.ts`) but requests failed with `"provider not supported"` because:
1. No URL regex in `providers.ts` matched Bedrock's `bedrock-runtime.{region}.amazonaws.com` URLs
2. The generic `authWrapper` tried to set `apiKey`, but Bedrock uses `accessKeyId`/`secretAccessKey` for AWS SigV4 signing
3. AWS SigV4 headers needed to be stripped before forwarding to the gateway (Cloudflare re-signs with stored credentials)

## Usage

```typescript
import { createAiGateway } from "ai-gateway-provider";
import { createAmazonBedrock } from "ai-gateway-provider/providers/amazon-bedrock";
import { generateText } from "ai";

// BYOK mode — Cloudflare holds the AWS credentials
const gateway = createAiGateway({
  accountId: "your-cf-account-id",
  gateway: "your-gateway",
  apiKey: "your-cf-token",
});
const bedrock = createAmazonBedrock({ region: "us-east-1" });

const { text } = await generateText({
  model: gateway(bedrock("us.anthropic.claude-sonnet-4-5-20250929-v1:0")),
  prompt: "Hello!",
});
```

## Test plan

- [x] Endpoint transform tests pass (15/15), including 2 new Bedrock cases (unencoded + URL-encoded model IDs)
- [x] All existing provider tests still pass (no regressions)
- [x] Manually verified end-to-end: request successfully routed through Cloudflare AI Gateway to Bedrock and received a valid response
- [x] Verify with client-provided AWS credentials (non-BYOK mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)