### PR TITLE
fix: keep demos on published workers-ai-provider version

### DIFF
--- a/demos/agent-scheduler/package.json
+++ b/demos/agent-scheduler/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/agent-task-manager-human-in-the-loop/package.json
+++ b/demos/agent-task-manager-human-in-the-loop/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/agent-task-manager/package.json
+++ b/demos/agent-task-manager/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/evaluator-optimiser/package.json
+++ b/demos/evaluator-optimiser/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/image-generation/package.json
+++ b/demos/image-generation/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/model-scraper/package.json
+++ b/demos/model-scraper/package.json
@@ -23,7 +23,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/orchestrator-workers/package.json
+++ b/demos/orchestrator-workers/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/parallelisation/package.json
+++ b/demos/parallelisation/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/prompt-chaining/package.json
+++ b/demos/prompt-chaining/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/routing/package.json
+++ b/demos/routing/package.json
@@ -18,7 +18,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/structured-output-node/package.json
+++ b/demos/structured-output-node/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"ai": "^6.0.143",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/structured-output/package.json
+++ b/demos/structured-output/package.json
@@ -20,7 +20,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/text-generation-stream/package.json
+++ b/demos/text-generation-stream/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/text-generation/package.json
+++ b/demos/text-generation/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/tool-calling-stream/package.json
+++ b/demos/tool-calling-stream/package.json
@@ -19,7 +19,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/tool-calling/package.json
+++ b/demos/tool-calling/package.json
@@ -20,7 +20,7 @@
 		"agents": "^0.9.0",
 		"ai": "^6.0.143",
 		"hono": "^4.12.9",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/demos/vision/package.json
+++ b/demos/vision/package.json
@@ -18,7 +18,7 @@
 		"hono": "^4.12.9",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
-		"workers-ai-provider": "^3.1.14",
+		"workers-ai-provider": "^3.1.13",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Hotfix for the failed build and release workflows.

The changeset version PR bumped demo dependencies to `workers-ai-provider@^3.1.14` before `3.1.14` was published to npm. That caused `pnpm install` to fail with:

```text
ERR_PNPM_NO_MATCHING_VERSION No matching version found for workers-ai-provider@^3.1.14
```

This PR reverts demo dependencies to the latest published range, `^3.1.13`, while leaving `packages/workers-ai-provider` at `3.1.14` so the release workflow can publish it.

## Verification

- `pnpm install --frozen-lockfile --child-concurrency=10`
- `pnpm lint-npm-lockfiles`
- `pnpm nx build workers-ai-provider`
- `pnpm nx build ai-gateway-provider`
- `pnpm nx build @cloudflare/tanstack-ai`

## Changeset

No changeset. This only updates private demo dependencies to unblock the release.
