### PR TITLE
fix(tanstack-ai): preserve streamed tool-call name and arguments (#523)

### DIFF
--- a/.changeset/tanstack-ai-tool-call-streaming-name.md
+++ b/.changeset/tanstack-ai-tool-call-streaming-name.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+Fix broken streamed tool calls in the Workers AI adapter ([#523](https://github.com/cloudflare/ai/issues/523)).
+
+Some Workers AI models stream a tool call's argument fragments before the function `name` arrives. The adapter buffers those fragments while waiting for the name (it must, because TanStack AI's `StreamProcessor` reads the tool name only once, from `TOOL_CALL_START`), but it previously dropped the buffered prefix and forwarded only the post-name fragment. The result was a `tool-call` message part with truncated/empty `arguments` (and, in earlier versions, a missing `name`), so tool dispatch silently failed.
+
+The adapter now tracks how many argument characters have been emitted and flushes any buffered fragments via `TOOL_CALL_ARGS` as soon as `TOOL_CALL_START` is emitted, guaranteeing the full argument string and the tool name reach the consumer regardless of the order in which the model streams `name` and `arguments`.

--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -351,7 +351,14 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 		let hasReceivedFinishReason = false;
 		const toolCallsInProgress = new Map<
 			number,
-			{ id: string; name: string; arguments: string; started: boolean }
+			{
+				id: string;
+				name: string;
+				arguments: string;
+				started: boolean;
+				/** Number of `arguments` chars already forwarded via TOOL_CALL_ARGS. */
+				emittedArgsLength: number;
+			}
 		>();
 
 		try {
@@ -556,6 +563,7 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 								name: toolCallDelta.function?.name || "",
 								arguments: "",
 								started: false,
+								emittedArgsLength: 0,
 							});
 						}
 
@@ -571,7 +579,11 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 							toolCall.arguments += toolCallDelta.function.arguments;
 						}
 
-						// Emit TOOL_CALL_START once we have id and name
+						// Emit TOOL_CALL_START once we have id and name. We must wait
+						// for the name: TanStack AI's StreamProcessor reads the tool
+						// name ONLY from TOOL_CALL_START (it is never updated by later
+						// events), so emitting early with an empty name produces a
+						// tool-call part with no `name`, breaking dispatch (issue #523).
 						if (toolCall.id && toolCall.name && !toolCall.started) {
 							toolCall.started = true;
 							yield {
@@ -585,14 +597,22 @@ export class WorkersAiTextAdapter<TModel extends WorkersAiTextModel> extends Bas
 							} satisfies StreamChunk;
 						}
 
-						// Stream tool call arguments
-						if (toolCallDelta.function?.arguments && toolCall.started) {
+						// Stream any argument fragments that haven't been forwarded
+						// yet. We track the emitted length rather than forwarding the
+						// raw per-chunk delta because some models stream argument
+						// fragments BEFORE the name arrives; those are buffered in
+						// `arguments` while we wait for the name, and must be flushed
+						// once START is emitted so the full argument string reaches
+						// the consumer (issue #523).
+						if (toolCall.started && toolCall.arguments.length > toolCall.emittedArgsLength) {
+							const argsDelta = toolCall.arguments.slice(toolCall.emittedArgsLength);
+							toolCall.emittedArgsLength = toolCall.arguments.length;
 							yield {
 								type: EventType.TOOL_CALL_ARGS,
 								toolCallId: toolCall.id,
 								model: chunk.model || model || this.model,
 								timestamp,
-								delta: toolCallDelta.function.arguments,
+								delta: argsDelta,
 							} satisfies StreamChunk;
 						}
 					}

--- a/packages/tanstack-ai/test/e2e/fixtures/binding-worker/src/index.ts
+++ b/packages/tanstack-ai/test/e2e/fixtures/binding-worker/src/index.ts
@@ -15,6 +15,7 @@ import { WorkersAiTranscriptionAdapter } from "../../../../../src/adapters/worke
 import type { WorkersAiTranscriptionModel } from "../../../../../src/adapters/workers-ai-transcription";
 import { WorkersAiSummarizeAdapter } from "../../../../../src/adapters/workers-ai-summarize";
 import { resolveDebugOption } from "@tanstack/ai/adapter-internals";
