### PR TITLE
fix(workers-ai-provider): prevent dynamic/ slugs from being routed as catalog models

### DIFF
--- a/.changeset/workers-ai-provider-dynamic-route-slug.md
+++ b/.changeset/workers-ai-provider-dynamic-route-slug.md
@@ -1,0 +1,15 @@
+---
+"workers-ai-provider": patch
+---
+
+Treat `dynamic/<model>` slugs as Workers AI model ids, not gateway catalog slugs.
+
+AI Gateway dynamic route prefixes (e.g. `dynamic/gemma-4-fallback`) must be
+passed through to `env.AI.run()` unmodified so Workers AI can resolve them
+through the configured gateway. Previously `createWorkersAI` treated any
+`"<provider>/<model>"` id that did not start with `@` as a third-party catalog
+slug, so `dynamic/<model>` ids were routed through `createGatewayDelegate`,
+which looked up `"dynamic"` in the provider registry, failed to find it, and
+threw `Unknown gateway provider "dynamic"`. Slugs starting with `dynamic/` are
+now excluded from catalog routing and reach `env.AI.run(model, inputs, { gateway })`
+directly, matching the contract of the Workers AI binding.

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -323,9 +323,13 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 
 	// Workers AI model ids are always `@cf/...`; gateway catalog slugs are
 	// `"<provider>/<model>"`. Anything with a slash that is not `@`-prefixed is
-	// treated as a catalog slug.
+	// treated as a catalog slug, unless it starts with `dynamic/` which is an
+	// AI Gateway dynamic routing prefix and must pass through to Workers AI.
 	const isGatewaySlug = (id: unknown): id is string =>
-		typeof id === "string" && !id.startsWith("@") && id.includes("/");
+		typeof id === "string" &&
+		!id.startsWith("@") &&
+		!id.startsWith("dynamic/") &&
+		id.includes("/");
 
 	// Settings is the union of both shapes here; the public `WorkersAI` interface
 	// narrows it per call via `ModelSettings<M>`. We branch at runtime and cast to

--- a/packages/workers-ai-provider/test/create-workers-ai.test.ts
+++ b/packages/workers-ai-provider/test/create-workers-ai.test.ts
@@ -238,6 +238,28 @@ describe("createWorkersAI implicit gateway routing", () => {
 		expect(model.provider).toBe("workersai.chat");
 	});
 
+	it("treats `dynamic/<model>` slugs as Workers AI model ids (not catalog slugs)", () => {
+		const { binding } = makeBinding();
+		const workersai = createWorkersAI({ binding, gateway: { id: "default" } });
+		const model = workersai("dynamic/gemma-4-fallback");
+		expect(model.modelId).toBe("dynamic/gemma-4-fallback");
+		expect(model.provider).toBe("workersai.chat");
+	});
+
+	it("routes `dynamic/<model>` slugs to Workers AI even when providers are configured", () => {
+		const { binding, runCalls } = makeBinding();
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [openaiPlugin],
+		});
+		const model = workersai("dynamic/gemma-4-fallback");
+		expect(model.modelId).toBe("dynamic/gemma-4-fallback");
+		expect(model.provider).toBe("workersai.chat");
+		// `.chat()` routes the same way.
+		expect(workersai.chat("dynamic/gemma-4-fallback").provider).toBe("workersai.chat");
+	});
+
 	it("builds the delegate lazily (only on first catalog slug)", () => {
 		const { binding } = makeBinding();
 		const createSpy = vi.spyOn(openaiPlugin, "create");


### PR DESCRIPTION
## Problem

`createWorkersAI` throws `Unknown gateway provider dynamic` when using AI Gateway dynamic routes like `dynamic/gemma-4-fallback`.

The `isGatewaySlug` function at `src/index.ts:327` classifies any model ID with `/` (and no `@` prefix) as a gateway catalog slug. `dynamic/` prefixes then fail `resolveProvider` since `dynamic` is not in the `GATEWAY_PROVIDERS` registry.

## Fix

Treat model IDs starting with `dynamic/` as Workers AI model IDs rather than catalog slugs. The `dynamic/` prefix is a Cloudflare-internal AI Gateway routing prefix that must be passed through to `env.AI.run(model, inputs, { gateway })` unmodified.

## Change

```diff
- const isGatewaySlug = (id: unknown): id is string =>
-   typeof id === "string" && !id.startsWith("@") && id.includes("/");
+ const isGatewaySlug = (id: unknown): id is string =>
+   typeof id === "string" &&
+   !id.startsWith("@") &&
+   !id.startsWith("dynamic/") &&
+   id.includes("/");
```

## Testing

1. Configure `createWorkersAI` with `gateway: { id: my-gateway }`
2. Call `wai(dynamic/gemma-4-fallback)`
3. Observe the model ID reaches `env.AI.run(dynamic/gemma-4-fallback, ...)` with the `gateway` option intact

Closes #581