### PR TITLE
fix(workers-ai-provider): support dynamic gateway routes

### DIFF
--- a/.changeset/twelve-llamas-float.md
+++ b/.changeset/twelve-llamas-float.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+fix(workers-ai-provider): pass dynamic AI Gateway routes through Workers AI

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -92,6 +92,7 @@ import {
 	type GatewayDelegate,
 	type ProviderPlugin,
 	type ResumeExpiredPolicy,
+	type WireFormat,
 } from "./gateway-delegate";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,7 @@ import {
  * configured. Every Cloudflare account has a `"default"` gateway.
  */
 const DEFAULT_GATEWAY_ID = "default";
+const DYNAMIC_ROUTE_WIRE_FORMAT: WireFormat = "openai";
 
 export type WorkersAISettings = (
 	| {
@@ -178,9 +180,17 @@ type IsCatalogSlug<M extends string> = string extends M
 	? false
 	: M extends `@${string}`
 		? false
-		: M extends `${string}/${string}`
-			? true
-			: false;
+		: M extends `dynamic/${string}`
+			? false
+			: M extends `${string}/${string}`
+				? true
+				: false;
+
+type IsDynamicRoute<M extends string> = string extends M
+	? false
+	: M extends `dynamic/${string}`
+		? true
+		: false;
 
 /**
  * Picks the per-model settings type from the (captured) literal model id:
@@ -189,7 +199,11 @@ type IsCatalogSlug<M extends string> = string extends M
  * options while `workersai("@cf/…", { … })` autocompletes chat settings.
  */
 type ModelSettings<M extends string> =
-	IsCatalogSlug<M> extends true ? DelegateCallOptions : WorkersAIChatSettings;
+	IsCatalogSlug<M> extends true
+		? DelegateCallOptions
+		: IsDynamicRoute<M> extends true
+			? DelegateCallOptions | WorkersAIChatSettings
+			: WorkersAIChatSettings;
 
 export interface WorkersAI {
 	<M extends string>(
@@ -291,6 +305,112 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 			isBinding,
 		});
 
+	const toGatewayOptions = (gateway: GatewayOptions | string | undefined): GatewayOptions | undefined =>
+		typeof gateway === "string" ? { id: gateway } : gateway;
+
+	const createDynamicRouteModel = (
+		modelId: TextGenerationModels,
+		settings: (WorkersAIChatSettings & DelegateCallOptions) = {},
+	) => {
+		if (
+			settings.fallback ||
+			settings.transport === "gateway" ||
+			settings.resume === true ||
+			settings.onProgress ||
+			settings.onResumeExpired ||
+			settings.byok
+		) {
+			throw new Error(
+				`"${modelId}" is an AI Gateway dynamic route. Dynamic routes use AI.run with ` +
+					"OpenAI-compatible chat-completions wire format; fallback, gateway transport, " +
+					"resume, BYOK, and resume callbacks must be configured on the dynamic route or " +
+					"gateway instead of per call.",
+			);
+		}
+
+		const gateway = {
+			...(toGatewayOptions(settings.gateway) ?? options.gateway ?? { id: DEFAULT_GATEWAY_ID }),
+		};
+		if (settings.metadata) {
+			gateway.metadata = {
+				...(gateway.metadata ?? {}),
+				...settings.metadata,
+			};
+		}
+		if (settings.collectLog !== undefined) {
+			gateway.collectLog = settings.collectLog;
+		}
+		if (settings.cacheTtl !== undefined) {
+			gateway.cacheTtl = settings.cacheTtl;
+		}
+		if (settings.skipCache !== undefined) {
+			gateway.skipCache = settings.skipCache;
+		}
+
+		const chatSettings = {
+			...settings,
+			gateway,
+		};
+		delete chatSettings.metadata;
+		delete chatSettings.collectLog;
+		delete chatSettings.cacheTtl;
+		delete chatSettings.skipCache;
+		delete chatSettings.resume;
+		delete chatSettings.fallback;
+		delete chatSettings.transport;
+		delete chatSettings.onDispatch;
+		delete chatSettings.onProgress;
+		delete chatSettings.onResumeExpired;
+		delete chatSettings.byok;
+
+		const plugin = options.providers?.find((p) => p.wireFormat === DYNAMIC_ROUTE_WIRE_FORMAT);
+		if (!plugin) {
+			if (options.providers?.length) {
+				throw new Error(
+					`"${modelId}" is an AI Gateway dynamic route. Dynamic routes return OpenAI-compatible ` +
+						"chat-completions wire format on the AI.run path, so configure the OpenAI " +
+						'provider plugin: import { openai } from "workers-ai-provider/openai"; ' +
+						"createWorkersAI({ binding: env.AI, providers: [openai] }).",
+				);
+			}
+			return createChatModel(modelId, chatSettings);
+		}
+		const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+			const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+			delete body.model;
+
+			const runOptions: Record<string, unknown> = {
+				gateway,
+				returnRawResponse: true,
+				...(settings.extraHeaders ? { extraHeaders: settings.extraHeaders } : {}),
+				...(init?.signal ? { signal: init.signal } : {}),
+			};
+			const response = await (binding as unknown as {
+				run(
+					model: string,
+					inputs: Record<string, unknown>,
+					options: Record<string, unknown>,
+				): Promise<Response>;
+			}).run(modelId, body, runOptions);
+			settings.onDispatch?.({
+				transport: "run",
+				resumeEnabled: false,
+				warnings: [],
+				status: response.status,
+				runId: response.headers.get("cf-aig-run-id"),
+				cfStep: response.headers.get("cf-aig-step"),
+				cacheStatus: response.headers.get("cf-aig-cache-status"),
+				logId: response.headers.get("cf-aig-log-id"),
+			});
+			return response;
+		}) as typeof globalThis.fetch;
+
+		return plugin.create({
+			modelId,
+			fetch: fetchImpl,
+		}) as unknown as WorkersAIChatLanguageModel;
+	};
+
 	// Third-party catalog routing: when `providers` is configured, a non-`@cf/`
 	// `"<provider>/<model>"` slug is dispatched through the gateway delegate
 	// instead of being treated as a Workers AI model id. Built lazily so the
@@ -321,11 +441,14 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 		return delegate;
 	};
 
