### PR TITLE
fix(workers-ai-provider): preserve structured-output name/description on native models

### DIFF
--- a/.changeset/workers-ai-provider-structured-output-name.md
+++ b/.changeset/workers-ai-provider-structured-output-name.md
@@ -1,0 +1,29 @@
+---
+"workers-ai-provider": patch
+---
+
+Keep structured-output `name`/`description` instead of dropping them on native Workers AI models.
+
+`Output.object({ schema, name, description })` and `generateObject({ schema,
+schemaName, schemaDescription })` pass a `name`/`description` alongside the JSON
+schema. On the native `@cf/...` path the provider previously forwarded only the
+bare schema as `response_format.json_schema` and silently discarded both.
+
+Native Workers AI expects `json_schema` to be a **bare** JSON Schema, not
+OpenAI's `{ name, schema, strict }` envelope, so we can't just wrap it (that
+would break native models). Instead the `name` is folded into the schema's
+standard `title` keyword and the `description` into its `description` keyword —
+the payload stays a valid bare schema while the guidance reaches the model.
+Existing schema-level `title`/`description` are never overwritten and the input
+schema is not mutated.
+
+Note on issue #559: the reported failure was OpenAI partner models (e.g.
+`openai/gpt-5.4-mini`) rejecting requests with `Missing required parameter:
+'response_format.json_schema.name'`. Partner-model slugs are no longer handled
+by this code path at all — they route through the AI Gateway delegate and the
+real `@ai-sdk/*` providers, which build the required `json_schema.name` envelope
+themselves (configure them via `createWorkersAI({ binding, providers: [openai]
+})`). This change covers the remaining native-model gap where that guidance was
+being dropped.
+
+See https://github.com/cloudflare/ai/issues/559.

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -267,6 +267,57 @@ export async function createRunBinary(
 }
 
 // ---------------------------------------------------------------------------
