### PR TITLE
Fix Workers AI tool call ID collisions

### DIFF
--- a/.changeset/fix-workers-ai-toolcallid-collisions.md
+++ b/.changeset/fix-workers-ai-toolcallid-collisions.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Rewrite Workers AI tool call IDs exposed to the AI SDK and restore the original provider IDs when building follow-up prompts to avoid collisions across chat turns.

--- a/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
+++ b/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3DataContent, LanguageModelV3Prompt } from "@ai-sdk/provider";
+import { toWorkersAIToolCallId } from "./utils";
 import type { WorkersAIContentPart, WorkersAIChatPrompt } from "./workersai-chat-prompt";
 
 /**
@@ -144,7 +145,7 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV3Prompt): {
 									arguments: JSON.stringify(part.input),
 									name: part.toolName,
 								},
-								id: part.toolCallId,
+								id: toWorkersAIToolCallId(part.toolCallId),
 								type: "function",
 							});
 							break;
@@ -216,7 +217,7 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV3Prompt): {
 						messages.push({
 							content,
 							name: toolResponse.toolName,
-							tool_call_id: toolResponse.toolCallId,
+							tool_call_id: toWorkersAIToolCallId(toolResponse.toolCallId),
 							role: "tool",
 						});
 					}

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -6,6 +6,7 @@ import type {
 import { generateId } from "ai";
 import { mapWorkersAIFinishReason } from "./map-workersai-finish-reason";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
+import { createAISDKToolCallId } from "./utils";
 
 /**
  * Prepend a stream-start event to an existing LanguageModelV3 stream.
@@ -317,7 +318,7 @@ export function getMappedStream(
 					closeToolCall(lastActiveToolIndex, controller);
 				}
 
-				const id = tcId || generateId();
+				const id = createAISDKToolCallId(tcId);
 				const toolName = tcName || "";
 				activeToolCalls.set(tcIndex, { id, toolName, args: "" });
 				lastActiveToolIndex = tcIndex;

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -323,6 +323,23 @@ export function prepareToolsAndToolChoice(
 // Tool call processing
 // ---------------------------------------------------------------------------
 
+const TOOL_CALL_ID_MARKER = "::cf-wai-tool-call::";
+
+export function createAISDKToolCallId(toolCallId: string | null | undefined): string {
+	const originalId = toolCallId || generateId();
+	return `${originalId}${TOOL_CALL_ID_MARKER}${generateId()}`;
+}
+
+export function toWorkersAIToolCallId(toolCallId: string): string {
+	const markerIndex = toolCallId.lastIndexOf(TOOL_CALL_ID_MARKER);
+	if (markerIndex === -1) return toolCallId;
+
+	const suffixIndex = markerIndex + TOOL_CALL_ID_MARKER.length;
+	if (suffixIndex >= toolCallId.length) return toolCallId;
+
+	return toolCallId.slice(0, markerIndex);
+}
+
 /** Workers AI flat tool call format (non-streaming, native) */
 interface FlatToolCall {
 	name: string;
@@ -406,7 +423,7 @@ function processToolCall(toolCall: FlatToolCall | OpenAIToolCall): LanguageModel
 				typeof fn.arguments === "string"
 					? fn.arguments
 					: JSON.stringify(fn.arguments || {}),
-			toolCallId: toolCall.id || generateId(),
+			toolCallId: createAISDKToolCallId(toolCall.id),
 			type: "tool-call",
 			toolName: fn.name,
 		};
@@ -419,7 +436,7 @@ function processToolCall(toolCall: FlatToolCall | OpenAIToolCall): LanguageModel
 			typeof flat.arguments === "string"
 				? flat.arguments
 				: JSON.stringify(flat.arguments || {}),
-		toolCallId: flat.id || generateId(),
+		toolCallId: createAISDKToolCallId(flat.id),
 		type: "tool-call",
 		toolName: flat.name,
 	};

