### PR TITLE
Add Bedrock routing to ai-gateway-provider

### DIFF
--- a/.changeset/smooth-beds-grab.md
+++ b/.changeset/smooth-beds-grab.md
@@ -1,0 +1,5 @@
+---
+"ai-gateway-provider": patch
+---
+
+Add Amazon Bedrock endpoint routing for AI Gateway provider requests.

--- a/packages/ai-gateway-provider/README.md
+++ b/packages/ai-gateway-provider/README.md
@@ -184,6 +184,7 @@ const aigateway = createAiGateway({
 
 - OpenAI
 - Anthropic
+- Amazon Bedrock
 - DeepSeek
 - Google AI Studio
 - Grok

--- a/packages/ai-gateway-provider/src/providers.ts
+++ b/packages/ai-gateway-provider/src/providers.ts
@@ -78,6 +78,21 @@ export const providers = [
 		headerKey: "api-key",
 	},
 	{
+		name: "aws-bedrock",
+		regex: /^https:\/\/bedrock-runtime\.(?<region>[^.]+)\.amazonaws\.com\/(?<rest>.*)$/,
+		transformEndpoint: (url: string) => {
+			const match = url.match(
+				/^https:\/\/bedrock-runtime\.(?<region>[^.]+)\.amazonaws\.com\/(?<rest>.*)$/,
+			);
+			if (!match || !match.groups) return url;
+			const { region, rest } = match.groups;
+			if (!region || rest === undefined) {
+				throw new Error("Failed to parse Amazon Bedrock endpoint URL.");
+			}
+			return `bedrock-runtime/${region}/${rest}`;
+		},
+	},
+	{
 		name: "openrouter",
 		regex: /^https:\/\/openrouter\.ai\/api\//,
 		transformEndpoint: (url: string) => url.replace(/^https:\/\/openrouter\.ai\/api\//, ""),

--- a/packages/ai-gateway-provider/test/endpoint.test.ts
+++ b/packages/ai-gateway-provider/test/endpoint.test.ts
@@ -52,6 +52,12 @@ const testCases = [
 		name: "azure-openai",
 		url: "https://myresource.openai.azure.com/openai/deployments/mydeployment/chat/completions?api-version=2024-02-15-preview",
 	},
+	{
+		expected:
+			"bedrock-runtime/us-east-1/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke",
+		name: "aws-bedrock",
+		url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke",
+	},
 ];
 
 describe("ProvidersConfigs endpoint parsing", () => {


### PR DESCRIPTION
## Summary

- add Amazon Bedrock Runtime URL detection to `ai-gateway-provider`
- transform Bedrock URLs into AI Gateway `aws-bedrock` endpoint paths
- add endpoint parsing coverage and list Amazon Bedrock in the package README
- add a patch changeset for `ai-gateway-provider`

Fixes #587.

## Root cause

`ai-gateway-provider/providers/amazon-bedrock` is exported, but `createAiGateway()` infers the target AI Gateway provider by matching the wrapped SDK request URL. The provider table did not include `bedrock-runtime.{region}.amazonaws.com`, so Bedrock models failed with `provider "amazon-bedrock" is currently not supported` before reaching AI Gateway.

## Validation

- `pnpm --filter ai-gateway-provider test -- --run`
- `pnpm --filter ai-gateway-provider type-check`
