### PR TITLE
fix: allow demo refresh to update pnpm lockfile

### DIFF
--- a/tools/aicli/src/npm.ts
+++ b/tools/aicli/src/npm.ts
@@ -37,8 +37,9 @@ export async function generateNpmLockfiles(): Promise<void> {
 
 	await config.save();
 
-	// Restore dependencies with pnpm
-	await $`pnpm install --child-concurrency=10`.verbose();
+	// Restore dependencies with pnpm. This can run after package.json changes,
+	// so allow pnpm-lock.yaml to be updated instead of using CI's frozen default.
+	await $`pnpm install --no-frozen-lockfile --child-concurrency=10`.verbose();
 }
 
 export async function lintNpmLockfiles(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the new demo refresh workflow after it failed while regenerating demo lockfiles.

`pnpm generate-npm-lockfiles` intentionally runs after demo `package.json` files are changed. At the end, the CLI restores root pnpm dependencies, but in CI pnpm defaults to frozen lockfile mode. That failed because `pnpm-lock.yaml` had not yet been updated for the changed demo manifests.

This changes the restore step to use `--no-frozen-lockfile`, allowing `pnpm-lock.yaml` to be updated as part of the generated demo refresh PR.

## Verification

- `pnpm --filter @repo/aicli type-check`
