### PR TITLE
fix: prevent release dependency cycles for demos

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
 	"privatePackages": {
 		"tag": false,
 		"version": false

--- a/.github/workflows/refresh-demo-dependencies.yml
+++ b/.github/workflows/refresh-demo-dependencies.yml
@@ -1,0 +1,89 @@
+name: Refresh demo dependencies
+
+on:
+    workflow_run:
+        workflows: [Release]
+        types: [completed]
+    workflow_dispatch:
+        inputs:
+            package:
+                description: Demo dependency package to refresh
+                required: true
+                default: workers-ai-provider
+            version:
+                description: Version to use. Leave empty to use latest from npm.
+                required: false
+                default: ""
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    refresh:
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+        runs-on: ubuntu-22.04
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: main
+
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: pnpm
+                  registry-url: https://registry.npmjs.org
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile --child-concurrency=10
+
+            - name: Resolve dependency version
+              id: dependency
+              env:
+                  INPUT_PACKAGE: ${{ inputs.package || 'workers-ai-provider' }}
+                  INPUT_VERSION: ${{ inputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  package="$INPUT_PACKAGE"
+                  version="$INPUT_VERSION"
+
+                  if [ -z "$version" ]; then
+                    version="$(npm view "$package" version)"
+                  fi
+
+                  echo "package=$package" >> "$GITHUB_OUTPUT"
+                  echo "version=$version" >> "$GITHUB_OUTPUT"
+                  echo "range=^$version" >> "$GITHUB_OUTPUT"
+
+            - name: Update demo package.json files
+              run: pnpm aicli update-demo-dependency "${{ steps.dependency.outputs.package }}" "${{ steps.dependency.outputs.range }}"
+
+            - name: Regenerate demo package-lock.json files
+              run: |
+                  if git diff --quiet -- demos; then
+                    echo "No demo dependency changes to lock."
+                    exit 0
+                  fi
+
+                  pnpm generate-npm-lockfiles
+
+            - name: Create pull request
+              uses: peter-evans/create-pull-request@v7
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: automation/update-demo-${{ steps.dependency.outputs.package }}
+                  delete-branch: true
+                  commit-message: "chore: update demos to ${{ steps.dependency.outputs.package }} ${{ steps.dependency.outputs.version }}"
+                  title: "chore: update demos to ${{ steps.dependency.outputs.package }} ${{ steps.dependency.outputs.version }}"
+                  body: |
+                      Updates demos to `${{ steps.dependency.outputs.package }}@${{ steps.dependency.outputs.range }}` after the package has been published to npm.
+
+                      This PR was created automatically after a successful release workflow.
+
+                      ## Verification
+
+                      - `pnpm generate-npm-lockfiles`

--- a/tools/aicli/src/bin/aicli.ts
+++ b/tools/aicli/src/bin/aicli.ts
@@ -1,4 +1,5 @@
 import { Command } from "@commander-js/extra-typings";
+import { updateDemoDependency } from "../demo-dependencies";
 import { generateNpmLockfiles, lintNpmLockfiles } from "../npm";
 
 const program = new Command();
@@ -17,6 +18,15 @@ program
 	.description("Lint all demos to ensure npm lockfiles are up to date")
 	.action(async () => {
 		await lintNpmLockfiles();
+	});
+
+program
+	.command("update-demo-dependency")
+	.description("Update a dependency range in every demo that depends on it")
+	.argument("<package>", "dependency package name")
+	.argument("<range>", "dependency range to write")
+	.action(async (packageName, range) => {
+		await updateDemoDependency(packageName, range);
 	});
 
 program.parseAsync();

--- a/tools/aicli/src/demo-dependencies.ts
+++ b/tools/aicli/src/demo-dependencies.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+type PackageJson = {
+	name?: string;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+};
+
+async function getDemos(): Promise<string[]> {
+	const demosRoot = path.resolve(repoRoot, "demos");
+	const entries = await fs.readdir(demosRoot, { withFileTypes: true });
+
+	return entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(demosRoot, entry.name));
+}
+
+export async function updateDemoDependency(
+	packageName: string,
+	range: string,
+): Promise<void> {
+	const demos = await getDemos();
+	let updated = 0;
+
+	for (const demoPath of demos) {
+		const packageJsonPath = path.join(demoPath, "package.json");
+
+		let packageJson: PackageJson;
+		try {
+			packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				continue;
+			}
+			throw error;
+		}
+
+		const currentRange = packageJson.dependencies?.[packageName];
+		if (currentRange === undefined || currentRange === range) {
+			continue;
+		}
+
+		packageJson.dependencies![packageName] = range;
+		await fs.writeFile(
+			packageJsonPath,
+			`${JSON.stringify(packageJson, null, "\t")}\n`,
+		);
+
+		console.log(
+			`Updated ${path.relative(repoRoot, packageJsonPath)}: ${packageName} ${currentRange} -> ${range}`,
+		);
+		updated++;
+	}
+
+	if (updated === 0) {
+		console.log(`No demos depend on ${packageName} with a different range.`);
+		return;
+	}
+
+	console.log(`Updated ${updated} demo package.json file(s).`);
+}


### PR DESCRIPTION
## Summary

Prevents release-version PRs from bumping demo npm dependency ranges before the new package version exists on npm, and adds a post-release automation path to refresh demos safely after publish.

## Changes

- Adds `bumpVersionsWithWorkspaceProtocolOnly: true` to `.changeset/config.json`.
  - Changesets will still handle dependencies that use `workspace:*`.
  - Demo npm semver ranges like `workers-ai-provider@^3.1.14` will not be bumped during the pre-publish version step.
- Adds `aicli update-demo-dependency <package> <range>`.
  - Updates all `demos/*/package.json` files that depend on the package.
- Adds `.github/workflows/refresh-demo-dependencies.yml`.
  - Runs after a successful `Release` workflow, or manually via `workflow_dispatch`.
  - Resolves the latest npm version for the target package.
  - Updates demo package ranges.
  - Runs `pnpm generate-npm-lockfiles`.
  - Opens a reviewable PR with the resulting demo lockfile updates.

## Why

Demos are part of the pnpm workspace, but they are also maintained as standalone npm-installable examples with their own `package-lock.json` files. They should not use `workspace:*` unless the demo lockfile tooling is redesigned.

The safe release flow should be:

1. Version and publish the package.
2. After publish succeeds, automatically open a demo refresh PR.
3. Review and merge the demo lockfile update separately.

This avoids the circular failure where CI tries to install a package version that has not been published yet.

## Verification

- `pnpm changeset status --since=origin/main`
- `pnpm --filter @repo/aicli type-check`
- `pnpm aicli update-demo-dependency not-a-real-demo-dependency '^1.0.0'`

## Changeset

No changeset. This only changes release/demo maintenance tooling.