+import { StreamProcessor } from "@tanstack/ai";
 
 const logger = resolveDebugOption(false);
 
@@ -163,6 +164,48 @@ export default {
 						} as any),
 					);
 					return jsonResponse({ chunks });
+				}
+
+				// ----- Tool call run through the real StreamProcessor -----
+				// Validates the FULL consumer pipeline: adapter event stream →
+				// @tanstack/ai StreamProcessor → UIMessage `tool-call` part.
+				// Regression coverage for https://github.com/cloudflare/ai/issues/523
+				// where the resulting part was missing its `name`/arguments.
+				case "/chat/tool-call-processed": {
+					const stream = adapter.chatStream({
+						model,
+						messages: [
+							{
+								role: "user",
+								content: "What is 2 + 3? You MUST use the calculator tool to answer.",
+							},
+						],
+						tools: [
+							{
+								name: "calculator",
+								description:
+									"Add two numbers. Returns their sum. Always use this tool for math.",
+								inputSchema: {
+									type: "object",
+									properties: {
+										a: { type: "number", description: "first number" },
+										b: { type: "number", description: "second number" },
+									},
+									required: ["a", "b"],
+								},
+							},
+						],
+						temperature: 0,
+					} as any);
+
+					const processor = new StreamProcessor();
+					await processor.process(stream as any);
+					const messages = processor.getMessages();
+					const toolCallParts = messages
+						.flatMap((m: any) => m.parts)
+						.filter((p: any) => p.type === "tool-call");
+
+					return jsonResponse({ messages, toolCallParts });
 				}
 
 				// ----- Tool round-trip (two calls simulating chat() loop) -----

--- a/packages/tanstack-ai/test/e2e/workers-ai-binding.e2e.test.ts
+++ b/packages/tanstack-ai/test/e2e/workers-ai-binding.e2e.test.ts
@@ -347,6 +347,51 @@ describe("Workers AI Binding E2E", () => {
 	});
 
 	// ------------------------------------------------------------------
+	// Per-model: tool call through the real StreamProcessor
+	// Regression guard for https://github.com/cloudflare/ai/issues/523 —
+	// the resulting UIMessage tool-call part must carry its `name` (and args).
+	// ------------------------------------------------------------------
+
+	describe("tool call → StreamProcessor part (per model)", () => {
+		for (const model of MODELS) {
+			it(`${model.label} — processed tool-call part has a name`, async () => {
+				if (!serverReady) return;
+
+				const r = getResult(model.label);
+				const data = await post("/chat/tool-call-processed", { model: model.id });
+
+				if (data.error) {
+					r.notes.push(`tool-proc: ${(data.error as string).slice(0, 40)}`);
+					return;
+				}
+
+				const parts = (data.toolCallParts as any[]) ?? [];
+
+				if (parts.length === 0) {
+					// Model may have answered as text instead of calling the tool.
+					// The dedicated tool-call test already records that; don't fail here.
+					r.notes.push("tool-proc: no tool-call part");
+					return;
+				}
+
+				// The core regression: every tool-call part MUST have a non-empty
+				// name, otherwise dispatch silently fails (issue #523).
+				for (const part of parts) {
+					expect(part.name, "tool-call part is missing its name").toBeTruthy();
+					expect(part.state).toBe("input-complete");
+					// Arguments must be valid JSON the consumer can dispatch.
+					expect(() => JSON.parse(part.arguments)).not.toThrow();
+				}
+
+				expect(parts[0].name).toBe("calculator");
+				console.log(
+					`  ✓ ${model.label}: processed tool-call part OK — name="${parts[0].name}" args=${parts[0].arguments}`,
+				);
+			});
+		}
+	});
+
+	// ------------------------------------------------------------------
 	// Per-model: tool round-trip (the key test for the binding bug fix)
 	// ------------------------------------------------------------------
 

