### PR TITLE
Forward AI Gateway supported URLs

### DIFF
--- a/.changeset/forward-gateway-supported-urls.md
+++ b/.changeset/forward-gateway-supported-urls.md
@@ -1,0 +1,5 @@
+---
+"ai-gateway-provider": patch
+---
+
+Forward supported URL metadata from wrapped provider models.

--- a/packages/ai-gateway-provider/src/index.ts
+++ b/packages/ai-gateway-provider/src/index.ts
@@ -22,12 +22,12 @@ export class AiGatewayChatLanguageModel implements LanguageModelV3 {
 	readonly specificationVersion = "v3";
 	readonly defaultObjectGenerationMode = "json";
 
-	readonly supportedUrls: Record<string, RegExp[]> | PromiseLike<Record<string, RegExp[]>> = {
-		// No URLS are supported for this language model
-	};
-
 	readonly models: InternalLanguageModelV3[];
 	readonly config: AiGatewaySettings;
+
+	get supportedUrls(): Record<string, RegExp[]> | PromiseLike<Record<string, RegExp[]>> {
+		return this.models[0]?.supportedUrls ?? {};
+	}
 
 	get modelId(): string {
 		if (!this.models[0]) {

--- a/packages/ai-gateway-provider/test/supported-urls.test.ts
+++ b/packages/ai-gateway-provider/test/supported-urls.test.ts
@@ -1,0 +1,26 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import { createAiGateway } from "../src";
+
+describe("supportedUrls", () => {
+	it("forwards supported URLs from the wrapped model", async () => {
+		const supportedUrls = {
+			"application/pdf": [/^https:\/\/example\.com\/.*$/],
+			"image/*": [/^https:\/\//],
+		};
+		const wrappedModel = {
+			modelId: "test-model",
+			provider: "test-provider",
+			specificationVersion: "v3",
+			supportedUrls,
+		} as unknown as LanguageModelV3;
+
+		const aigateway = createAiGateway({
+			accountId: "test-account-id",
+			apiKey: "test-api-key",
+			gateway: "test-gateway",
+		});
+
+		await expect(await aigateway(wrappedModel).supportedUrls).toBe(supportedUrls);
+	});
+});


### PR DESCRIPTION
## Summary

- Forward `supportedUrls` from the wrapped language model instead of hardcoding an empty map.
- Add a regression test covering URL metadata passthrough.
- Add a patch changeset for `ai-gateway-provider`.

Fixes #545.

## Verification

- `pnpm --dir packages/ai-gateway-provider test:ci -- supported-urls.test.ts`
- `pnpm --dir packages/ai-gateway-provider test:ci`
- `pnpm --dir packages/ai-gateway-provider type-check`
- `pnpm --dir packages/ai-gateway-provider build`
- `pnpm exec oxfmt --check packages/ai-gateway-provider/src/index.ts packages/ai-gateway-provider/test/supported-urls.test.ts`
- `git diff --check`

Local note: on Windows, I used Git Bash as the pnpm script shell for install/build scripts because the repo scripts use POSIX commands.

This was implemented with Codex assistance and manually reviewed before submission.