### PR TITLE
fix(workers-ai-provider): enforce forced tool choice + recover gpt-oss leaked tool calls

### DIFF
--- a/.changeset/workers-ai-provider-forced-tool-choice.md
+++ b/.changeset/workers-ai-provider-forced-tool-choice.md
@@ -1,0 +1,31 @@
+---
+"workers-ai-provider": patch
+---
+
+Map the AI SDK's forced single-tool choice to the documented named-function form.
+
+Previously `toolChoice: { type: "tool", toolName }` was downgraded to
+`tool_choice: "required"` (with the tool list filtered to the single function).
+Workers AI treats `"required"` as advisory: on long contexts and reasoning
+models (e.g. `@cf/google/gemma-4-26b-a4b-it`, `@cf/qwen/qwq-32b`,
+`@cf/qwen/qwen3-30b-a3b-fp8`) the model would "fail open" and answer in prose
+instead of calling the requested tool.
+
+Now the provider sends the OpenAI-style named-function form
+`tool_choice: { type: "function", function: { name } }`, which Workers AI
+enforces server-side, and keeps the full tool list (matching OpenAI semantics
+and preserving tool-result context fidelity).
+
+Note: forcing a tool on a reasoning model with insufficient `max_tokens` is
+validated server-side and now surfaces as a clear error (Workers AI `8006`)
+rather than silently producing no tool call.
+
+Additionally, recover forced tool calls that gpt-oss models leak as text.
+When a tool is forced, gpt-oss (harmony format) sometimes emits the tool call
+as raw JSON in `message.content` with an empty `tool_calls` array and
+`finish_reason: "stop"`. The provider now detects this — only when a tool was
+forced and the leaked JSON's `name` matches a requested tool — and
+reinterprets it as a structured tool call (with `finishReason: "tool-calls"`
+and a warning), across both `generateText` and `streamText`. Ambiguous leaks
+(harmony channel/role names, hallucinated names) are left untouched to avoid
+fabricating bogus calls.

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -6,7 +6,12 @@ import type {
 import { generateId } from "ai";
 import { mapWorkersAIFinishReason } from "./map-workersai-finish-reason";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
-import { createAISDKToolCallId } from "./utils";
+import {
+	createAISDKToolCallId,
+	getToolNames,
+	isForcedToolChoice,
+	parseLeakedToolCalls,
+} from "./utils";
 
 /**
  * Prepend a stream-start event to an existing LanguageModelV3 stream.
@@ -64,6 +69,10 @@ function isNullFinalizationChunk(tc: Record<string, unknown>): boolean {
  */
 export function getMappedStream(
 	response: Response | ReadableStream<Uint8Array>,
+	salvageContext?: {
+		tools: Array<{ function: { name?: string } }> | undefined;
+		toolChoice: unknown;
+	},
 ): ReadableStream<LanguageModelV3StreamPart> {
 	const rawStream =
 		response instanceof ReadableStream
@@ -73,6 +82,18 @@ export function getMappedStream(
 	if (!rawStream) {
 		throw new Error("No readable stream available for SSE parsing.");
 	}
+
+	// gpt-oss harmony quirk: a forced tool call can be streamed as `content`
+	// text deltas instead of structured tool calls. When a tool was forced,
+	// buffer the text content (rather than emitting it incrementally) so we can
+	// reinterpret it as a tool call at flush time. Text is unexpected in forced
+	// mode anyway, so buffering it does not regress a useful stream.
+	// See https://github.com/cloudflare/ai/issues/560.
+	const knownToolNames = getToolNames(salvageContext?.tools);
+	const bufferContentForSalvage =
+		isForcedToolChoice(salvageContext?.toolChoice) && knownToolNames.size > 0;
+	let contentBuffer = "";
+	let anyToolCallStarted = false;
 
 	// State shared across the transform
 	let usage: LanguageModelV3Usage = {
@@ -146,20 +167,24 @@ export function getMappedStream(
 				if (nativeResponse != null && nativeResponse !== "") {
 					const responseText = String(nativeResponse);
 					if (responseText.length > 0) {
-						// Close active reasoning block before text starts
-						if (reasoningId) {
-							controller.enqueue({ type: "reasoning-end", id: reasoningId });
-							reasoningId = null;
+						if (bufferContentForSalvage) {
+							contentBuffer += responseText;
+						} else {
+							// Close active reasoning block before text starts
+							if (reasoningId) {
+								controller.enqueue({ type: "reasoning-end", id: reasoningId });
+								reasoningId = null;
+							}
+							if (!textId) {
+								textId = generateId();
+								controller.enqueue({ type: "text-start", id: textId });
+							}
+							controller.enqueue({
+								type: "text-delta",
+								id: textId,
+								delta: responseText,
+							});
 						}
-						if (!textId) {
-							textId = generateId();
-							controller.enqueue({ type: "text-start", id: textId });
-						}
-						controller.enqueue({
-							type: "text-delta",
-							id: textId,
-							delta: responseText,
-						});
 					}
 				}
 
@@ -197,20 +222,24 @@ export function getMappedStream(
 
 					const textDelta = delta.content as string | undefined;
 					if (textDelta && textDelta.length > 0) {
-						// Close active reasoning block before text starts
-						if (reasoningId) {
-							controller.enqueue({ type: "reasoning-end", id: reasoningId });
-							reasoningId = null;
+						if (bufferContentForSalvage) {
+							contentBuffer += textDelta;
+						} else {
+							// Close active reasoning block before text starts
+							if (reasoningId) {
+								controller.enqueue({ type: "reasoning-end", id: reasoningId });
+								reasoningId = null;
+							}
+							if (!textId) {
+								textId = generateId();
+								controller.enqueue({ type: "text-start", id: textId });
+							}
+							controller.enqueue({
+								type: "text-delta",
+								id: textId,
+								delta: textDelta,
+							});
 						}
-						if (!textId) {
-							textId = generateId();
-							controller.enqueue({ type: "text-start", id: textId });
-						}
-						controller.enqueue({
-							type: "text-delta",
-							id: textId,
-							delta: textDelta,
-						});
 					}
 
 					const deltaToolCalls = delta.tool_calls as
@@ -234,17 +263,59 @@ export function getMappedStream(
 					closeToolCall(idx, controller);
 				}
 
-				// Close open text/reasoning blocks
+				// Close open reasoning block before any salvaged tool calls.
 				if (reasoningId) {
 					controller.enqueue({ type: "reasoning-end", id: reasoningId });
 				}
+
+				// Salvage a forced tool call that streamed as buffered text.
+				let salvagedToolCalls = false;
+				if (bufferContentForSalvage && !anyToolCallStarted && contentBuffer.trim()) {
+					const salvaged = parseLeakedToolCalls(contentBuffer, knownToolNames);
+					if (salvaged.length > 0) {
+						for (const call of salvaged) {
+							controller.enqueue({
+								type: "tool-input-start",
+								id: call.toolCallId,
+								toolName: call.toolName,
+							});
+							controller.enqueue({
+								type: "tool-input-delta",
+								id: call.toolCallId,
+								delta: call.input,
+							});
+							controller.enqueue({ type: "tool-input-end", id: call.toolCallId });
+							controller.enqueue(call);
+						}
+						salvagedToolCalls = true;
+						// Stream warnings are fixed at stream-start, so surface the
+						// reinterpretation here for observability instead.
+						console.warn(
+							`[workers-ai-provider] Recovered ${salvaged.length} forced tool call(s) that the model streamed as text content instead of structured tool calls.`,
+						);
+					} else {
+						// Not a recoverable tool call — emit the buffered text as-is.
+						const id = generateId();
+						controller.enqueue({ type: "text-start", id });
+						controller.enqueue({ type: "text-delta", id, delta: contentBuffer });
+						controller.enqueue({ type: "text-end", id });
+					}
+				} else if (bufferContentForSalvage && contentBuffer.trim()) {
+					// Real tool calls were present alongside buffered text — emit text.
+					const id = generateId();
+					controller.enqueue({ type: "text-start", id });
+					controller.enqueue({ type: "text-delta", id, delta: contentBuffer });
+					controller.enqueue({ type: "text-end", id });
+				}
+
 				if (textId) {
 					controller.enqueue({ type: "text-end", id: textId });
 				}
 
 				// Detect premature termination
-				const effectiveFinishReason =
-					!receivedDone && receivedAnyData && !finishReason
+				const effectiveFinishReason = salvagedToolCalls
+					? ({ unified: "tool-calls", raw: "stop" } as LanguageModelV3FinishReason)
+					: !receivedDone && receivedAnyData && !finishReason
 						? ({
 								unified: "error",
 								raw: "stream-truncated",
@@ -322,6 +393,7 @@ export function getMappedStream(
 				const toolName = tcName || "";
 				activeToolCalls.set(tcIndex, { id, toolName, args: "" });
 				lastActiveToolIndex = tcIndex;
+				anyToolCallStarted = true;
 
 				controller.enqueue({
 					type: "tool-input-start",

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -301,12 +301,17 @@ export function prepareToolsAndToolChoice(
 		case "required":
 			return { tool_choice: "required", tools: mappedTools };
 
-		// Workers AI does not support tool mode directly,
-		// so we filter the tools and force the tool choice through 'required'
+		// Force a specific tool via the OpenAI-style named-function form.
+		// Workers AI enforces this server-side, unlike "required" which is
+		// advisory and "fails open" on long contexts / reasoning models (the
+		// model can answer in prose instead of calling the tool). The full tool
+		// list is kept (not filtered to the single function) to match OpenAI
+		// semantics and preserve tool-result context fidelity.
+		// See https://github.com/cloudflare/ai/issues/560.
 		case "tool":
 			return {
-				tool_choice: "required",
-				tools: mappedTools.filter((tool) => tool.function.name === toolChoice.toolName),
+				tool_choice: { type: "function", function: { name: toolChoice.toolName } },
+				tools: mappedTools,
 			};
 		default: {
 			const exhaustiveCheck = type satisfies never;
@@ -462,6 +467,133 @@ export function processToolCalls(output: Record<string, unknown>): LanguageModel
 export function processPartialToolCalls(partialToolCalls: PartialToolCall[]) {
 	const mergedToolCalls = mergePartialToolCalls(partialToolCalls);
 	return processToolCalls({ tool_calls: mergedToolCalls });
+}
+
+// ---------------------------------------------------------------------------
+// Forced tool-call salvage (gpt-oss harmony quirk)
+// ---------------------------------------------------------------------------
+
+/**
+ * Was a specific tool forced for this request?
+ *
+ * True for both `tool_choice: "required"` and the named-function form
+ * `{ type: "function", function: { name } }`.
+ */
+export function isForcedToolChoice(toolChoice: unknown): boolean {
+	if (toolChoice === "required") return true;
+	return (
+		typeof toolChoice === "object" &&
+		toolChoice !== null &&
+		(toolChoice as { type?: unknown }).type === "function"
+	);
+}
+
+/**
+ * Parse tool calls that a model leaked as JSON text instead of structured
+ * `tool_calls`. Shared by the non-streaming salvage and the streaming buffer.
+ *
+ * Only JSON objects whose `name` is one of `knownToolNames` are recovered;
+ * everything else (prose, harmony channel/role leaks like `{"name":"analysis"}`,
+ * hallucinated names) is ignored to avoid fabricating bogus calls.
+ */
+export function parseLeakedToolCalls(
+	text: string,
+	knownToolNames: Set<string>,
+): LanguageModelV3ToolCall[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text.trim());
+	} catch {
+		return [];
+	}
+
+	const candidates = Array.isArray(parsed) ? parsed : [parsed];
+	const salvaged: LanguageModelV3ToolCall[] = [];
+
+	for (const candidate of candidates) {
+		if (typeof candidate !== "object" || candidate === null) continue;
+		const obj = candidate as Record<string, unknown>;
+		const name = obj.name;
+		if (typeof name !== "string" || !knownToolNames.has(name)) continue;
+
+		// Arguments may be wrapped (`arguments`/`parameters`) or flattened as
+		// siblings of `name`.
+		let args: unknown;
+		if ("arguments" in obj) {
+			args = obj.arguments;
+		} else if ("parameters" in obj) {
+			args = obj.parameters;
+		} else {
+			const { name: _name, ...rest } = obj;
+			args = rest;
+		}
+
+		salvaged.push({
+			input: typeof args === "string" ? args : JSON.stringify(args ?? {}),
+			toolCallId: createAISDKToolCallId(undefined),
+			type: "tool-call",
+			toolName: name,
+		});
+	}
+
+	return salvaged;
+}
+
+/** Collect the requested tool names from mapped tools. */
+export function getToolNames(
+	tools: Array<{ function: { name?: string } }> | undefined,
+): Set<string> {
+	return new Set(
+		(tools ?? [])
+			.map((tool) => tool.function?.name)
+			.filter((name): name is string => typeof name === "string"),
+	);
+}
+
+/**
+ * Salvage a tool call that a model leaked into text content instead of the
+ * structured `tool_calls` field.
+ *
+ * Workers AI's gpt-oss models (harmony format) sometimes emit a forced tool
+ * call as raw JSON in `message.content` with an empty `tool_calls` array and
+ * `finish_reason: "stop"` — typically when the forced tool is a poor fit for
+ * the conversation. The content looks like one of:
+ *
+ *   {"name":"read_skill_resource","path":"feedback.txt"}        (flat args)
+ *   {"name":"calc","arguments":{"a":1}}                          (wrapped args)
+ *   [{"name":"calc","parameters":{"a":1}}]                       (array form)
+ *
+ * This reinterprets that text as a structured tool call. It is intentionally
+ * narrow to avoid false positives:
+ *   - only runs when a tool was *forced* (required / named-function), so a
+ *     tool call was explicitly demanded by the caller;
+ *   - only runs when there are no real structured tool calls to override;
+ *   - only matches JSON objects whose `name` is one of the requested tools.
+ *
+ * Returns the salvaged tool calls, or `null` when nothing was salvaged.
+ *
+ * See https://github.com/cloudflare/ai/issues/560.
+ */
+export function salvageToolCallsFromText(
+	output: Record<string, unknown>,
+	context: {
+		tools: Array<{ function: { name?: string } }> | undefined;
+		toolChoice: unknown;
+	},
+): LanguageModelV3ToolCall[] | null {
+	if (!isForcedToolChoice(context.toolChoice)) return null;
+
+	// Never override real tool calls.
+	if (processToolCalls(output).length > 0) return null;
+
+	const knownToolNames = getToolNames(context.tools);
+	if (knownToolNames.size === 0) return null;
+
+	const text = processText(output);
+	if (!text) return null;
+
+	const salvaged = parseLeakedToolCalls(text, knownToolNames);
+	return salvaged.length > 0 ? salvaged : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -9,6 +9,7 @@ import {
 	prepareToolsAndToolChoice,
 	processText,
 	processToolCalls,
+	salvageToolCallsFromText,
 } from "./utils";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
 import type { TextGenerationModels } from "./workersai-models";
@@ -203,6 +204,57 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		};
 	}
 
+	/**
+	 * Extract reasoning, text, and tool calls from a non-streaming response.
+	 *
+	 * Shared by `doGenerate` and `doStream`'s graceful-degradation branch (the
+	 * path gpt-oss falls through, since it doesn't support `/ai/run/` streaming
+	 * and is retried non-streaming). When a forced tool call was leaked into
+	 * text content (gpt-oss harmony quirk), it is salvaged into a structured
+	 * tool call and the leaked JSON text is suppressed. A warning is appended in
+	 * place so callers can observe the reinterpretation.
+	 */
+	private extractContent(
+		outputRecord: Record<string, unknown>,
+		args: ReturnType<typeof this.getArgs>["args"],
+		warnings: SharedV3Warning[],
+	) {
+		const choices = outputRecord.choices as
+			| Array<{ message?: { reasoning_content?: string; reasoning?: string } }>
+			| undefined;
+		const reasoningContent =
+			choices?.[0]?.message?.reasoning_content ?? choices?.[0]?.message?.reasoning;
+
+		const toolCalls = processToolCalls(outputRecord);
+		const salvaged =
+			toolCalls.length === 0
+				? salvageToolCallsFromText(outputRecord, {
+						tools: args.tools,
+						toolChoice: args.tool_choice,
+					})
+				: null;
+
+		if (salvaged) {
+			warnings.push({
+				type: "other",
+				message: `Recovered ${salvaged.length} forced tool call(s) that the model emitted as text content instead of structured tool calls (model: ${this.modelId}).`,
+			});
+		}
+
+		return {
+			reasoningContent,
+			// Suppress the leaked JSON text when we salvaged a tool call from it.
+			text: salvaged ? "" : (processText(outputRecord) ?? ""),
+			toolCalls: salvaged ?? toolCalls,
+			// When salvaged, the upstream finish_reason is "stop"; report
+			// "tool-calls" so the response is indistinguishable from a native
+			// tool call and the agentic loop continues correctly.
+			finishReason: salvaged
+				? ({ unified: "tool-calls", raw: "stop" } as const)
+				: mapWorkersAIFinishReason(outputRecord),
+		};
+	}
+
 	async doGenerate(
 		options: Parameters<LanguageModelV3["doGenerate"]>[0],
 	): Promise<Awaited<ReturnType<LanguageModelV3["doGenerate"]>>> {
@@ -230,25 +282,20 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		}
 
 		const outputRecord = output as Record<string, unknown>;
-		const choices = outputRecord.choices as
-			| Array<{
-					message?: { reasoning_content?: string; reasoning?: string };
-			  }>
-			| undefined;
-		const reasoningContent =
-			choices?.[0]?.message?.reasoning_content ?? choices?.[0]?.message?.reasoning;
+		const { reasoningContent, text, toolCalls, finishReason } = this.extractContent(
+			outputRecord,
+			args,
+			warnings,
+		);
 
 		return {
-			finishReason: mapWorkersAIFinishReason(outputRecord),
+			finishReason,
 			content: [
 				...(reasoningContent
 					? [{ type: "reasoning" as const, text: reasoningContent }]
 					: []),
-				{
-					type: "text",
-					text: processText(outputRecord) ?? "",
-				},
-				...processToolCalls(outputRecord),
+				{ type: "text" as const, text },
+				...toolCalls,
 			],
 			usage: mapWorkersAIUsage(output as Record<string, unknown>),
 			warnings,
@@ -279,20 +326,24 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		// If the binding returned a stream, pipe it through the SSE mapper
 		if (response instanceof ReadableStream) {
 			return {
-				stream: prependStreamStart(getMappedStream(response), warnings),
+				stream: prependStreamStart(
+					getMappedStream(response, {
+						tools: args.tools,
+						toolChoice: args.tool_choice,
+					}),
+					warnings,
+				),
 			};
 		}
 
 		// Graceful degradation: some models return a non-streaming response even
 		// when stream:true is requested. Wrap the complete response as a stream.
 		const outputRecord = response as Record<string, unknown>;
-		const choices = outputRecord.choices as
-			| Array<{
-					message?: { reasoning_content?: string; reasoning?: string };
-			  }>
-			| undefined;
-		const reasoningContent =
-			choices?.[0]?.message?.reasoning_content ?? choices?.[0]?.message?.reasoning;
+		const { reasoningContent, text, toolCalls, finishReason } = this.extractContent(
+			outputRecord,
+			args,
+			warnings,
+		);
 
 		let textId: string | null = null;
 		let reasoningId: string | null = null;
@@ -316,7 +367,6 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 						controller.enqueue({ type: "reasoning-end", id: reasoningId });
 					}
 
-					const text = processText(outputRecord);
 					if (text) {
 						textId = generateId();
 						controller.enqueue({ type: "text-start", id: textId });
@@ -324,13 +374,13 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 						controller.enqueue({ type: "text-end", id: textId });
 					}
 
-					for (const toolCall of processToolCalls(outputRecord)) {
+					for (const toolCall of toolCalls) {
 						controller.enqueue(toolCall);
 					}
 
 					controller.enqueue({
 						type: "finish",
-						finishReason: mapWorkersAIFinishReason(outputRecord),
+						finishReason,
 						usage: mapWorkersAIUsage(response as Record<string, unknown>),
 					});
 					controller.close();

--- a/packages/workers-ai-provider/test/e2e/fixtures/binding-worker/src/index.ts
+++ b/packages/workers-ai-provider/test/e2e/fixtures/binding-worker/src/index.ts
@@ -220,6 +220,40 @@ export default {
 					});
 				}
 
+				// ----- toolChoice forced to a specific tool (named-function form) -----
+				case "/chat/tool-forced": {
+					const result = await generateText({
+						model: provider(model as any),
+						messages: [
+							{ role: "system", content: "You are a warm, encouraging coach." },
+							{
+								role: "user",
+								content: "That went really well! How do you think I did?",
+							},
+						],
+						tools: {
+							record_feedback: {
+								description: "Record structured coaching feedback.",
+								inputSchema: z.object({
+									score: z.number().describe("score out of 10"),
+									note: z.string().describe("short feedback note"),
+								}),
+							},
+							lookup_schedule: {
+								description: "Look up the practice schedule.",
+								inputSchema: z.object({ day: z.string() }),
+							},
+						},
+						toolChoice: { type: "tool", toolName: "record_feedback" },
+					});
+
+					return jsonResponse({
+						text: result.text,
+						toolCalls: result.toolCalls,
+						finishReason: result.finishReason,
+					});
+				}
+
 				// ----- Structured output -----
 				case "/chat/structured": {
 					const result = await generateText({

--- a/packages/workers-ai-provider/test/e2e/workers-ai-binding.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-binding.e2e.test.ts
@@ -53,6 +53,7 @@ const results: Record<
 		toolRoundTrip: Status;
 		toolMultiStep: Status;
 		toolRequired: Status;
+		toolForced: Status;
 		structuredOutput: Status;
 		notes: string[];
 	}
@@ -68,6 +69,7 @@ function getResult(label: string) {
 			toolRoundTrip: "fail",
 			toolMultiStep: "fail",
 			toolRequired: "fail",
+			toolForced: "fail",
 			structuredOutput: "fail",
 			notes: [],
 		};
@@ -88,7 +90,7 @@ function printSummaryTable() {
 	const pad = (s: string, n: number) => s + " ".repeat(Math.max(0, n - s.length));
 	const maxLabel = Math.max(...labels.map((l) => l.length), 5);
 
-	const header = `${pad("Model", maxLabel)} | Chat | Strm | Turn | Tool | T-RT | T-MS | T-Rq | JSON | Notes`;
+	const header = `${pad("Model", maxLabel)} | Chat | Strm | Turn | Tool | T-RT | T-MS | T-Rq | T-Fc | JSON | Notes`;
 	const sep = "-".repeat(header.length + 10);
 
 	console.log(`\n${sep}`);
@@ -101,13 +103,14 @@ function printSummaryTable() {
 		const r = results[label];
 		const notes = r.notes.length > 0 ? r.notes.join("; ") : "";
 		console.log(
-			`${pad(label, maxLabel)} | ${statusIcon(r.chat)} | ${statusIcon(r.stream)} | ${statusIcon(r.multiTurn)} | ${statusIcon(r.toolCall)} | ${statusIcon(r.toolRoundTrip)} | ${statusIcon(r.toolMultiStep)} | ${statusIcon(r.toolRequired)} | ${statusIcon(r.structuredOutput)} | ${notes}`,
+			`${pad(label, maxLabel)} | ${statusIcon(r.chat)} | ${statusIcon(r.stream)} | ${statusIcon(r.multiTurn)} | ${statusIcon(r.toolCall)} | ${statusIcon(r.toolRoundTrip)} | ${statusIcon(r.toolMultiStep)} | ${statusIcon(r.toolRequired)} | ${statusIcon(r.toolForced)} | ${statusIcon(r.structuredOutput)} | ${notes}`,
 		);
 	}
 
 	console.log(sep);
 	console.log("  OK = works    ~ = partial/quirky    X = broken/error");
 	console.log("  T-MS = multi-step agentic loop    T-Rq = toolChoice required");
+	console.log("  T-Fc = toolChoice forced to a specific tool (named-function form)");
 	console.log(`${sep}\n`);
 }
 
@@ -401,6 +404,44 @@ describe("Workers AI Binding E2E", () => {
 				} else {
 					r.toolRequired = "fail";
 					r.notes.push("t-rq: no tool call or content");
+				}
+			});
+		}
+	});
+
+	// ------------------------------------------------------------------
+	// toolChoice forced to a specific tool (per model)
+	// Validates the named-function mapping over the binding path.
+	// ------------------------------------------------------------------
+	describe("toolChoice forced (named tool, per model)", () => {
+		for (const model of MODELS) {
+			it(`${model.label} — toolChoice forced via binding`, async () => {
+				if (!serverReady) return;
+
+				const r = getResult(model.label);
+				const data = await post("/chat/tool-forced", { model: model.id });
+
+				if (data.error) {
+					r.toolForced = "fail";
+					r.notes.push(`t-fc: ${String(data.error).slice(0, 60)}`);
+					return;
+				}
+
+				const toolCalls = data.toolCalls as Array<{ toolName?: string }> | undefined;
+				const forcedCall = Array.isArray(toolCalls)
+					? toolCalls.find((c) => c.toolName === "record_feedback")
+					: undefined;
+				if (forcedCall) {
+					r.toolForced = "ok";
+				} else if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+					r.toolForced = "warn";
+					r.notes.push(`t-fc: called ${toolCalls[0].toolName} instead of forced tool`);
+				} else if (typeof data.text === "string" && (data.text as string).length > 0) {
+					r.toolForced = "warn";
+					r.notes.push("t-fc: answered as text despite forced tool");
+				} else {
+					r.toolForced = "fail";
+					r.notes.push("t-fc: no tool call or content");
 				}
 			});
 		}

--- a/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
@@ -82,6 +82,7 @@ const results: Record<
 		toolRoundTrip: Status;
 		toolMultiStep: Status;
 		toolRequired: Status;
+		toolForced: Status;
 		structuredOutput: Status;
 		notes: string[];
 	}
@@ -96,6 +97,7 @@ function getResult(label: string) {
 			toolRoundTrip: "skip",
 			toolMultiStep: "skip",
 			toolRequired: "skip",
+			toolForced: "skip",
 			structuredOutput: "skip",
 			notes: [],
 		};
@@ -123,7 +125,7 @@ function printSummaryTable() {
 	const pad = (s: string, n: number) => s + " ".repeat(Math.max(0, n - s.length));
 	const maxLabel = Math.max(...labels.map((l) => l.length), 5);
 
-	const header = `${pad("Model", maxLabel)} | Chat | Turn | Tool | T-RT | T-MS | T-Rq | JSON | Notes`;
+	const header = `${pad("Model", maxLabel)} | Chat | Turn | Tool | T-RT | T-MS | T-Rq | T-Fc | JSON | Notes`;
 	const sep = "-".repeat(header.length + 10);
 
 	console.log(`\n${sep}`);
@@ -136,13 +138,14 @@ function printSummaryTable() {
 		const r = results[label];
 		const notes = r.notes.length > 0 ? r.notes.join("; ") : "";
 		console.log(
-			`${pad(label, maxLabel)} | ${statusIcon(r.chat)} | ${statusIcon(r.multiTurn)} | ${statusIcon(r.toolCalling)} | ${statusIcon(r.toolRoundTrip)} | ${statusIcon(r.toolMultiStep)} | ${statusIcon(r.toolRequired)} | ${statusIcon(r.structuredOutput)} | ${notes}`,
+			`${pad(label, maxLabel)} | ${statusIcon(r.chat)} | ${statusIcon(r.multiTurn)} | ${statusIcon(r.toolCalling)} | ${statusIcon(r.toolRoundTrip)} | ${statusIcon(r.toolMultiStep)} | ${statusIcon(r.toolRequired)} | ${statusIcon(r.toolForced)} | ${statusIcon(r.structuredOutput)} | ${notes}`,
 		);
 	}
 
 	console.log(sep);
 	console.log("  OK = works    ~ = partial/quirky    X = broken    - = skipped");
 	console.log("  T-MS = multi-step agentic loop    T-Rq = toolChoice required");
+	console.log("  T-Fc = toolChoice forced to a specific tool (named-function form)");
 	console.log(`${sep}\n`);
 }
 
@@ -437,6 +440,72 @@ describe.skipIf(skip())("Workers AI REST E2E", () => {
 				} catch (err: unknown) {
 					r.toolRequired = "fail";
 					r.notes.push(`t-rq: ${(err as Error).message.slice(0, 60)}`);
+				}
+			});
+		}
+	});
+
+	// ------------------------------------------------------------------
+	// toolChoice forced to a specific tool (per model)
+	// Validates the named-function mapping: toolChoice { type: "tool", toolName }
+	// must force that exact tool even with a prose-tempting prompt. "required"
+	// alone "fails open" on reasoning models (qwq-32b, gemma-4) — see issue #560.
+	// ------------------------------------------------------------------
+	describe("toolChoice forced (named tool)", () => {
+		for (const model of MODELS) {
+			it(`${model.label} — toolChoice forced to specific tool`, async () => {
+				const r = getResult(model.label);
+
+				try {
+					const provider = makeProvider();
+
+					const result = await generateText({
+						model: provider(model.id as ModelId),
+						messages: [
+							{ role: "system", content: "You are a warm, encouraging coach." },
+							{
+								role: "user",
+								content: "That went really well! How do you think I did?",
+							},
+						],
+						tools: {
+							record_feedback: {
+								description: "Record structured coaching feedback.",
+								inputSchema: z.object({
+									score: z.number().describe("score out of 10"),
+									note: z.string().describe("short feedback note"),
+								}),
+							},
+							// A second, unrelated tool to confirm the forced choice
+							// targets the named tool while the full list is sent.
+							lookup_schedule: {
+								description: "Look up the practice schedule.",
+								inputSchema: z.object({ day: z.string() }),
+							},
+						},
+						toolChoice: { type: "tool", toolName: "record_feedback" },
+					});
+
+					const forcedCall = result.toolCalls?.find(
+						(c) => c.toolName === "record_feedback",
+					);
+					if (forcedCall) {
+						r.toolForced = "ok";
+					} else if (result.toolCalls && result.toolCalls.length > 0) {
+						r.toolForced = "warn";
+						r.notes.push(
+							`t-fc: called ${result.toolCalls[0].toolName} instead of forced tool`,
+						);
+					} else if (result.text.length > 0) {
+						r.toolForced = "warn";
+						r.notes.push("t-fc: answered as text despite forced tool");
+					} else {
+						r.toolForced = "fail";
+						r.notes.push("t-fc: no tool call or content");
+					}
+				} catch (err: unknown) {
+					r.toolForced = "fail";
+					r.notes.push(`t-fc: ${(err as Error).message.slice(0, 60)}`);
 				}
 			});
 		}

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -212,6 +212,117 @@ describe("REST API - Streaming Text Tests", () => {
 		expect(await result.finishReason).toBe("tool-calls");
 	});
 
+	it("should salvage a forced tool call leaked into streamed text content (gpt-oss harmony)", async () => {
+		// gpt-oss can stream a forced tool call as `content` text deltas with
+		// finish_reason "stop" instead of structured tool_calls. With a forced
+		// tool choice, the provider buffers the text and reinterprets it.
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"{\\"name\\":\\"get_weather\\","},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{"content":"\\"location\\":\\"London\\"}"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Get the weather for London",
+			tools: {
+				get_weather: {
+					description: "Get the weather in a location",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+			toolChoice: { type: "tool", toolName: "get_weather" },
+		});
+
+		const toolCalls: any[] = [];
+		let accumulatedText = "";
+		for await (const chunk of result.fullStream) {
+			if (chunk.type === "tool-call") toolCalls.push(chunk);
+			if (chunk.type === "text-delta") accumulatedText += (chunk as { text: string }).text;
+		}
+
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].toolName).toBe("get_weather");
+		expect(toolCalls[0].input).toEqual({ location: "London" });
+		// The leaked JSON text must not surface as assistant text.
+		expect(accumulatedText).toBe("");
+		expect(await result.finishReason).toBe("tool-calls");
+	});
+
+	it("should not salvage streamed text when the leaked name is not a known tool", async () => {
+		// A harmony channel/role leak (e.g. "analysis") must not be fabricated
+		// into a tool call; the buffered text is surfaced as-is instead.
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"choices":[{"delta":{"content":"{\\"name\\":\\"analysis\\",\\"location\\":\\"x\\"}"},"finish_reason":null}]}\n\n`,
+							`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Get the weather for London",
+			tools: {
+				get_weather: {
+					description: "Get the weather in a location",
+					inputSchema: z.object({ location: z.string() }),
+				},
+			},
+			toolChoice: { type: "tool", toolName: "get_weather" },
+		});
+
+		const toolCalls: any[] = [];
+		let accumulatedText = "";
+		for await (const chunk of result.fullStream) {
+			if (chunk.type === "tool-call") toolCalls.push(chunk);
+			if (chunk.type === "text-delta") accumulatedText += (chunk as { text: string }).text;
+		}
+
+		expect(toolCalls).toHaveLength(0);
+		expect(accumulatedText).toBe('{"name":"analysis","location":"x"}');
+		expect(await result.finishReason).toBe("stop");
+	});
+
 	it("should handle streamed tool calls (OpenAI format) with tools present", async () => {
 		server.use(
 			http.post(

--- a/packages/workers-ai-provider/test/utils.test.ts
+++ b/packages/workers-ai-provider/test/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	processText,
 	normalizeMessagesForBinding,
 	prepareToolsAndToolChoice,
+	salvageToolCallsFromText,
 	createRun,
 	toWorkersAIToolCallId,
 } from "../src/utils";
@@ -379,14 +380,127 @@ describe("prepareToolsAndToolChoice", () => {
 		expect(result.tools).toHaveLength(2);
 	});
 
-	it("should handle 'tool' tool choice by filtering and using 'required'", () => {
+	it("should handle 'tool' tool choice with the named-function form", () => {
 		const result = prepareToolsAndToolChoice(sampleTools, {
 			type: "tool",
 			toolName: "calculator",
 		});
-		expect(result.tool_choice).toBe("required");
-		expect(result.tools).toHaveLength(1);
-		expect(result.tools![0].function.name).toBe("calculator");
+		expect(result.tool_choice).toEqual({
+			type: "function",
+			function: { name: "calculator" },
+		});
+		// Full tool list is preserved (not filtered to the single function).
+		expect(result.tools).toHaveLength(2);
+		expect(result.tools!.map((t) => t.function.name)).toEqual(["get_weather", "calculator"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// salvageToolCallsFromText (gpt-oss harmony quirk)
+// ---------------------------------------------------------------------------
+
+describe("salvageToolCallsFromText", () => {
+	const tools = [
+		{ function: { name: "read_skill_resource" } },
+		{ function: { name: "calculator" } },
+	];
+	const namedChoice = { type: "function", function: { name: "read_skill_resource" } };
+
+	// A gpt-oss response that leaked the forced tool call into text content.
+	function leakedResponse(content: string) {
+		return {
+			choices: [
+				{
+					message: { role: "assistant", content, tool_calls: [] },
+					finish_reason: "stop",
+				},
+			],
+		};
+	}
+
+	it("salvages a flat-args tool call leaked into content", () => {
+		const output = leakedResponse(
+			'{"name":"read_skill_resource","path":"feedback.txt","name_arg":"x"}',
+		);
+		const result = salvageToolCallsFromText(output, { tools, toolChoice: namedChoice });
+		expect(result).not.toBeNull();
+		expect(result).toHaveLength(1);
+		expect(result![0].toolName).toBe("read_skill_resource");
+		expect(JSON.parse(result![0].input)).toEqual({ path: "feedback.txt", name_arg: "x" });
+		expect(result![0].type).toBe("tool-call");
+	});
+
+	it("salvages a wrapped-arguments tool call", () => {
+		const output = leakedResponse('{"name":"calculator","arguments":{"a":1,"b":2}}');
+		const result = salvageToolCallsFromText(output, {
+			tools,
+			toolChoice: { type: "function", function: { name: "calculator" } },
+		});
+		expect(result).toHaveLength(1);
+		expect(result![0].toolName).toBe("calculator");
+		expect(JSON.parse(result![0].input)).toEqual({ a: 1, b: 2 });
+	});
+
+	it("salvages a wrapped-parameters tool call in array form", () => {
+		const output = leakedResponse('[{"name":"calculator","parameters":{"a":3,"b":4}}]');
+		const result = salvageToolCallsFromText(output, { tools, toolChoice: "required" });
+		expect(result).toHaveLength(1);
+		expect(result![0].toolName).toBe("calculator");
+		expect(JSON.parse(result![0].input)).toEqual({ a: 3, b: 4 });
+	});
+
+	it("returns null when the tool choice is not forced", () => {
+		const output = leakedResponse('{"name":"read_skill_resource","path":"x.txt"}');
+		expect(
+			salvageToolCallsFromText(output, { tools, toolChoice: { type: "auto" } }),
+		).toBeNull();
+		expect(salvageToolCallsFromText(output, { tools, toolChoice: undefined })).toBeNull();
+	});
+
+	it("returns null when real structured tool calls are present", () => {
+		const output = {
+			choices: [
+				{
+					message: {
+						content: '{"name":"read_skill_resource","path":"x.txt"}',
+						tool_calls: [
+							{
+								id: "1",
+								type: "function",
+								function: { name: "calculator", arguments: "{}" },
+							},
+						],
+					},
+				},
+			],
+		};
+		expect(salvageToolCallsFromText(output, { tools, toolChoice: namedChoice })).toBeNull();
+	});
+
+	it("returns null when the JSON name is not a known tool", () => {
+		const output = leakedResponse('{"name":"unknown_tool","path":"x.txt"}');
+		expect(salvageToolCallsFromText(output, { tools, toolChoice: namedChoice })).toBeNull();
+	});
+
+	it("returns null when content is plain prose (not JSON)", () => {
+		const output = leakedResponse("You did wonderfully, I'm proud of your progress!");
+		expect(salvageToolCallsFromText(output, { tools, toolChoice: namedChoice })).toBeNull();
+	});
+
+	it("returns null when there are no tools", () => {
+		const output = leakedResponse('{"name":"read_skill_resource","path":"x.txt"}');
+		expect(
+			salvageToolCallsFromText(output, { tools: undefined, toolChoice: "required" }),
+		).toBeNull();
+	});
+
+	it("ignores array entries whose name is unknown, keeping known ones", () => {
+		const output = leakedResponse(
+			'[{"name":"unknown","x":1},{"name":"calculator","arguments":{"a":9}}]',
+		);
+		const result = salvageToolCallsFromText(output, { tools, toolChoice: "required" });
+		expect(result).toHaveLength(1);
+		expect(result![0].toolName).toBe("calculator");
 	});
 });
 


### PR DESCRIPTION
## Summary

Two related fixes for **forced tool calling** on Workers AI via `workers-ai-provider`.

### 1. Map forced single-tool choice to the named-function form (fixes #560)

`prepareToolsAndToolChoice` translated the AI SDK's `toolChoice: { type: "tool", toolName }` into `tool_choice: "required"` (and filtered the tool list to the single function). Workers AI treats `"required"` as **advisory** — on long contexts and reasoning models the model "fails open" and answers in prose instead of calling the tool.

We now send the documented OpenAI-style named-function form:

```ts
case "tool":
  return {
    tool_choice: { type: "function", function: { name: toolChoice.toolName } },
    tools: mappedTools, // full list, matching OpenAI semantics
  };
```

Workers AI enforces this server-side. The full tool list is kept (not filtered) to match OpenAI semantics and preserve tool-result context fidelity.

> Note: forcing a tool on a reasoning model with insufficient `max_tokens` is validated server-side and now surfaces as a clear error (Workers AI `8006`) rather than silently producing no tool call.

### 2. Recover forced tool calls that gpt-oss leaks as text (mitigates #574)

When a tool is forced, gpt-oss (harmony format) sometimes emits the call as **raw JSON in `message.content`** with an empty `tool_calls` array and `finish_reason: "stop"` — typically when the forced tool is a poor fit for the conversation. This breaks agentic loops (no executable tool call; the "answer" is malformed JSON).

We now detect and reinterpret this as a structured tool call, across both `generateText` (and `doStream`'s graceful-degradation branch) and the real SSE streaming path. The salvage is intentionally **conservative** to avoid fabricating bogus calls:

- only runs when a tool was **forced** (`required` / named-function);
- only when there are **no real** structured tool calls to override;
- only matches JSON objects whose `name` is one of the **requested** tools.

Ambiguous leaks (harmony channel/role names like `{"name":"analysis"}`, hallucinated names) are left untouched. On salvage we suppress the leaked JSON text, report `finishReason: "tool-calls"`, and surface a warning (`generateText`) / `console.warn` (streaming, where `stream-start` warnings are already fixed).

This recovers the call **envelope**; in these leak cases gpt-oss often hallucinates the arguments, so recovered args are not high-confidence. The robust fix belongs in Cloudflare's upstream harmony parser — filed as #574.

## Evidence (live REST API, 7 models)

Forced an ill-fitting tool on a prose-tempting prompt. Tool calls produced (`required` vs named-function):

| Model | required | named-function |
|---|---|---|
| `@cf/google/gemma-4-26b-a4b-it` (long ctx) | ❌ 0 | ✅ 1 |
| `@cf/qwen/qwq-32b` (reasoning) | ❌ 0 (2/3 runs) | ✅ 1 (3/3) |
| `@cf/qwen/qwen3-30b-a3b-fp8` (long ctx) | ❌ 0 | ✅ 1 |
| Llama 3.1 / 3.3 / 4 family | ✅ 1 | ✅ 1 (harmless) |
| `@cf/openai/gpt-oss-120b` / `-20b` | ⚠️ leaks as text | ⚠️ leaks as text → salvaged when `name` matches |

## Changes

- `src/utils.ts` — named-function mapping; add `isForcedToolChoice`, `parseLeakedToolCalls`, `getToolNames`, `salvageToolCallsFromText`.
- `src/workersai-chat-language-model.ts` — shared `extractContent()` used by `doGenerate` and `doStream` graceful-degradation; thread `tools`/`tool_choice` into `getMappedStream`.
- `src/streaming.ts` — buffer `content` deltas in forced-tool mode, salvage at flush, report `tool-calls` finish reason on salvage.

## Tests

- **Unit** (385 pass): named-function mapping + 9 salvage cases (flat/wrapped/array args + all negative guards); streaming salvage success + a "don't fabricate from channel-leak names" negative.
- **E2E** — new forced single-tool (`T-Fc`) case across 8 models for both REST and binding.
  - REST: ran live, all 8 pass.
  - Binding: ran live via `wrangler dev`; verified `binding.run()` accepts the named-function `tool_choice` object for all 8 models (no errors).

## Test plan

- [ ] `pnpm --filter workers-ai-provider test:ci`
- [ ] `pnpm --filter workers-ai-provider test:e2e:rest` (needs `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`)
- [ ] `pnpm --filter workers-ai-provider test:e2e:binding` (needs wrangler auth)

Refs: #560, #574

Made with [Cursor](https://cursor.com)