-	// Workers AI model ids are always `@cf/...`; gateway catalog slugs are
-	// `"<provider>/<model>"`. Anything with a slash that is not `@`-prefixed is
-	// treated as a catalog slug.
+	// Workers AI model ids are usually `@cf/...`, but AI Gateway dynamic routes
+	// use the `dynamic/<route>` namespace and must pass through to `AI.run`.
+	// Other non-`@` ids with a slash are treated as catalog slugs.
 	const isGatewaySlug = (id: unknown): id is string =>
-		typeof id === "string" && !id.startsWith("@") && id.includes("/");
+		typeof id === "string" &&
+		!id.startsWith("@") &&
+		!id.startsWith("dynamic/") &&
+		id.includes("/");
 
 	// Settings is the union of both shapes here; the public `WorkersAI` interface
 	// narrows it per call via `ModelSettings<M>`. We branch at runtime and cast to
@@ -334,6 +457,12 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 		modelId: TextGenerationModels,
 		settings?: WorkersAIChatSettings | DelegateCallOptions,
 	): WorkersAIChatLanguageModel => {
+		if (typeof modelId === "string" && modelId.startsWith("dynamic/")) {
+			return createDynamicRouteModel(
+				modelId,
+				settings as (WorkersAIChatSettings & DelegateCallOptions) | undefined,
+			);
+		}
 		if (isGatewaySlug(modelId)) {
 			// The delegate returns a `LanguageModelV3` built by the configured plugin.
 			// It's structurally compatible with the AI SDK consumers this provider is

--- a/packages/workers-ai-provider/test/create-workers-ai.test.ts
+++ b/packages/workers-ai-provider/test/create-workers-ai.test.ts
@@ -1,7 +1,9 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { createWorkersAI } from "../src/index";
 import type { ProviderPlugin } from "../src/gateway-delegate";
+import { openai as openaiWirePlugin } from "../src/openai";
 
 /** Minimal binding that records run/gateway calls. */
 function makeBinding() {
@@ -221,6 +223,149 @@ describe("createWorkersAI implicit gateway routing", () => {
 		expect(model.provider).toBe("workersai.chat");
 	});
 
+	it("passes `dynamic/...` ids through as Workers AI models when no OpenAI-wire plugin is configured", async () => {
+		const run = vi.fn(async () => ({ response: "Hello from dynamic route" }));
+		const binding = { run } as unknown as Parameters<typeof createWorkersAI>[0] extends {
+			binding: infer B;
+		}
+			? B
+			: never;
+		const workersai = createWorkersAI({
+			binding,
+		});
+
+		const result = await generateText({
+			model: workersai("dynamic/gemma-4-fallback", { safePrompt: true }),
+			prompt: "Say hello.",
+		});
+
+		expect(result.text).toBe("Hello from dynamic route");
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0][0]).toBe("dynamic/gemma-4-fallback");
+		expect(run.mock.calls[0][2]).toMatchObject({
+			gateway: { id: "default" },
+		});
+	});
+
+	it("uses the OpenAI-wire provider plugin for `dynamic/...` ids when configured", async () => {
+		const run = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						id: "chatcmpl-test",
+						object: "chat.completion",
+						created: 0,
+						model: "gpt-4o",
+						choices: [
+							{
+								index: 0,
+								message: {
+									role: "assistant",
+									content: "Hello from OpenAI-wire dynamic route",
+								},
+								finish_reason: "stop",
+							},
+						],
+						usage: {
+							prompt_tokens: 4,
+							completion_tokens: 6,
+							total_tokens: 10,
+						},
+					}),
+					{
+						headers: {
+							"content-type": "application/json",
+							"cf-aig-cache-status": "MISS",
+							"cf-aig-log-id": "log-123",
+						},
+					},
+				),
+		);
+		const onDispatch = vi.fn();
+		const binding = { run } as unknown as Parameters<typeof createWorkersAI>[0] extends {
+			binding: infer B;
+		}
+			? B
+			: never;
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [openaiWirePlugin],
+		});
+
+		const result = await generateText({
+			model: workersai("dynamic/gemma-4-fallback", {
+				cacheTtl: 60,
+				collectLog: true,
+				metadata: { route: "gemma" },
+				onDispatch,
+				skipCache: true,
+			}),
+			prompt: "Say hello.",
+		});
+
+		expect(result.text).toBe("Hello from OpenAI-wire dynamic route");
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0][0]).toBe("dynamic/gemma-4-fallback");
+		expect(run.mock.calls[0][1]).not.toHaveProperty("model");
+		expect(run.mock.calls[0][2]).toMatchObject({
+			gateway: {
+				cacheTtl: 60,
+				collectLog: true,
+				id: "default",
+				metadata: { route: "gemma" },
+				skipCache: true,
+			},
+			returnRawResponse: true,
+		});
+		expect(onDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				cacheStatus: "MISS",
+				logId: "log-123",
+				resumeEnabled: false,
+				transport: "run",
+			}),
+		);
+	});
+
+	it("throws for `dynamic/...` ids when providers are configured without the OpenAI-wire plugin", () => {
+		const { binding } = makeBinding();
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [
+				{
+					wireFormat: "anthropic",
+					create: openaiPlugin.create,
+				},
+			],
+		});
+
+		expect(() => workersai("dynamic/anty")).toThrow(/OpenAI-compatible/);
+		expect(() => workersai("dynamic/anty")).toThrow(/workers-ai-provider\/openai/);
+	});
+
+	it("throws for unsupported delegate-only options on `dynamic/...` ids", () => {
+		const { binding } = makeBinding();
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [openaiWirePlugin],
+		});
+
+		expect(() =>
+			workersai("dynamic/gemma-4-fallback", {
+				fallback: { mode: "client", models: ["openai/gpt-5-mini"] },
+			}),
+		).toThrow(/must be configured on the dynamic route/);
+		expect(() =>
+			workersai("dynamic/gemma-4-fallback", { transport: "gateway" }),
+		).toThrow(/must be configured on the dynamic route/);
+		expect(() => workersai("dynamic/gemma-4-fallback", { resume: true })).toThrow(
+			/must be configured on the dynamic route/,
+		);
+	});
+
 	it("throws a helpful error for a catalog slug when providers are NOT configured", () => {
 		const { binding } = makeBinding();
 		const workersai = createWorkersAI({ binding, gateway: { id: "default" } });
@@ -268,6 +413,10 @@ describe("createWorkersAI implicit gateway routing", () => {
 
 		// `@cf/...` id → WorkersAIChatSettings autocompletes.
 		workersai("@cf/zai-org/glm-4.7-flash", {
+			safePrompt: true,
+			reasoning_effort: "low",
+		});
+		workersai("dynamic/gemma-4-fallback", {
 			safePrompt: true,
 			reasoning_effort: "low",
 		});


### PR DESCRIPTION
## Summary
- Treat `dynamic/<route>` as an AI Gateway dynamic route instead of resolving `dynamic` as a catalog provider slug.
- Dispatch dynamic routes through `env.AI.run("dynamic/...", ..., { gateway, returnRawResponse: true })` and parse OpenAI-compatible dynamic responses with the configured OpenAI-wire provider plugin when available.
- Default dynamic routes to the account `default` gateway, forward metadata/cache/log controls, and fail fast for delegate-only options that should be configured on the dynamic route itself.

## Test plan
- `pnpm --filter workers-ai-provider exec vitest run test/create-workers-ai.test.ts`
- `pnpm --filter workers-ai-provider type-check`
- `pnpm --filter workers-ai-provider test:ci`
- Live checked `dynamic/gemma-4-fallback` and `dynamic/anty` on the default gateway; both returned OpenAI-compatible dynamic route responses when parsed through the OpenAI-wire provider path.

Closes #581

Made with [Cursor](https://cursor.com)