--- a/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
+++ b/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { convertToWorkersAIChatMessages } from "../src/convert-to-workersai-chat-messages";
+import { createAISDKToolCallId } from "../src/utils";
 
 describe("convertToWorkersAIChatMessages", () => {
 	describe("tool call ID preservation", () => {
@@ -151,6 +152,82 @@ describe("convertToWorkersAIChatMessages", () => {
 			expect(messages[0].content).toBe("");
 			expect(messages[0].tool_calls).toBeDefined();
 			expect(messages[0].tool_calls![0].id).toBe(originalId);
+		});
+
+		it("should restore rewritten assistant tool call IDs before sending to Workers AI", () => {
+			const originalId = "functions.list_toolbox_tools:0";
+			const rewrittenId = createAISDKToolCallId(originalId);
+
+			const { messages } = convertToWorkersAIChatMessages([
+				{
+					role: "assistant" as const,
+					content: [
+						{
+							type: "tool-call" as const,
+							toolCallId: rewrittenId,
+							toolName: "list_toolbox_tools",
+							input: {},
+						},
+					],
+				},
+			]);
+
+			expect(messages[0].tool_calls![0].id).toBe(originalId);
+		});
+
+		it("should restore rewritten tool result IDs for tool error outputs", () => {
+			const originalId = "functions.invoke_toolbox_tool:1";
+			const rewrittenId = createAISDKToolCallId(originalId);
+
+			const { messages } = convertToWorkersAIChatMessages([
+				{
+					role: "tool" as const,
+					content: [
+						{
+							type: "tool-result" as const,
+							toolCallId: rewrittenId,
+							toolName: "invoke_toolbox_tool",
+							output: { type: "error-text", value: "tool failed" } as any,
+						},
+					],
+				},
+			]);
+
+			expect(messages[0].tool_call_id).toBe(originalId);
+			expect(messages[0].content).toBe("tool failed");
+		});
+
+		it("should round-trip already-unique GLM-style IDs back to their exact original", () => {
+			const originalId = "chatcmpl-tool-8a89c35582d60474";
+			const rewrittenId = createAISDKToolCallId(originalId);
+
+			const { messages } = convertToWorkersAIChatMessages([
+				{
+					role: "assistant" as const,
+					content: [
+						{
+							type: "tool-call" as const,
+							toolCallId: rewrittenId,
+							toolName: "get_weather",
+							input: { city: "London" },
+						},
+					],
+				},
+				{
+					role: "tool" as const,
+					content: [
+						{
+							type: "tool-result" as const,
+							toolCallId: rewrittenId,
+							toolName: "get_weather",
+							output: { type: "json", value: { weather: "Raining" } } as any,
+						},
+					],
+				},
+			]);
+
+			expect(messages[0].tool_calls![0].id).toBe(originalId);
+			expect(messages[1].tool_call_id).toBe(originalId);
 		});
 	});
 

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -5,6 +5,7 @@ import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import { createWorkersAI } from "../src/index";
+import { toWorkersAIToolCallId } from "../src/utils";
 
 const TEST_ACCOUNT_ID = "test-account-id";
 const TEST_API_KEY = "test-api-key";
@@ -206,7 +207,8 @@ describe("REST API - Streaming Text Tests", () => {
 
 		expect(toolCalls).toHaveLength(1);
 		expect(toolCalls[0].toolName).toBe("get_weather");
-		expect(toolCalls[0].toolCallId).toBe("call123");
+		expect(toolCalls[0].toolCallId).not.toBe("call123");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("call123");
 		expect(await result.finishReason).toBe("tool-calls");
 	});
 
@@ -263,7 +265,8 @@ describe("REST API - Streaming Text Tests", () => {
 
 		expect(toolCalls).toHaveLength(1);
 		expect(toolCalls[0].toolName).toBe("get_weather");
-		expect(toolCalls[0].toolCallId).toBe("chatcmpl-tool-abc");
+		expect(toolCalls[0].toolCallId).not.toBe("chatcmpl-tool-abc");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("chatcmpl-tool-abc");
 		expect(await result.finishReason).toBe("tool-calls");
 	});
 
@@ -496,7 +499,8 @@ describe("Binding - Streaming Text Tests", () => {
 
 		expect(toolCalls).toHaveLength(1);
 		expect(toolCalls[0].toolName).toBe("get_weather");
-		expect(toolCalls[0].toolCallId).toBe("call_abc");
+		expect(toolCalls[0].toolCallId).not.toBe("call_abc");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("call_abc");
 	});
 
 	it("should handle streamed multiple tool calls via binding", async () => {
@@ -575,6 +579,98 @@ describe("Binding - Streaming Text Tests", () => {
 		expect(toolCalls[1].toolName).toBe("get_temperature");
 	});
 
+	it("should rewrite repeated Kimi-style tool call IDs across turns and restore originals in prompts", async () => {
+		const capturedInputs: any[] = [];
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (_modelName: string, inputs: any) => {
+					capturedInputs.push(inputs);
+					return mockStream([
+						{
+							tool_calls: [
+								{
+									id: "functions.list_toolbox_tools:0",
+									type: "function",
+									index: 0,
+									function: { name: "list_toolbox_tools", arguments: "{}" },
+								},
+							],
+						},
+						{ finish_reason: "tool_calls" },
+						"[DONE]",
+					]);
+				},
+			},
+		});
+
+		const model = workersai(TEST_MODEL);
+		const tools = {
+			list_toolbox_tools: {
+				description: "List tools",
+				inputSchema: z.object({}),
+			},
+		};
+
+		const first = streamText({
+			model,
+			messages: [{ role: "user", content: "first" }],
+			tools,
+		});
+		const firstToolCalls: any[] = [];
+		for await (const chunk of first.fullStream) {
+			if (chunk.type === "tool-call") firstToolCalls.push(chunk);
+		}
+
+		const second = streamText({
+			model,
+			messages: [
+				{ role: "user", content: "first" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool-call",
+							toolCallId: firstToolCalls[0].toolCallId,
+							toolName: "list_toolbox_tools",
+							input: {},
+						},
+					],
+				},
+				{
+					role: "tool",
+					content: [
+						{
+							type: "tool-result",
+							toolCallId: firstToolCalls[0].toolCallId,
+							toolName: "list_toolbox_tools",
+							output: { type: "text", value: "[]" },
+						},
+					],
+				},
+				{ role: "user", content: "second" },
+			] as any,
+			tools,
+		});
+		const secondToolCalls: any[] = [];
+		for await (const chunk of second.fullStream) {
+			if (chunk.type === "tool-call") secondToolCalls.push(chunk);
+		}
+
+		expect(firstToolCalls).toHaveLength(1);
+		expect(secondToolCalls).toHaveLength(1);
+		expect(firstToolCalls[0].toolCallId).not.toBe(secondToolCalls[0].toolCallId);
+		expect(toWorkersAIToolCallId(firstToolCalls[0].toolCallId)).toBe(
+			"functions.list_toolbox_tools:0",
+		);
+		expect(toWorkersAIToolCallId(secondToolCalls[0].toolCallId)).toBe(
+			"functions.list_toolbox_tools:0",
+		);
+		expect(capturedInputs[1].messages[1].tool_calls[0].id).toBe(
+			"functions.list_toolbox_tools:0",
+		);
+		expect(capturedInputs[1].messages[2].tool_call_id).toBe("functions.list_toolbox_tools:0");
+	});
+
 	it("should handle streamed OpenAI-format tool calls with reasoning via binding", async () => {
 		const workersai = createWorkersAI({
 			binding: {
@@ -649,7 +745,8 @@ describe("Binding - Streaming Text Tests", () => {
 		expect(reasoning).toBe("Let me check the weather.");
 		expect(toolCalls).toHaveLength(1);
 		expect(toolCalls[0].toolName).toBe("get_weather");
-		expect(toolCalls[0].toolCallId).toBe("chatcmpl-tool-abc");
+		expect(toolCalls[0].toolCallId).not.toBe("chatcmpl-tool-abc");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("chatcmpl-tool-abc");
 		expect(await result.finishReason).toBe("tool-calls");
 	});
 
@@ -1583,7 +1680,17 @@ describe("Incremental Tool Call Streaming", () => {
 		const toolCall = parts.find((p) => p.type === "tool-call");
 		expect(toolCall).toBeDefined();
 		expect(toolCall.toolName).toBe("get_weather");
-		expect(toolCall.toolCallId).toBe("call1");
+		expect(toolCall.toolCallId).not.toBe("call1");
+		expect(toWorkersAIToolCallId(toolCall.toolCallId)).toBe("call1");
+
+		const toolEventIds = parts
+			.filter((p) =>
+				["tool-input-start", "tool-input-delta", "tool-input-end", "tool-call"].includes(
+					p.type,
+				),
+			)
+			.map((p) => p.toolCallId ?? p.id);
+		expect(new Set(toolEventIds)).toEqual(new Set([toolCall.toolCallId]));
 
 		// The AI SDK assembles and parses the full arguments from incremental events
 		const args = toolCall.args ?? toolCall.input;
@@ -2242,7 +2349,8 @@ describe("Eager tool-input-end streaming (issue #488)", () => {
 			"tool-input-end",
 			"tool-call",
 		]);
-		expect(toolCallData[0].toolCallId).toBe("solo");
+		expect(toolCallData[0].toolCallId).not.toBe("solo");
+		expect(toWorkersAIToolCallId(toolCallData[0].toolCallId)).toBe("solo");
 		expect(toolCallData[0].toolName).toBe("get_weather");
 	});
 
@@ -2498,8 +2606,10 @@ describe("Eager tool-input-end streaming (issue #488)", () => {
 			"tool-call",
 		]);
 
-		expect(toolCalls[0].toolCallId).toBe("call_1");
-		expect(toolCalls[1].toolCallId).toBe("call_2");
+		expect(toolCalls[0].toolCallId).not.toBe("call_1");
+		expect(toolCalls[1].toolCallId).not.toBe("call_2");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("call_1");
+		expect(toWorkersAIToolCallId(toolCalls[1].toolCallId)).toBe("call_2");
 	});
 
 	it("should not double-close a tool call (finalization + new index)", async () => {
@@ -2639,8 +2749,10 @@ describe("Eager tool-input-end streaming (issue #488)", () => {
 			"tool-input-end",
 			"tool-call",
 		]);
-		expect(toolCalls[0].toolCallId).toBe("call_1");
-		expect(toolCalls[1].toolCallId).toBe("call_2");
+		expect(toolCalls[0].toolCallId).not.toBe("call_1");
+		expect(toolCalls[1].toolCallId).not.toBe("call_2");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("call_1");
+		expect(toWorkersAIToolCallId(toolCalls[1].toolCallId)).toBe("call_2");
 	});
 
 	it("should handle three sequential OpenAI-format tool calls with eager close", async () => {
@@ -2736,9 +2848,12 @@ describe("Eager tool-input-end streaming (issue #488)", () => {
 		}
 
 		expect(toolCalls).toHaveLength(3);
-		expect(toolCalls[0].toolCallId).toBe("call_1");
-		expect(toolCalls[1].toolCallId).toBe("call_2");
-		expect(toolCalls[2].toolCallId).toBe("call_3");
+		expect(toolCalls[0].toolCallId).not.toBe("call_1");
+		expect(toolCalls[1].toolCallId).not.toBe("call_2");
+		expect(toolCalls[2].toolCallId).not.toBe("call_3");
+		expect(toWorkersAIToolCallId(toolCalls[0].toolCallId)).toBe("call_1");
+		expect(toWorkersAIToolCallId(toolCalls[1].toolCallId)).toBe("call_2");
+		expect(toWorkersAIToolCallId(toolCalls[2].toolCallId)).toBe("call_3");
 
 		const toolEvents = events.filter((e) =>
 			["tool-input-start", "tool-input-end", "tool-call"].includes(e),

--- a/packages/workers-ai-provider/test/utils.test.ts
+++ b/packages/workers-ai-provider/test/utils.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
+	createAISDKToolCallId,
 	processPartialToolCalls,
 	processToolCalls,
 	processText,
 	normalizeMessagesForBinding,
 	prepareToolsAndToolChoice,
 	createRun,
+	toWorkersAIToolCallId,
 } from "../src/utils";
 
 // ---------------------------------------------------------------------------
@@ -120,7 +122,8 @@ describe("processPartialToolCalls", () => {
 		expect(result).toHaveLength(1);
 		expect(result[0].input).toBe('{"param": "value"}');
 		expect(result[0].toolName).toBe("test_func");
-		expect(result[0].toolCallId).toBe("call_123");
+		expect(result[0].toolCallId).not.toBe("call_123");
+		expect(toWorkersAIToolCallId(result[0].toolCallId)).toBe("call_123");
 	});
 
 	it("should handle multiple partial tool calls with different indices", () => {
@@ -148,8 +151,8 @@ describe("processPartialToolCalls", () => {
 		const result = processPartialToolCalls(partialCalls);
 		expect(result).toHaveLength(2);
 
-		const call1 = result.find((call) => call.toolCallId === "call_1");
-		const call2 = result.find((call) => call.toolCallId === "call_2");
+		const call1 = result.find((call) => toWorkersAIToolCallId(call.toolCallId) === "call_1");
+		const call2 = result.find((call) => toWorkersAIToolCallId(call.toolCallId) === "call_2");
 
 		expect(call1?.input).toBe('{"a":"value1"}');
 		expect(call2?.input).toBe('{"b":"value2"}');
@@ -176,14 +179,14 @@ describe("processToolCalls", () => {
 		};
 
 		const result = processToolCalls(output);
-		expect(result).toEqual([
-			{
-				input: '{"param": "value"}',
-				toolCallId: "call_123",
-				toolName: "test_function",
-				type: "tool-call",
-			},
-		]);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			input: '{"param": "value"}',
+			toolName: "test_function",
+			type: "tool-call",
+		});
+		expect(result[0].toolCallId).not.toBe("call_123");
+		expect(toWorkersAIToolCallId(result[0].toolCallId)).toBe("call_123");
 	});
 
 	it("should handle tool calls with object arguments", () => {
@@ -216,14 +219,14 @@ describe("processToolCalls", () => {
 		};
 
 		const result = processToolCalls(output);
-		expect(result).toEqual([
-			{
-				input: '{"param": "value"}',
-				toolCallId: "call_123",
-				toolName: "test_function",
-				type: "tool-call",
-			},
-		]);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			input: '{"param": "value"}',
+			toolName: "test_function",
+			type: "tool-call",
+		});
+		expect(result[0].toolCallId).not.toBe("call_123");
+		expect(toWorkersAIToolCallId(result[0].toolCallId)).toBe("call_123");
 	});
 
 	it("should return empty array when no tool calls present", () => {
@@ -272,8 +275,40 @@ describe("processToolCalls", () => {
 		const result = processToolCalls(output);
 		expect(result).toHaveLength(1);
 		expect(result[0].toolName).toBe("get_weather");
-		expect(result[0].toolCallId).toBe("call_abc");
+		expect(result[0].toolCallId).not.toBe("call_abc");
+		expect(toWorkersAIToolCallId(result[0].toolCallId)).toBe("call_abc");
 		expect(result[0].input).toBe('{"city": "London"}');
+	});
+
+	it("should rewrite duplicate Kimi-style tool call IDs for AI SDK consumers", () => {
+		const output = {
+			tool_calls: [
+				{
+					id: "functions.list_toolbox_tools:0",
+					type: "function",
+					function: { name: "list_toolbox_tools", arguments: "{}" },
+				},
+				{
+					id: "functions.list_toolbox_tools:0",
+					type: "function",
+					function: { name: "list_toolbox_tools", arguments: "{}" },
+				},
+			],
+		};
+
+		const result = processToolCalls(output);
+		expect(result).toHaveLength(2);
+		expect(result[0].toolCallId).not.toBe(result[1].toolCallId);
+		expect(toWorkersAIToolCallId(result[0].toolCallId)).toBe("functions.list_toolbox_tools:0");
+		expect(toWorkersAIToolCallId(result[1].toolCallId)).toBe("functions.list_toolbox_tools:0");
+	});
+
+	it("should round-trip already-unique GLM-style tool call IDs", () => {
+		const originalId = "chatcmpl-tool-8a89c35582d60474";
+		const rewrittenId = createAISDKToolCallId(originalId);
+
+		expect(rewrittenId).not.toBe(originalId);
+		expect(toWorkersAIToolCallId(rewrittenId)).toBe(originalId);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Rewrite Workers AI tool call IDs before exposing them to the AI SDK so provider-local IDs, like Kimi's `functions.{toolName}:0`, do not collide across chat turns.
- Restore the original Workers AI tool call IDs when serializing prior assistant tool calls and tool results back into follow-up prompts.
- Add regression coverage for repeated Kimi-style IDs, GLM-style already-unique ID round-trips, streaming partial tool-call events, and tool error outputs.

Related upstream issue: https://github.com/cloudflare/agents/issues/1465

## Why workers-ai-provider

The provider is the single boundary where Workers AI runtime IDs enter the AI SDK ecosystem. Normalizing here fixes all direct and framework consumers, including `@cloudflare/ai-chat`, without changing AI SDK APIs or requiring each persistence layer to special-case Workers AI/Kimi ID shapes.

## Non-regression note

Models that already emit unique IDs, such as GLM-style `chatcmpl-tool-...`, are still supported: IDs are rewritten only at the AI SDK boundary and restored exactly when sent back to Workers AI in the next request.

## Verification

- `pnpm --dir "packages/workers-ai-provider" exec vitest --run test/utils.test.ts test/convert-to-workersai-chat-messages.test.ts test/stream-text.test.ts`
- `pnpm --filter workers-ai-provider test:ci`
- `pnpm --filter workers-ai-provider type-check`
- `pnpm --filter workers-ai-provider build`

Note: `pnpm install` emitted a pre-existing patch warning for `@ai-sdk/google-vertex`; it did not affect these checks.