### PR TITLE
fix(workers-ai-provider): preserve structured output schema name

### DIFF
--- a/.changeset/tidy-workers-ai-schema-name.md
+++ b/.changeset/tidy-workers-ai-schema-name.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Preserve structured output schema names in Workers AI chat requests.

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -99,7 +99,13 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 						response_format: {
 							type: "json_schema",
 							json_schema:
-								responseFormat?.type === "json" ? responseFormat.schema : undefined,
+								responseFormat?.type === "json" && responseFormat.schema != null
+									? {
+											name: responseFormat.name ?? "response",
+											description: responseFormat.description,
+											schema: responseFormat.schema,
+										}
+									: undefined,
 						},
 						tools: undefined,
 						tool_choice: undefined,

--- a/packages/workers-ai-provider/test/structured-output.test.ts
+++ b/packages/workers-ai-provider/test/structured-output.test.ts
@@ -73,6 +73,58 @@ describe("REST API - Structured Output Tests", () => {
 		expect(object?.recipe.ingredients.length).toBeGreaterThan(0);
 		expect(object?.recipe.steps.length).toBeGreaterThan(0);
 	});
+
+	it("should forward structured output name and description", async () => {
+		let requestBody: any;
+
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async ({ request }) => {
+					requestBody = await request.json();
+
+					return HttpResponse.json({
+						errors: [],
+						messages: [],
+						result: {
+							response: JSON.stringify({
+								recipe: {
+									ingredients: [{ amount: "200g", name: "spaghetti" }],
+									name: "Spaghetti Bolognese",
+									steps: ["Cook spaghetti."],
+								},
+							}),
+						},
+						success: true,
+					});
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Give me a Spaghetti Bolognese recipe",
+			output: Output.object({
+				description: "A recipe response",
+				name: "Recipe",
+				schema: recipeSchema,
+			}),
+		});
+
+		expect(requestBody.response_format).toMatchObject({
+			type: "json_schema",
+			json_schema: {
+				description: "A recipe response",
+				name: "Recipe",
+				schema: expect.any(Object),
+			},
+		});
+	});
 });
 
 describe("Binding - Structured Output Tests", () => {


### PR DESCRIPTION
## Summary

- wrap AI SDK structured-output schemas in the OpenAI-compatible `json_schema` envelope before sending them to Workers AI
- preserve `Output.object({ name, description })` on the request body, defaulting the schema name to `response` when not provided
- add REST regression coverage for the request body sent by `workers-ai-provider`

Fixes #559.

## Validation

- `corepack pnpm --filter workers-ai-provider exec vitest --watch=false test/structured-output.test.ts`
- `corepack pnpm --filter workers-ai-provider type-check`
- `corepack pnpm --filter workers-ai-provider test:ci`
- `corepack pnpm exec oxfmt --check packages/workers-ai-provider/src/workersai-chat-language-model.ts packages/workers-ai-provider/test/structured-output.test.ts`
