### PR TITLE
Reject non-image chat file parts in workers-ai-provider

### DIFF
--- a/.changeset/bright-files-check.md
+++ b/.changeset/bright-files-check.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Reject non-image chat file parts instead of forwarding them as image URLs.

--- a/.changeset/bright-files-check.md
+++ b/.changeset/bright-files-check.md
@@ -2,4 +2,26 @@
 "workers-ai-provider": patch
 ---
 
-Reject non-image chat file parts instead of forwarding them as image URLs.
+Validate `file` parts in chat messages before sending them to Workers AI.
+
+Previously every `file` part in a user message was unconditionally wrapped as
+an `image_url`, regardless of its `mediaType`. Non-image files (e.g.
+`application/pdf`, `audio/*`, `video/*`, `application/octet-stream`) were
+forwarded as if they were valid vision inputs, and a missing `mediaType`
+silently defaulted to `image/png`, producing a corrupt data URL.
+
+Now `convertToWorkersAIChatMessages`:
+
+- throws an `UnsupportedFunctionalityError` when a `file` part has a
+  non-`image/*` `mediaType`, or no `mediaType` at all, instead of forwarding
+  broken multimodal content;
+- matches the `image/` prefix case-insensitively (per RFC 2045), so media
+  types such as `IMAGE/JPEG` are accepted while the caller's original casing
+  is preserved in the emitted data URL;
+- preserves the provided image `mediaType` instead of defaulting missing
+  media types to `image/png`.
+
+This is a behavior change: inputs that previously "succeeded" with broken or
+defaulted media types now throw a clear, catchable error. Type-correct callers
+(the AI SDK always sets `mediaType` on file parts) are unaffected for valid
+image inputs.

--- a/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
+++ b/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3DataContent, LanguageModelV3Prompt } from "@ai-sdk/provider";
+import { UnsupportedFunctionalityError } from "@ai-sdk/provider";
 import { toWorkersAIToolCallId } from "./utils";
 import type { WorkersAIContentPart, WorkersAIChatPrompt } from "./workersai-chat-prompt";
 