+// Structured output (JSON mode)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `response_format.json_schema` payload for native Workers AI models.
+ *
+ * Native Workers AI (`@cf/...`) expects `json_schema` to be a **bare** JSON
+ * Schema, NOT OpenAI's `{ name, schema, strict }` envelope. That envelope is
+ * only required by partner-model routes (e.g. `openai/...`), which never reach
+ * this code — they go through the gateway delegate and the real `@ai-sdk/*`
+ * providers, which build the envelope themselves. Wrapping the schema here would
+ * break native models, so we must keep the bare shape.
+ *
+ * The AI SDK's structured-output `name` / `description` (from
+ * `Output.object({ schema, name, description })` / `generateObject`) would
+ * otherwise be silently dropped on this path. We preserve them as the standard
+ * JSON Schema `title` (from `name`) and `description` keywords, which keeps the
+ * payload a valid bare schema while still passing the LLM guidance through.
+ *
+ * Existing schema-level `title` / `description` are never overwritten, empty
+ * strings are ignored, and the input schema object is never mutated.
+ *
+ * See https://github.com/cloudflare/ai/issues/559.
+ */
+export function buildJsonSchemaPayload(
+	schema: unknown,
+	name?: string,
+	description?: string,
+): unknown {
+	// Only objects can carry JSON Schema keywords. Anything else (incl.
+	// `undefined` when no schema was supplied) passes through untouched.
+	if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+		return schema;
+	}
+
+	const record = schema as Record<string, unknown>;
+	const addTitle = !!name && record.title === undefined;
+	const addDescription = !!description && record.description === undefined;
+
+	if (!addTitle && !addDescription) {
+		return schema;
+	}
+
+	return {
+		...record,
+		...(addTitle ? { title: name } : {}),
+		...(addDescription ? { description } : {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // Tool preparation
 // ---------------------------------------------------------------------------
 

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -5,6 +5,7 @@ import { mapWorkersAIFinishReason } from "./map-workersai-finish-reason";
 import { mapWorkersAIUsage } from "./map-workersai-usage";
 import { getMappedStream, prependStreamStart } from "./streaming";
 import {
+	buildJsonSchemaPayload,
 	normalizeMessagesForBinding,
 	prepareToolsAndToolChoice,
 	processText,
@@ -94,13 +95,23 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 			}
 
 			case "json": {
+				// Native Workers AI expects a BARE JSON Schema under `json_schema`
+				// (not OpenAI's `{ name, schema, strict }` envelope — partner models
+				// that need that go through the gateway delegate, not this path). We
+				// fold the AI SDK's `name`/`description` into the schema as `title`/
+				// `description` so they aren't lost. See
+				// https://github.com/cloudflare/ai/issues/559.
+				const json = responseFormat?.type === "json" ? responseFormat : undefined;
 				return {
 					args: {
 						...baseArgs,
 						response_format: {
 							type: "json_schema",
-							json_schema:
-								responseFormat?.type === "json" ? responseFormat.schema : undefined,
+							json_schema: buildJsonSchemaPayload(
+								json?.schema,
+								json?.name,
+								json?.description,
+							),
 						},
 						tools: undefined,
 						tool_choice: undefined,

--- a/packages/workers-ai-provider/test/e2e/fixtures/gateway-worker/src/index.ts
+++ b/packages/workers-ai-provider/test/e2e/fixtures/gateway-worker/src/index.ts
@@ -7,7 +7,7 @@
  * JSON so the test harness can assert on it.
  */
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateText, streamText } from "ai";
+import { generateText, jsonSchema, Output, streamText } from "ai";
 import { anthropic } from "../../../../../src/anthropic";
 import type { DispatchInfo } from "../../../../../src/gateway-delegate";
 import { createGatewayDelegate } from "../../../../../src/gateway-delegate";
@@ -144,6 +144,43 @@ export default {
 						resumeEnabled: dispatch?.resumeEnabled,
 						lastOffset,
 						streamErr,
+					});
+				}
+
+				// --- Run path: structured output (issue #559) ---
+				// Drives a partner model (openai-wire) through the delegate with
+				// `Output.object({ schema, name, description })`. The real @ai-sdk/openai
+				// provider must build the `response_format.json_schema.name` envelope
+				// OpenAI requires — the failure mode reported in #559.
+				case "/run/structured": {
+					let dispatch: DispatchInfo | undefined;
+					const result = await generateText({
+						model: wai(body.slug ?? "openai/gpt-5-mini", {
+							onDispatch: (info) => {
+								dispatch = info;
+							},
+						}),
+						prompt: "What is the capital of France and its approximate population in millions?",
+						output: Output.object({
+							schema: jsonSchema<{
+								capital: string;
+								population_millions: number;
+							}>({
+								type: "object",
+								properties: {
+									capital: { type: "string" },
+									population_millions: { type: "number" },
+								},
+								required: ["capital", "population_millions"],
+								additionalProperties: false,
+							}),
+							name: "CountryCapital",
+							description: "A country's capital city and its population.",
+						}),
+					});
+					return json({
+						output: result.output,
+						transport: dispatch?.transport,
 					});
 				}
 

--- a/packages/workers-ai-provider/test/e2e/workers-ai-gateway.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-gateway.e2e.test.ts
@@ -67,6 +67,17 @@ function isModelUnavailable(err: string): boolean {
 	);
 }
 
+/**
+ * A model returned a response the AI SDK could not coerce into the requested
+ * object — a structured-output *capability* limitation of that model, not a
+ * delegate/provider bug. Tolerated for non-guaranteed models only.
+ */
+function isStructuredOutputUnsupported(err: string): boolean {
+	return /no object generated|could not parse the response|did not match schema|response did not match/i.test(
+		err,
+	);
+}
+
 let wrangler: ChildProcess | null = null;
 let ready = false;
 /** Set in beforeAll: does the resumable run path actually work on this account? */
@@ -175,6 +186,39 @@ describe.skipIf(!RUN)("AI Gateway delegate E2E", () => {
 					expect(typeof data.runId).toBe("string");
 					expect((data.runId as string).length).toBeGreaterThan(0);
 					expect(data.lastOffset).toBeGreaterThan(0);
+				})();
+			});
+		}
+	});
+
+	// --- Structured output (issue #559) ---
+	// The partner path must satisfy OpenAI's `response_format.json_schema.name`
+	// requirement (built by the real @ai-sdk/openai provider, not dropped).
+	describe("run path — structured output", () => {
+		for (const m of RUN_MODELS) {
+			it(`${m.label} — structured output via Output.object`, (ctx) => {
+				if (!runPathReady) return ctx.skip(`run path not ready (${runPathReason})`);
+				return (async () => {
+					const data = await post("/run/structured", { slug: m.slug });
+					if (data.error) {
+						const err = String(data.error);
+						if (
+							!m.guaranteed &&
+							(isModelUnavailable(err) || isStructuredOutputUnsupported(err))
+						) {
+							return ctx.skip(
+								`structured output unavailable/unsupported: ${err.slice(0, 80)}`,
+							);
+						}
+						throw new Error(`[run/structured] ${m.label}: ${err}`);
+					}
+					const output = data.output as {
+						capital?: unknown;
+						population_millions?: unknown;
+					} | null;
+					expect(output, "no structured output returned").toBeTruthy();
+					expect(typeof output?.capital).toBe("string");
+					expect(typeof output?.population_millions).toBe("number");
 				})();
 			});
 		}

--- a/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-rest.e2e.test.ts
@@ -524,11 +524,16 @@ describe.skipIf(skip())("Workers AI REST E2E", () => {
 					const result = await generateText({
 						model: provider(model.id as ModelId),
 						prompt: "What is the capital of France and its approximate population in millions?",
+						// name/description are folded into the bare schema as
+						// title/description on the native path (issue #559) — assert
+						// real models still accept the payload.
 						output: Output.object({
 							schema: z.object({
 								capital: z.string(),
 								population_millions: z.number(),
 							}),
+							name: "CountryCapital",
+							description: "A country's capital city and its population.",
 						}),
 					});
 

--- a/packages/workers-ai-provider/test/structured-output.test.ts
+++ b/packages/workers-ai-provider/test/structured-output.test.ts
@@ -1,4 +1,4 @@
-import { generateText, Output } from "ai";
+import { generateObject, generateText, Output, streamText } from "ai";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -115,5 +115,240 @@ describe("Binding - Structured Output Tests", () => {
 		expect(object?.recipe.name).toBe("Spaghetti Bolognese");
 		expect(object?.recipe.ingredients.length).toBeGreaterThan(0);
 		expect(object?.recipe.steps.length).toBeGreaterThan(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Wire-payload shape for native models (issue #559)
+//
+// Native Workers AI expects a BARE JSON Schema under `response_format.
+// json_schema` (not OpenAI's `{ name, schema, strict }` envelope). The AI SDK's
+// `name`/`description` must be preserved as JSON Schema `title`/`description`
+// rather than dropped. Partner models (e.g. `openai/...`) take a different
+// route (the gateway delegate) and are not exercised here.
+// ---------------------------------------------------------------------------
+
+const simpleSchema = z.object({ ok: z.boolean() });
+
+/** Capture the JSON body of the next request to the Workers AI run endpoint. */
+function captureRestBody(): { get: () => any } {
+	let body: any;
+	server.use(
+		http.post(
+			`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+			async ({ request }) => {
+				body = await request.json();
+				return HttpResponse.json({
+					result: { response: JSON.stringify({ ok: true }) },
+				});
+			},
+		),
+	);
+	return { get: () => body };
+}
+
+describe("REST API - response_format wire shape (issue #559)", () => {
+	beforeAll(() => server.listen());
+	afterEach(() => server.resetHandlers());
+	afterAll(() => server.close());
+
+	it("sends a bare JSON Schema, not an OpenAI envelope", async () => {
+		const captured = captureRestBody();
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Return ok",
+			output: Output.object({ schema: simpleSchema }),
+		});
+
+		const rf = captured.get().response_format;
+		expect(rf.type).toBe("json_schema");
+		// Bare schema keywords are top-level on json_schema...
+		expect(rf.json_schema.type).toBe("object");
+		expect(rf.json_schema.properties).toHaveProperty("ok");
+		// ...and the OpenAI envelope keys must NOT be present.
+		expect(rf.json_schema).not.toHaveProperty("schema");
+		expect(rf.json_schema).not.toHaveProperty("strict");
+		expect(rf.json_schema).not.toHaveProperty("name");
+	});
+
+	it("folds Output.object name/description into title/description", async () => {
+		const captured = captureRestBody();
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Return ok",
+			output: Output.object({
+				schema: simpleSchema,
+				name: "Result",
+				description: "A boolean result",
+			}),
+		});
+
+		const jsonSchema = captured.get().response_format.json_schema;
+		expect(jsonSchema.title).toBe("Result");
+		expect(jsonSchema.description).toBe("A boolean result");
+		// Still a bare schema.
+		expect(jsonSchema.type).toBe("object");
+		expect(jsonSchema).not.toHaveProperty("schema");
+	});
+
+	it("preserves the same shape on the streaming path", async () => {
+		let body: any;
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async ({ request }) => {
+					body = await request.json();
+					return new Response(
+						[`data: {"response":"{\\"ok\\":true}"}\n\n`, "data: [DONE]\n\n"].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Return ok",
+			output: Output.object({ schema: simpleSchema, name: "Result" }),
+		});
+		for await (const _ of result.textStream) {
+			// drain
+		}
+
+		const jsonSchema = body.response_format.json_schema;
+		expect(jsonSchema.type).toBe("object");
+		expect(jsonSchema.title).toBe("Result");
+		expect(jsonSchema).not.toHaveProperty("schema");
+	});
+});
+
+describe("generateObject - response_format wire shape (issue #559)", () => {
+	beforeAll(() => server.listen());
+	afterEach(() => server.resetHandlers());
+	afterAll(() => server.close());
+
+	it("folds schemaName/schemaDescription into title/description", async () => {
+		const captured = captureRestBody();
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = await generateObject({
+			model: workersai(TEST_MODEL),
+			schema: simpleSchema,
+			schemaName: "Result",
+			schemaDescription: "A boolean result",
+			prompt: "Return ok",
+		});
+
+		expect(result.object).toEqual({ ok: true });
+		const jsonSchema = captured.get().response_format.json_schema;
+		expect(jsonSchema.type).toBe("object");
+		expect(jsonSchema.title).toBe("Result");
+		expect(jsonSchema.description).toBe("A boolean result");
+		// Still a bare schema, not an OpenAI envelope.
+		expect(jsonSchema).not.toHaveProperty("schema");
+		expect(jsonSchema).not.toHaveProperty("strict");
+	});
+
+	it("sends a bare schema when no schemaName/description given", async () => {
+		const captured = captureRestBody();
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = await generateObject({
+			model: workersai(TEST_MODEL),
+			schema: simpleSchema,
+			prompt: "Return ok",
+		});
+
+		expect(result.object).toEqual({ ok: true });
+		const jsonSchema = captured.get().response_format.json_schema;
+		expect(jsonSchema.type).toBe("object");
+		expect(jsonSchema.properties).toHaveProperty("ok");
+		expect(jsonSchema).not.toHaveProperty("title");
+		expect(jsonSchema).not.toHaveProperty("schema");
+	});
+});
+
+describe("Binding - response_format wire shape (issue #559)", () => {
+	it("sends a bare JSON Schema with folded title/description", async () => {
+		let inputs: any;
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (_modelName: string, capturedInputs: any) => {
+					inputs = capturedInputs;
+					return { response: JSON.stringify({ ok: true }) };
+				},
+			} as any,
+		});
+
+		await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Return ok",
+			output: Output.object({
+				schema: simpleSchema,
+				name: "Result",
+				description: "A boolean result",
+			}),
+		});
+
+		const rf = inputs.response_format;
+		expect(rf.type).toBe("json_schema");
+		expect(rf.json_schema.type).toBe("object");
+		expect(rf.json_schema.title).toBe("Result");
+		expect(rf.json_schema.description).toBe("A boolean result");
+		expect(rf.json_schema).not.toHaveProperty("schema");
+		expect(rf.json_schema).not.toHaveProperty("strict");
+	});
+
+	it("does not overwrite a description already present in the schema", async () => {
+		let inputs: any;
+		const workersai = createWorkersAI({
+			binding: {
+				run: async (_modelName: string, capturedInputs: any) => {
+					inputs = capturedInputs;
+					return { response: JSON.stringify({ ok: true }) };
+				},
+			} as any,
+		});
+
+		// Top-level `.describe()` becomes the schema's `description`.
+		const describedSchema = z.object({ ok: z.boolean() }).describe("Schema-level description");
+
+		await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Return ok",
+			output: Output.object({
+				schema: describedSchema,
+				description: "Output-level description",
+			}),
+		});
+
+		expect(inputs.response_format.json_schema.description).toBe("Schema-level description");
 	});
 });

--- a/packages/workers-ai-provider/test/utils.test.ts
+++ b/packages/workers-ai-provider/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
+	buildJsonSchemaPayload,
 	createAISDKToolCallId,
 	processPartialToolCalls,
 	processToolCalls,
@@ -10,6 +11,100 @@ import {
 	createRun,
 	toWorkersAIToolCallId,
 } from "../src/utils";
+
+// ---------------------------------------------------------------------------
+// buildJsonSchemaPayload
+// ---------------------------------------------------------------------------
+
+describe("buildJsonSchemaPayload", () => {
+	const schema = {
+		type: "object",
+		properties: { ok: { type: "boolean" } },
+		required: ["ok"],
+	} as const;
+
+	it("returns the bare schema unchanged when no name/description given", () => {
+		const result = buildJsonSchemaPayload(schema);
+		// Same reference: nothing to add, no clone needed.
+		expect(result).toBe(schema);
+	});
+
+	it("does NOT wrap the schema in an OpenAI { name, schema } envelope", () => {
+		const result = buildJsonSchemaPayload(schema, "Result", "A result") as Record<
+			string,
+			unknown
+		>;
+		// The bare schema keywords stay at the top level...
+		expect(result.type).toBe("object");
+		expect(result.properties).toEqual(schema.properties);
+		// ...and the envelope keys are absent.
+		expect(result).not.toHaveProperty("schema");
+		expect(result).not.toHaveProperty("strict");
+	});
+
+	it("folds name into JSON Schema `title`", () => {
+		const result = buildJsonSchemaPayload(schema, "Result") as Record<string, unknown>;
+		expect(result.title).toBe("Result");
+		expect(result).not.toHaveProperty("description");
+	});
+
+	it("folds description into JSON Schema `description`", () => {
+		const result = buildJsonSchemaPayload(schema, undefined, "A boolean result") as Record<
+			string,
+			unknown
+		>;
+		expect(result.description).toBe("A boolean result");
+		expect(result).not.toHaveProperty("title");
+	});
+
+	it("folds both name and description when both are provided", () => {
+		const result = buildJsonSchemaPayload(schema, "Result", "A boolean result") as Record<
+			string,
+			unknown
+		>;
+		expect(result.title).toBe("Result");
+		expect(result.description).toBe("A boolean result");
+	});
+
+	it("never overwrites an existing schema-level title", () => {
+		const withTitle = { ...schema, title: "Existing" };
+		const result = buildJsonSchemaPayload(withTitle, "Result") as Record<string, unknown>;
+		expect(result.title).toBe("Existing");
+	});
+
+	it("never overwrites an existing schema-level description", () => {
+		const withDescription = { ...schema, description: "Existing description" };
+		const result = buildJsonSchemaPayload(
+			withDescription,
+			undefined,
+			"New description",
+		) as Record<string, unknown>;
+		expect(result.description).toBe("Existing description");
+	});
+
+	it("ignores empty-string name/description", () => {
+		const result = buildJsonSchemaPayload(schema, "", "");
+		expect(result).toBe(schema);
+	});
+
+	it("does not mutate the input schema", () => {
+		const input = { type: "object", properties: { ok: { type: "boolean" } } };
+		const snapshot = structuredClone(input);
+		buildJsonSchemaPayload(input, "Result", "A result");
+		expect(input).toEqual(snapshot);
+	});
+
+	it("passes through undefined (no schema, plain JSON mode)", () => {
+		expect(buildJsonSchemaPayload(undefined, "Result", "A result")).toBeUndefined();
+	});
+
+	it("passes through non-object schemas untouched", () => {
+		expect(buildJsonSchemaPayload(true as unknown, "Result")).toBe(true);
+		expect(buildJsonSchemaPayload(null, "Result")).toBeNull();
+		const arr = [1, 2, 3];
+		expect(buildJsonSchemaPayload(arr, "Result")).toBe(arr);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // normalizeMessagesForBinding


### PR DESCRIPTION
## Summary

On the native `@cf/...` path, the provider forwarded only the bare JSON schema as `response_format.json_schema` and **dropped** the structured-output `name`/`description` supplied via `Output.object({ schema, name, description })` or `generateObject({ schemaName, schemaDescription })`.

Native Workers AI expects `json_schema` to be a **bare** JSON Schema, not OpenAI's `{ name, schema, strict }` envelope. Wrapping it would break native models, so instead this PR folds:

- `name` → the schema's standard JSON Schema `title` keyword
- `description` → the schema's `description` keyword

…keeping the payload a valid bare schema while passing the LLM guidance through. Existing schema-level `title`/`description` are never overwritten, and the input schema object is not mutated. The logic lives in a new pure helper, `buildJsonSchemaPayload`, with a single call site in the chat model's `getArgs` JSON branch.

## Relationship to #559 (please read)

#559 reports OpenAI **partner** models (e.g. `openai/gpt-5.4-mini`) failing structured output with `Missing required parameter: 'response_format.json_schema.name'`.

- **Partner-model slugs no longer flow through this code path.** They route through the AI Gateway delegate and the real `@ai-sdk/*` providers, which build the required `json_schema.name` envelope themselves. Configure via `createWorkersAI({ binding, providers: [openai] })`; without `providers` you now get a clear config error instead of the cryptic OpenAI one.
- **This PR closes the adjacent native-model gap**, where the same `name`/`description` were silently discarded.

So this is not a literal fix of the OP's partner-model error (that's handled by the routing) — it's the related native-path correctness fix.

## Design note for reviewers

Mapping `name → title` / `description → description` is a deliberate, standard, non-breaking choice (valid JSON Schema keywords; ignored by models that don't use them). An alternative would be to drop them with an `"unsupported"` warning. Happy to switch if maintainers prefer that.

## Test plan

- [x] Unit: `buildJsonSchemaPayload` — folding, no-overwrite of existing title/description, no input mutation, empty-string/undefined/non-object passthrough
- [x] Integration (mocked transport): wire-payload shape asserted across REST + binding, `generateText`/`Output.object` + `generateObject`, and streaming — confirms a bare schema (no `{ schema, strict, name }` envelope) with folded `title`/`description`
- [x] E2E native (`@cf/`): structured-output case now passes `name`/`description`; verified across 8 models
- [x] E2E partner (gateway delegate): new `/run/structured` fixture endpoint + test, verified live on unified billing against `openai/gpt-5-mini`, `google/gemini-2.5-flash`, `anthropic/claude-haiku-4.5`, `alibaba/qwen3-max` (non-`guaranteed` models that can't do structured output skip)
- [x] `pnpm build`, typecheck (package + fixture), and lint all clean


Made with [Cursor](https://cursor.com)