--- a/packages/tanstack-ai/test/tool-call-streaming.test.ts
+++ b/packages/tanstack-ai/test/tool-call-streaming.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for streamed tool calls.
+ *
+ * Regression coverage for https://github.com/cloudflare/ai/issues/523 —
+ * "Tool calling broken in tanstack-ai package".
+ *
+ * Unlike `workers-ai-adapter.test.ts` (which mocks `@tanstack/ai`), these tests
+ * pipe the WorkersAiTextAdapter's raw AG-UI event stream through the REAL
+ * `@tanstack/ai` StreamProcessor and assert on the resulting UIMessage
+ * `tool-call` parts. This is the exact pipeline a consuming app uses, so it
+ * catches contract mismatches (e.g. a `tool-call` part missing its `name`)
+ * that adapter-only assertions cannot.
+ *
+ * The bug: some Workers AI models stream a tool call's argument fragments
+ * BEFORE the function name arrives. The adapter buffered those fragments while
+ * waiting for the name (so it could emit a TOOL_CALL_START with the name, which
+ * the StreamProcessor reads only once), but then dropped the buffered prefix —
+ * forwarding only the post-name fragment. The result was a tool-call part with
+ * truncated/empty arguments (and, in older versions, a missing name), so tool
+ * dispatch silently failed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { StreamProcessor } from "@tanstack/ai";
+import { WorkersAiTextAdapter } from "../src/adapters/workers-ai";
+import type { WorkersAiTextModel } from "../src/adapters/workers-ai";
+
+const MODEL = "@cf/zai-org/glm-4.7-flash" as WorkersAiTextModel;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a binding that streams raw SSE chunks straight through the shim. */
+function createSseBinding(chunks: string[]) {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(encoder.encode(chunk));
+			}
+			controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+			controller.close();
+		},
+	});
+	return {
+		run: vi.fn().mockResolvedValue(stream),
+		gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+	};
+}
+
+/** OpenAI-format chat completion chunk (as Workers AI emits for many models). */
+function oaiChunk(delta: unknown, finishReason: string | null = null): string {
+	return `data: ${JSON.stringify({
+		id: "c1",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "glm",
+		choices: [{ index: 0, delta, finish_reason: finishReason }],
+	})}\n\n`;
+}
+
+async function processToUiMessages(adapterStream: AsyncIterable<unknown>) {
+	const processor = new StreamProcessor();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- adapter stream is structurally an AsyncIterable<StreamChunk>
+	await processor.process(adapterStream as any);
+	return processor.getMessages();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- UIMessage parts are dynamically shaped
+function toolCallParts(messages: any[]): any[] {
+	return messages.flatMap((m) => m.parts).filter((p) => p.type === "tool-call");
+}
+
+const TOOLS = [
+	{
+		name: "search_events",
+		description: "Search the calendar",
+		inputSchema: {
+			type: "object",
+			properties: { date_from: { type: "string" }, date_to: { type: "string" } },
+		},
+	},
+];
+
+function chatWith(adapter: WorkersAiTextAdapter<WorkersAiTextModel>) {
+	return adapter.chatStream({
+		model: MODEL,
+		messages: [{ role: "user", content: "What's happening today?" }],
+		tools: TOOLS,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal options for test
+	} as any);
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-format streaming (REST / OpenAI-compatible endpoint shape)
+// ---------------------------------------------------------------------------
+
+describe("streamed tool calls → real StreamProcessor (OpenAI format)", () => {
+	it("name first, args streamed across multiple deltas", async () => {
+		const binding = createSseBinding([
+			oaiChunk({
+				tool_calls: [
+					{ index: 0, id: "x", type: "function", function: { name: "search_events", arguments: "" } },
+				],
+			}),
+			oaiChunk({ tool_calls: [{ index: 0, function: { arguments: '{"date_from": "2026-05-05"' } }] }),
+			oaiChunk({ tool_calls: [{ index: 0, function: { arguments: ', "date_to": "2026-05-05"}' } }] }),
+			oaiChunk({}, "tool_calls"),
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].name).toBe("search_events");
+		expect(parts[0].state).toBe("input-complete");
+		expect(JSON.parse(parts[0].arguments)).toEqual({
+			date_from: "2026-05-05",
+			date_to: "2026-05-05",
+		});
+	});
+
+	it("args streamed BEFORE the name arrives (issue #523)", async () => {
+		const binding = createSseBinding([
+			// first delta carries args but NO name yet
+			oaiChunk({ tool_calls: [{ index: 0, id: "x", type: "function", function: { arguments: '{"date_from": "2026-05-05"' } }] }),
+			// name arrives later, with the remaining args
+			oaiChunk({ tool_calls: [{ index: 0, function: { name: "search_events", arguments: ', "date_to": "2026-05-05"}' } }] }),
+			oaiChunk({}, "tool_calls"),
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		// Name must be present — this is the core regression.
+		expect(parts[0].name).toBe("search_events");
+		// And NO argument fragment may be dropped.
+		expect(JSON.parse(parts[0].arguments)).toEqual({
+			date_from: "2026-05-05",
+			date_to: "2026-05-05",
+		});
+	});
+
+	it("name and full args delivered in a single delta with finish in same chunk", async () => {
+		const binding = createSseBinding([
+			oaiChunk(
+				{
+					tool_calls: [
+						{
+							index: 0,
+							id: "x",
+							type: "function",
+							function: {
+								name: "search_events",
+								arguments: '{"date_from": "2026-05-05", "date_to": "2026-05-05"}',
+							},
+						},
+					],
+				},
+				"tool_calls",
+			),
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].name).toBe("search_events");
+		expect(JSON.parse(parts[0].arguments)).toEqual({
+			date_from: "2026-05-05",
+			date_to: "2026-05-05",
+		});
+	});
+
+	it("parallel tool calls keep distinct names and arguments", async () => {
+		const binding = createSseBinding([
+			oaiChunk({
+				tool_calls: [
+					{ index: 0, id: "a", type: "function", function: { name: "search_events", arguments: "" } },
+					{ index: 1, id: "b", type: "function", function: { name: "search_events", arguments: "" } },
+				],
+			}),
+			oaiChunk({ tool_calls: [{ index: 0, function: { arguments: '{"date_from": "2026-05-05"}' } }] }),
+			oaiChunk({ tool_calls: [{ index: 1, function: { arguments: '{"date_from": "2026-06-01"}' } }] }),
+			oaiChunk({}, "tool_calls"),
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(2);
+		for (const part of parts) {
+			expect(part.name).toBe("search_events");
+			expect(part.state).toBe("input-complete");
+		}
+		expect(JSON.parse(parts[0].arguments)).toEqual({ date_from: "2026-05-05" });
+		expect(JSON.parse(parts[1].arguments)).toEqual({ date_from: "2026-06-01" });
+		// IDs must be unique so the consumer can match results back.
+		expect(parts[0].id).not.toBe(parts[1].id);
+	});
+
+	it("stream truncated before finish_reason still yields a usable tool call", async () => {
+		const binding = createSseBinding([
+			oaiChunk({ tool_calls: [{ index: 0, id: "x", type: "function", function: { name: "search_events", arguments: '{"date_from": "2026-05-05"}' } }] }),
+			// no finish_reason chunk — premature termination
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].name).toBe("search_events");
+		expect(parts[0].state).toBe("input-complete");
+		expect(JSON.parse(parts[0].arguments)).toEqual({ date_from: "2026-05-05" });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Native Workers AI streaming format (binding shim path)
+// ---------------------------------------------------------------------------
+
+describe("streamed tool calls → real StreamProcessor (native Workers AI format)", () => {
+	it("single-chunk native tool call yields full name + args", async () => {
+		const binding = createSseBinding([
+			'data: {"response":"","tool_calls":[{"name":"search_events","arguments":{"date_from":"2026-05-05","date_to":"2026-05-05"}}]}\n\n',
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].name).toBe("search_events");
+		expect(JSON.parse(parts[0].arguments)).toEqual({
+			date_from: "2026-05-05",
+			date_to: "2026-05-05",
+		});
+	});
+
+	it("native format streaming name then incremental args", async () => {
+		const binding = createSseBinding([
+			'data: {"tool_calls":[{"id":"t0","index":0,"function":{"name":"search_events"}}]}\n\n',
+			'data: {"tool_calls":[{"index":0,"function":{"arguments":"{\\"date_from\\": \\"2026-05-05\\""}}]}\n\n',
+			'data: {"tool_calls":[{"index":0,"function":{"arguments":", \\"date_to\\": \\"2026-05-05\\"}"}}]}\n\n',
+		]);
+		const parts = toolCallParts(await processToUiMessages(chatWith(new WorkersAiTextAdapter(MODEL, { binding }))));
+
+		expect(parts).toHaveLength(1);
+		expect(parts[0].name).toBe("search_events");
+		expect(JSON.parse(parts[0].arguments)).toEqual({
+			date_from: "2026-05-05",
+			date_to: "2026-05-05",
+		});
+	});
+});

--- a/packages/tanstack-ai/test/workers-ai-adapter.test.ts
+++ b/packages/tanstack-ai/test/workers-ai-adapter.test.ts
@@ -173,6 +173,115 @@ describe("WorkersAiTextAdapter.chatStream", () => {
 		expect(runFinished.finishReason).toBe("tool_calls");
 	});
 
+	it("should keep arguments streamed BEFORE the tool name (issue #523)", async () => {
+		// Some models stream argument fragments before the function name. The
+		// adapter must wait for the name before emitting TOOL_CALL_START (the
+		// StreamProcessor reads the name only once, from START), but it must NOT
+		// drop the argument fragments buffered while waiting.
+		const binding = createStreamingBinding([
+			// args first, no name yet
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"x","type":"function","function":{"arguments":"{\\"location\\":"}}]},"finish_reason":null}]}\n\n',
+			// name + remaining args
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"get_weather","arguments":"\\"SF\\"}"}}]},"finish_reason":null}]}\n\n',
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+		]);
+		const adapter = new WorkersAiTextAdapter(MODEL, { binding });
+
+		const chunks = await collectChunks(
+			adapter.chatStream({
+				model: MODEL,
+				messages: [{ role: "user", content: "Weather in SF?" }],
+				tools: [{ name: "get_weather", description: "Get weather", inputSchema: { type: "object" } }],
+			} as any),
+		);
+
+		// START must carry the name (both fields the StreamProcessor accepts).
+		const toolStart = chunks.filter((c: any) => c.type === "TOOL_CALL_START");
+		expect(toolStart).toHaveLength(1);
+		expect(toolStart[0].toolName).toBe("get_weather");
+		expect(toolStart[0].toolCallName).toBe("get_weather");
+
+		// START must precede the first ARGS event.
+		const startIdx = chunks.findIndex((c: any) => c.type === "TOOL_CALL_START");
+		const firstArgsIdx = chunks.findIndex((c: any) => c.type === "TOOL_CALL_ARGS");
+		expect(startIdx).toBeGreaterThanOrEqual(0);
+		expect(firstArgsIdx).toBeGreaterThan(startIdx);
+
+		// Concatenated ARGS deltas must reconstruct the FULL argument string,
+		// including the fragment that arrived before the name.
+		const argsDeltas = chunks
+			.filter((c: any) => c.type === "TOOL_CALL_ARGS")
+			.map((c: any) => c.delta)
+			.join("");
+		expect(argsDeltas).toBe('{"location":"SF"}');
+
+		// END carries the parsed input and the name.
+		const toolEnd = chunks.filter((c: any) => c.type === "TOOL_CALL_END");
+		expect(toolEnd).toHaveLength(1);
+		expect(toolEnd[0].toolName).toBe("get_weather");
+		expect(toolEnd[0].input).toEqual({ location: "SF" });
+	});
+
+	it("should not emit TOOL_CALL_ARGS before a name (and START) are known", async () => {
+		// Until the name arrives, START cannot be emitted, so no ARGS should
+		// leak out either — otherwise the consumer would receive args for a tool
+		// call it never saw start.
+		const binding = createStreamingBinding([
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"x","type":"function","function":{"arguments":"{\\"a\\":1}"}}]},"finish_reason":null}]}\n\n',
+			// Stream ends WITHOUT a name ever arriving.
+		]);
+		const adapter = new WorkersAiTextAdapter(MODEL, { binding });
+
+		const chunks = await collectChunks(
+			adapter.chatStream({
+				model: MODEL,
+				messages: [{ role: "user", content: "hi" }],
+				tools: [{ name: "noop", description: "noop", inputSchema: { type: "object" } }],
+			} as any),
+		);
+
+		// No START (no name) ⇒ no ARGS either.
+		expect(chunks.find((c: any) => c.type === "TOOL_CALL_START")).toBeUndefined();
+		expect(chunks.find((c: any) => c.type === "TOOL_CALL_ARGS")).toBeUndefined();
+	});
+
+	it("should handle parallel streamed tool calls with unique ids and names", async () => {
+		const binding = createStreamingBinding([
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"a","type":"function","function":{"name":"get_weather","arguments":""}},{"index":1,"id":"b","type":"function","function":{"name":"get_time","arguments":""}}]},"finish_reason":null}]}\n\n',
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"city\\":\\"SF\\"}"}}]},"finish_reason":null}]}\n\n',
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"tz\\":\\"PT\\"}"}}]},"finish_reason":null}]}\n\n',
+			'data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+		]);
+		const adapter = new WorkersAiTextAdapter(MODEL, { binding });
+
+		const chunks = await collectChunks(
+			adapter.chatStream({
+				model: MODEL,
+				messages: [{ role: "user", content: "Weather and time in SF?" }],
+				tools: [
+					{ name: "get_weather", description: "w", inputSchema: { type: "object" } },
+					{ name: "get_time", description: "t", inputSchema: { type: "object" } },
+				],
+			} as any),
+		);
+
+		const starts = chunks.filter((c: any) => c.type === "TOOL_CALL_START");
+		const ends = chunks.filter((c: any) => c.type === "TOOL_CALL_END");
+		expect(starts).toHaveLength(2);
+		expect(ends).toHaveLength(2);
+
+		const names = starts.map((s: any) => s.toolName).sort();
+		expect(names).toEqual(["get_time", "get_weather"]);
+
+		// Unique tool call ids so results can be matched back.
+		const ids = starts.map((s: any) => s.toolCallId);
+		expect(new Set(ids).size).toBe(2);
+
+		const endByName = Object.fromEntries(ends.map((e: any) => [e.toolName, e.input]));
+		expect(endByName.get_weather).toEqual({ city: "SF" });
+		expect(endByName.get_time).toEqual({ tz: "PT" });
+	});
+
 	it("should forward tools to the binding", async () => {
 		const binding = createStreamingBinding(['data: {"response":"ok"}\n\n']);
 		const adapter = new WorkersAiTextAdapter(MODEL, { binding });


### PR DESCRIPTION
## Summary

Fixes [#523](https://github.com/cloudflare/ai/issues/523) — "Tool calling broken in tanstack-ai package".

Some Workers AI models (e.g. GLM, QwQ) stream a tool call's **argument fragments before the function `name` arrives**. The Workers AI streaming adapter must wait for the name before emitting `TOOL_CALL_START`, because TanStack AI's `StreamProcessor` reads the tool name **only once — from `TOOL_CALL_START`** — and never updates it from later events.

While waiting for the name, the adapter buffered those early argument fragments into `toolCall.arguments`, but then forwarded only the **current chunk's** delta via `TOOL_CALL_ARGS`, permanently dropping the buffered prefix:

```ts
// before
if (toolCallDelta.function?.arguments && toolCall.started) {
  yield { type: TOOL_CALL_ARGS, ..., delta: toolCallDelta.function.arguments };
}
```

Because the `StreamProcessor` only backfills a tool-call part's `arguments` from `TOOL_CALL_END.input` when the streamed args are empty, the result was a `tool-call` UIMessage part with **truncated/empty `arguments`** (and, in the version the reporter hit, a **missing `name`**) — so tool dispatch silently failed.

## Fix

Track how many argument characters have already been emitted (`emittedArgsLength`) and flush any buffered fragments via `TOOL_CALL_ARGS` as soon as `TOOL_CALL_START` fires. This guarantees the full argument string **and** the tool name reach the consumer regardless of the order in which the model streams `name` and `arguments`.

The change is isolated to the streaming tool-call branch of `WorkersAiTextAdapter.chatStream` in `packages/tanstack-ai/src/adapters/workers-ai.ts`.

## Why this is the right layer

I traced the consumer pipeline through `@tanstack/ai`'s `StreamProcessor` (`processor.js` / `message-updaters.js`) and confirmed:
- `handleToolCallStartEvent` sets the tool name from `chunk.toolCallName ?? chunk.toolName` and it is the **only** place the name is set.
- `handleToolCallArgsEvent` accumulates the part's `arguments` from streamed `TOOL_CALL_ARGS` deltas.
- `handleToolCallEndEvent` only applies `input` when the accumulated `arguments` is empty.

So the adapter must emit `START` with the name and stream **all** argument fragments — which is exactly what this PR ensures.

## Test plan

- [x] `pnpm test` — 254 unit tests pass (including new coverage below)
- [x] `pnpm type-check` — clean
- [x] biome lint / editor lints — clean
- [x] `pnpm test:e2e:binding` — **79/79 pass against live Workers AI models** (full ~174s run, real model calls). Every model that emits a structured streaming tool call now produces a correctly-named `tool-call` part with full arguments and `input-complete` state, including the **QwQ-32B reasoning model** that previously produced nameless parts.

### New / updated tests

- **`test/tool-call-streaming.test.ts`** (new): integration tests that pipe the adapter through the **real `@tanstack/ai` StreamProcessor** (no mocks) and assert the final UIMessage `tool-call` parts — covers name-first, **args-before-name (the regression)**, single-delta + finish in one chunk, parallel tool calls, premature termination, and the native Workers AI streaming format.
- **`test/workers-ai-adapter.test.ts`**: adapter-level event assertions — `TOOL_CALL_START` carries the name and precedes `TOOL_CALL_ARGS`; concatenated `TOOL_CALL_ARGS` deltas reconstruct the full argument string even when args precede the name; no `ARGS` leak before `START`; parallel calls keep distinct ids/names.
- **e2e** (`test/e2e/fixtures/binding-worker/src/index.ts` + `workers-ai-binding.e2e.test.ts`): new `/chat/tool-call-processed` endpoint runs the adapter through the real `StreamProcessor`; a per-model e2e test asserts the processed `tool-call` part always has a non-empty `name`, `state: "input-complete"`, and valid JSON `arguments`.

### Fixture change

- `test/e2e/fixtures/binding-worker/wrangler.jsonc`: enabled `nodejs_compat`. Importing `StreamProcessor` from `@tanstack/ai` pulls in transitive deps that reference Node built-ins (`node:fs/promises`); without the flag the test worker fails to boot, which previously made every per-model e2e test silently no-op via `if (!serverReady) return;`.

A changeset is included (`@cloudflare/tanstack-ai` patch).

> Note: two unrelated, pre-existing e2e issues surface as console warnings (not failures): Deepgram Nova-3 transcription payload shape and the deprecated `@cf/facebook/bart-large-cnn` summarize model. Out of scope for this PR.