@@ -43,17 +44,23 @@ function toUint8Array(data: LanguageModelV3DataContent): Uint8Array | null {
 
 function assertImageMediaType(mediaType: string | undefined): string {
 	if (!mediaType) {
-		throw new Error(
-			"Workers AI chat only supports image file parts with an image/* mediaType. " +
+		throw new UnsupportedFunctionalityError({
+			functionality: "file-part-without-media-type",
+			message:
+				"Workers AI chat only supports image file parts with an image/* mediaType. " +
 				"Received a file part without a mediaType.",
-		);
+		});
 	}
 
-	if (!mediaType.startsWith("image/")) {
-		throw new Error(
-			"Workers AI chat only supports image file parts with an image/* mediaType. " +
+	// Media types are case-insensitive (RFC 2045), so compare against a
+	// lower-cased copy while preserving the caller's original casing on output.
+	if (!mediaType.toLowerCase().startsWith("image/")) {
+		throw new UnsupportedFunctionalityError({
+			functionality: "non-image-file-part",
+			message:
+				"Workers AI chat only supports image file parts with an image/* mediaType. " +
 				`Received mediaType "${mediaType}".`,
-		);
+		});
 	}
 
 	return mediaType;
@@ -83,7 +90,7 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV3Prompt): {
 
 			case "user": {
 				const textParts: string[] = [];
-				const imageParts: { image: Uint8Array; mediaType: string | undefined }[] = [];
+				const imageParts: { image: Uint8Array; mediaType: string }[] = [];
 
 				for (const part of content) {
 					switch (part.type) {

--- a/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
+++ b/packages/workers-ai-provider/src/convert-to-workersai-chat-messages.ts
@@ -41,6 +41,24 @@ function toUint8Array(data: LanguageModelV3DataContent): Uint8Array | null {
 	return null;
 }
 
+function assertImageMediaType(mediaType: string | undefined): string {
+	if (!mediaType) {
+		throw new Error(
+			"Workers AI chat only supports image file parts with an image/* mediaType. " +
+				"Received a file part without a mediaType.",
+		);
+	}
+
+	if (!mediaType.startsWith("image/")) {
+		throw new Error(
+			"Workers AI chat only supports image file parts with an image/* mediaType. " +
+				`Received mediaType "${mediaType}".`,
+		);
+	}
+
+	return mediaType;
+}
+
 function uint8ArrayToBase64(bytes: Uint8Array): string {
 	let binary = "";
 	const chunkSize = 8192;
@@ -74,11 +92,12 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV3Prompt): {
 							break;
 						}
 						case "file": {
+							const mediaType = assertImageMediaType(part.mediaType);
 							const imageBytes = toUint8Array(part.data);
 							if (imageBytes) {
 								imageParts.push({
 									image: imageBytes,
-									mediaType: part.mediaType,
+									mediaType,
 								});
 							}
 							break;
@@ -93,10 +112,9 @@ export function convertToWorkersAIChatMessages(prompt: LanguageModelV3Prompt): {
 					}
 					for (const img of imageParts) {
 						const base64 = uint8ArrayToBase64(img.image);
-						const mediaType = img.mediaType || "image/png";
 						contentArray.push({
 							type: "image_url",
-							image_url: { url: `data:${mediaType};base64,${base64}` },
+							image_url: { url: `data:${img.mediaType};base64,${base64}` },
 						});
 					}
 					messages.push({ content: contentArray, role: "user" });

--- a/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
+++ b/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { UnsupportedFunctionalityError } from "@ai-sdk/provider";
 import { convertToWorkersAIChatMessages } from "../src/convert-to-workersai-chat-messages";
 import { createAISDKToolCallId } from "../src/utils";
 
@@ -482,6 +483,53 @@ describe("convertToWorkersAIChatMessages", () => {
 			expect(() => convertToWorkersAIChatMessages(prompt)).toThrow(
 				"Workers AI chat only supports image file parts with an image/* mediaType. Received a file part without a mediaType.",
 			);
+		});
+
+		it("should throw an UnsupportedFunctionalityError for non-image file parts", () => {
+			const prompt = [
+				{
+					role: "user" as const,
+					content: [
+						{
+							type: "file" as const,
+							data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+							mediaType: "application/pdf",
+							providerOptions: undefined,
+						},
+					],
+				},
+			];
+
+			expect(() => convertToWorkersAIChatMessages(prompt)).toThrow(
+				UnsupportedFunctionalityError,
+			);
+		});
+
+		it("should accept image media types regardless of casing", () => {
+			const prompt = [
+				{
+					role: "user" as const,
+					content: [
+						{ type: "text" as const, text: "What is this?" },
+						{
+							type: "file" as const,
+							data: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+							mediaType: "IMAGE/JPEG",
+							providerOptions: undefined,
+						},
+					],
+				},
+			];
+
+			const { messages } = convertToWorkersAIChatMessages(prompt);
+
+			expect(messages).toHaveLength(1);
+			const content = messages[0].content;
+			expect(Array.isArray(content)).toBe(true);
+			const parts = content as Array<{ type: string; image_url?: { url: string } }>;
+			expect(parts[1].type).toBe("image_url");
+			// Original casing is preserved in the emitted data URL.
+			expect(parts[1].image_url!.url).toMatch(/^data:IMAGE\/JPEG;base64,/);
 		});
 
 		it("should use plain string content when no images are present", () => {

--- a/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
+++ b/packages/workers-ai-provider/test/convert-to-workersai-chat-messages.test.ts
@@ -444,6 +444,46 @@ describe("convertToWorkersAIChatMessages", () => {
 			);
 		});
 
+		it("should throw for non-image file parts", () => {
+			const prompt = [
+				{
+					role: "user" as const,
+					content: [
+						{ type: "text" as const, text: "Summarize this PDF" },
+						{
+							type: "file" as const,
+							data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+							mediaType: "application/pdf",
+							providerOptions: undefined,
+						},
+					],
+				},
+			];
+
+			expect(() => convertToWorkersAIChatMessages(prompt)).toThrow(
+				'Workers AI chat only supports image file parts with an image/* mediaType. Received mediaType "application/pdf".',
+			);
+		});
+
+		it("should throw when a file part is missing a media type", () => {
+			const prompt = [
+				{
+					role: "user" as const,
+					content: [
+						{
+							type: "file" as const,
+							data: new Uint8Array([1, 2, 3]),
+							providerOptions: undefined,
+						} as any,
+					],
+				},
+			];
+
+			expect(() => convertToWorkersAIChatMessages(prompt)).toThrow(
+				"Workers AI chat only supports image file parts with an image/* mediaType. Received a file part without a mediaType.",
+			);
+		});
+
 		it("should use plain string content when no images are present", () => {
 			const prompt = [
 				{

--- a/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
@@ -529,6 +529,68 @@ describe.skipIf(skip())("Workers AI REST E2E", () => {
 				console.log(`  [vision] ${model.label} OK — "${result.text.slice(0, 100)}"`);
 			});
 		}
+
+		// SVG (image/svg+xml) is accepted by the converter because it is an
+		// image/* media type, but Workers AI does NOT actually support vector
+		// markup as a vision input. As of this writing, Kimi K2.7 raster vision
+		// works (see the test above) while the same request with an SVG data URL
+		// is rejected server-side with an Internal Server Error (code 8005),
+		// whereas an equivalent PNG succeeds.
+		//
+		// This test is exploratory and intentionally tolerant: it documents that
+		// the converter forwards SVG unchanged and records whichever outcome the
+		// backend returns, so it won't flake if Cloudflare later adds (or keeps
+		// rejecting) SVG support.
+		it("Kimi K2.7 Code — SVG image input via REST (currently unsupported by backend)", async () => {
+			const provider = makeProvider();
+
+			// A plain red circle on a white background.
+			const svg =
+				'<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">' +
+				'<rect width="64" height="64" fill="white"/>' +
+				'<circle cx="32" cy="32" r="24" fill="red"/>' +
+				"</svg>";
+			const svgBytes = new TextEncoder().encode(svg);
+
+			try {
+				const result = await generateText({
+					model: provider("@cf/moonshotai/kimi-k2.7-code" as ModelId),
+					messages: [
+						{
+							role: "user",
+							content: [
+								{
+									type: "text",
+									text: "What shape and color is in this image? Answer in one short sentence.",
+								},
+								{
+									type: "image",
+									image: svgBytes,
+									mediaType: "image/svg+xml",
+								},
+							],
+						},
+					],
+				});
+
+				// If the backend ever starts accepting SVG, just record what came back.
+				expect(typeof result.text).toBe("string");
+				const understoodSvg =
+					result.text.toLowerCase().includes("circle") ||
+					result.text.toLowerCase().includes("red");
+				console.log(
+					`  [vision:svg] Kimi K2.7 Code accepted SVG — understood=${understoodSvg} — "${result.text.slice(0, 120)}"`,
+				);
+			} catch (err: unknown) {
+				// Expected today: the converter forwarded the SVG (no client-side
+				// rejection), but Workers AI rejected it server-side.
+				const message = (err as Error).message;
+				expect(message).toContain("Workers AI API error");
+				console.log(
+					`  [vision:svg] Kimi K2.7 Code rejected SVG server-side — "${message.slice(0, 120)}"`,
+				);
+			}
+		});
 	});
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- validate Workers AI chat `file` parts have an `image/*` media type before converting them to `image_url`
- preserve the provided image media type instead of defaulting missing media types to `image/png`
- add regression tests and a changeset for the published provider

Fixes #541.

## Testing

- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter workers-ai-provider exec vitest test/convert-to-workersai-chat-messages.test.ts --run`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter workers-ai-provider run type-check`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter workers-ai-provider run build`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm lint`
