### PR TITLE
fix(workers-ai-provider): surface failures as retryable APICallErrors

### DIFF
--- a/.changeset/workers-ai-retryable-errors.md
+++ b/.changeset/workers-ai-retryable-errors.md
@@ -1,0 +1,29 @@
+---
+"workers-ai-provider": minor
+---
+
+Native Workers AI failures are now surfaced as AI SDK `APICallError`s so the AI
+SDK's built-in retry (`maxRetries`) can engage on transient errors.
+
+Previously the binding path (`env.AI.run`) threw plain `Error`s and the REST
+path threw a generic `Error`, so the AI SDK never retried them — most notably
+the common **"out of capacity"** failure (internal code `3040`, HTTP `429`) and
+other 5xx blips just failed the call outright.
+
+- **Binding path**: errors thrown by `env.AI.run` are normalized into an
+  `APICallError` across every Workers AI model — chat, embedding, image, speech,
+  transcription, and reranking. The Workers AI internal error code is parsed from
+  the message (or a numeric `code` property) and mapped to the documented HTTP
+  status (e.g. `3040`/`3036` → `429`, `3007`/`3008` → `408`, `5007` → `400`), and
+  `APICallError` derives `isRetryable` from that status (retryable on
+  408/409/429/5xx). Unrecognized errors get no status and stay non-retryable
+  (prior behavior). `AbortError`/`TimeoutError` cancellations propagate
+  unchanged.
+- **REST path**: non-OK responses now throw an `APICallError` carrying the real
+  `statusCode`, response headers (so `Retry-After` is honored), and body, instead
+  of a generic `Error`. The error message keeps the same
+  `Workers AI API error (<status> <statusText>): <body>` shape.
+
+This means transient capacity/5xx errors are now automatically retried with
+exponential backoff by `generateText`/`streamText` (default 2 retries; tune via
+`maxRetries`). Set `maxRetries: 0` to opt out.

--- a/packages/workers-ai-provider/src/utils.ts
+++ b/packages/workers-ai-provider/src/utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@cloudflare/gateway-core";
 import { generateId } from "ai";
 import type { WorkersAIChatPrompt } from "./workersai-chat-prompt";
+import { apiCallErrorFromResponse } from "./workersai-error";
 
 // Re-exported from `@cloudflare/gateway-core` (single source of truth) so the
 // existing `workers-ai-provider/src/utils` import paths keep working unchanged.
@@ -155,7 +156,9 @@ export function createRun(config: CreateRunConfig): AiRun {
 			signal: signal as AbortSignal | undefined,
 		});
 
-		// Check for HTTP errors before processing
+		// Check for HTTP errors before processing. Surface as an APICallError so
+		// the AI SDK can classify retryability from the status (429 / 5xx → retry)
+		// and honor any Retry-After header.
 		if (!response.ok && !returnRawResponse) {
 			let errorBody: string;
 			try {
@@ -163,9 +166,10 @@ export function createRun(config: CreateRunConfig): AiRun {
 			} catch {
 				errorBody = "<unable to read response body>";
 			}
-			throw new Error(
-				`Workers AI API error (${response.status} ${response.statusText}): ${errorBody}`,
-			);
+			throw apiCallErrorFromResponse(response, errorBody, {
+				url,
+				requestBodyValues: inputs,
+			});
 		}
 
 		if (returnRawResponse) {
@@ -204,9 +208,10 @@ export function createRun(config: CreateRunConfig): AiRun {
 				} catch {
 					errorBody = "<unable to read response body>";
 				}
-				throw new Error(
-					`Workers AI API error (${retryResponse.status} ${retryResponse.statusText}): ${errorBody}`,
-				);
+				throw apiCallErrorFromResponse(retryResponse, errorBody, {
+					url,
+					requestBodyValues: inputs,
+				});
 			}
 
 			const retryData = await retryResponse.json<{
@@ -261,9 +266,10 @@ export async function createRunBinary(
 		} catch {
 			errorBody = "<unable to read response body>";
 		}
-		throw new Error(
-			`Workers AI API error (${response.status} ${response.statusText}): ${errorBody}`,
-		);
+		throw apiCallErrorFromResponse(response, errorBody, {
+			url,
+			requestBodyValues: { contentType, byteLength: audioBytes.byteLength },
+		});
 	}
 
 	const data = await response.json<{ result?: Record<string, unknown> }>();

--- a/packages/workers-ai-provider/src/workersai-chat-language-model.ts
+++ b/packages/workers-ai-provider/src/workersai-chat-language-model.ts
@@ -13,6 +13,7 @@ import {
 	salvageToolCallsFromText,
 } from "./utils";
 import type { WorkersAIChatSettings } from "./workersai-chat-settings";
+import { normalizeBindingError } from "./workersai-error";
 import type { TextGenerationModels } from "./workersai-models";
 
 type WorkersAIChatConfig = {
@@ -277,14 +278,24 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		});
 		const runOptions = this.getRunOptions();
 
-		const output = await this.config.binding.run(
-			args.model as keyof AiModels,
-			inputs as AiModels[keyof AiModels]["inputs"],
-			{
-				...runOptions,
-				signal: options.abortSignal,
-			} as AiOptions,
-		);
+		let output: unknown;
+		try {
+			output = await this.config.binding.run(
+				args.model as keyof AiModels,
+				inputs as AiModels[keyof AiModels]["inputs"],
+				{
+					...runOptions,
+					signal: options.abortSignal,
+				} as AiOptions,
+			);
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage.
+			throw normalizeBindingError(error, {
+				model: args.model,
+				requestBodyValues: inputs,
+			});
+		}
 
 		if (output instanceof ReadableStream) {
 			throw new Error(
@@ -325,14 +336,24 @@ export class WorkersAIChatLanguageModel implements LanguageModelV3 {
 		});
 		const runOptions = this.getRunOptions();
 
-		const response = await this.config.binding.run(
-			args.model as keyof AiModels,
-			inputs as AiModels[keyof AiModels]["inputs"],
-			{
-				...runOptions,
-				signal: options.abortSignal,
-			} as AiOptions,
-		);
+		let response: unknown;
+		try {
+			response = await this.config.binding.run(
+				args.model as keyof AiModels,
+				inputs as AiModels[keyof AiModels]["inputs"],
+				{
+					...runOptions,
+					signal: options.abortSignal,
+				} as AiOptions,
+			);
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage.
+			throw normalizeBindingError(error, {
+				model: args.model,
+				requestBodyValues: inputs,
+			});
+		}
 
 		// If the binding returned a stream, pipe it through the SSE mapper
 		if (response instanceof ReadableStream) {

--- a/packages/workers-ai-provider/src/workersai-embedding-model.ts
+++ b/packages/workers-ai-provider/src/workersai-embedding-model.ts
@@ -4,6 +4,7 @@ import type {
 	EmbeddingModelV3Result,
 } from "@ai-sdk/provider";
 import { TooManyEmbeddingValuesForCallError } from "@ai-sdk/provider";
+import { normalizeBindingError } from "./workersai-error";
 import type { EmbeddingModels } from "./workersai-models";
 
 export type WorkersAIEmbeddingConfig = {
@@ -72,17 +73,27 @@ export class WorkersAIEmbeddingModel implements EmbeddingModelV3 {
 			...passthroughOptions
 		} = this.settings;
 
-		const response = await this.config.binding.run(
-			this.modelId as keyof AiModels,
-			{
-				text: values,
-			},
-			{
-				gateway: this.config.gateway ?? gateway,
-				signal: abortSignal,
-				...passthroughOptions,
-			} as AiOptions,
-		);
+		let response: unknown;
+		try {
+			response = await this.config.binding.run(
+				this.modelId as keyof AiModels,
+				{
+					text: values,
+				},
+				{
+					gateway: this.config.gateway ?? gateway,
+					signal: abortSignal,
+					...passthroughOptions,
+				} as AiOptions,
+			);
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage.
+			throw normalizeBindingError(error, {
+				model: this.modelId,
+				requestBodyValues: { text: values },
+			});
+		}
 
 		return {
 			embeddings: (response as { data: number[][] }).data,

--- a/packages/workers-ai-provider/src/workersai-error.ts
+++ b/packages/workers-ai-provider/src/workersai-error.ts
@@ -1,0 +1,159 @@
+import { APICallError } from "@ai-sdk/provider";
+
+/**
+ * Workers AI internal error code → HTTP status code.
+ *
+ * The Workers AI **binding** (`env.AI.run`) throws plain `Error`s whose message
+ * carries the internal code (e.g. `"3040: Capacity temporarily exceeded"`) but
+ * no HTTP status. The AI SDK's retry machinery only retries `APICallError`s
+ * whose `statusCode` is retryable (408 / 409 / 429 / >= 500), so we translate
+ * the internal code into the documented HTTP status and let `APICallError`
+ * derive retryability from it — this is what makes transient failures like
+ * "out of capacity" (3040 → 429) automatically retried.
+ *
+ * Source: https://developers.cloudflare.com/workers-ai/platform/errors/
+ */
+export const WORKERS_AI_ERROR_CODE_TO_STATUS: Record<number, number> = {
+	5007: 400, // No such model
+	5004: 400, // Invalid data
+	3039: 400, // Finetune missing required files
+	3003: 400, // Incomplete request
+	5018: 403, // Account not allowed for private model
+	5016: 403, // Model agreement not accepted
+	3023: 403, // Account blocked
+	3041: 403, // Account not allowed for private model
+	5019: 405, // Deprecated SDK version
+	5005: 405, // LoRa unsupported
+	3042: 404, // Invalid model ID
+	3006: 413, // Request too large
+	3007: 408, // Timeout
+	3008: 408, // Aborted
+	3036: 429, // Account limited (daily free allocation used up)
+	3040: 429, // Out of capacity (no data center to forward to)
+};
+
+/**
+ * Best-effort extraction of a Workers AI internal error code from a thrown
+ * binding error. Prefers a numeric `code` property when present, otherwise
+ * parses the `"<code>: <message>"` form the binding uses (optionally prefixed,
+ * e.g. `"InferenceUpstreamError: 3040: ..."`). Only recognized codes are
+ * returned, and when several `"<number>:"` groups appear (e.g. a leading
+ * request id) the first that maps to a known code wins, so unrelated numbers
+ * can't be misread as a code.
+ */
+export function parseWorkersAIErrorCode(error: unknown): number | undefined {
+	if (error && typeof error === "object") {
+		const code = (error as { code?: unknown }).code;
+		if (typeof code === "number" && code in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+			return code;
+		}
+		if (typeof code === "string") {
+			const parsed = Number.parseInt(code, 10);
+			if (Number.isFinite(parsed) && parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+				return parsed;
+			}
+		}
+	}
+
+	const message = messageOf(error);
+	for (const match of message.matchAll(/\b(\d{3,5})\s*:/g)) {
+		const parsed = Number.parseInt(match[1]!, 10);
+		if (parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+			return parsed;
+		}
+	}
+
+	return undefined;
+}
+
+/** Read a human-readable message from any thrown value (Error, DOMException, plain object, string). */
+function messageOf(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object") {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+	return String(error);
+}
+
+/**
+ * True for cancellation errors that must propagate untouched (never wrapped, so
+ * the AI SDK's own abort detection still fires). Mirrors the AI SDK's
+ * `isAbortError`: a real abort from `fetch`/the binding is a `DOMException`,
+ * which is NOT `instanceof Error`, so both must be checked.
+ */
+function isAbortError(error: unknown): boolean {
+	return (
+		(error instanceof Error || error instanceof DOMException) &&
+		(error.name === "AbortError" ||
+			error.name === "ResponseAborted" ||
+			error.name === "TimeoutError")
+	);
+}
+
+/** Serialize `Headers` to the plain object shape `APICallError` expects. */
+function headersToObject(headers: Headers): Record<string, string> {
+	const out: Record<string, string> = {};
+	headers.forEach((value, key) => {
+		out[key] = value;
+	});
+	return out;
+}
+
+/**
+ * Normalize an error thrown by the Workers AI **binding** (`env.AI.run`) into an
+ * `APICallError` so the AI SDK can classify and retry it.
+ *
+ * Cancellations (`AbortError` / `TimeoutError` / `ResponseAborted`, including
+ * `DOMException` aborts) and errors that are already an `APICallError` pass
+ * through unchanged. Everything else becomes an
+ * `APICallError`; when the internal code maps to a known HTTP status, that
+ * `statusCode` is attached and `APICallError` derives `isRetryable` from it.
+ * Unrecognized errors get no `statusCode`, so they stay non-retryable (the
+ * prior behavior).
+ */
+export function normalizeBindingError(
+	error: unknown,
+	context: { model: string; requestBodyValues: unknown },
+): unknown {
+	if (APICallError.isInstance(error) || isAbortError(error)) {
+		return error;
+	}
+
+	const code = parseWorkersAIErrorCode(error);
+	const statusCode = code != null ? WORKERS_AI_ERROR_CODE_TO_STATUS[code] : undefined;
+	const message = messageOf(error);
+
+	return new APICallError({
+		message,
+		url: `workers-ai:binding/run/${context.model}`,
+		requestBodyValues: context.requestBodyValues,
+		statusCode,
+		responseBody: message,
+		cause: error,
+		...(code != null ? { data: { workersAIErrorCode: code } } : {}),
+	});
+}
+
+/**
+ * Build an `APICallError` from a non-OK Workers AI **REST** response. The HTTP
+ * status is authoritative here, so `APICallError` derives `isRetryable` from it
+ * directly (429 / 5xx → retryable). Response headers are preserved so the AI
+ * SDK can honor `Retry-After`. The message keeps the historical
+ * `"Workers AI API error (<status> <statusText>): <body>"` shape.
+ */
+export function apiCallErrorFromResponse(
+	response: Response,
+	errorBody: string,
+	context: { url: string; requestBodyValues: unknown },
+): APICallError {
+	return new APICallError({
+		message: `Workers AI API error (${response.status} ${response.statusText}): ${errorBody}`,
+		url: context.url,
+		requestBodyValues: context.requestBodyValues,
+		statusCode: response.status,
+		responseHeaders: headersToObject(response.headers),
+		responseBody: errorBody,
+	});
+}

--- a/packages/workers-ai-provider/src/workersai-image-model.ts
+++ b/packages/workers-ai-provider/src/workersai-image-model.ts
@@ -1,4 +1,5 @@
 import type { ImageModelV3, SharedV3Warning } from "@ai-sdk/provider";
+import { normalizeBindingError } from "./workersai-error";
 import type { WorkersAIImageSettings } from "./workersai-image-settings";
 import type { ImageGenerationModels } from "./workersai-models";
 
@@ -48,19 +49,26 @@ export class WorkersAIImageModel implements ImageModelV3 {
 		}
 
 		const generateImage = async () => {
-			const output = (await this.config.binding.run(
-				this.modelId as keyof AiModels,
-				{
-					height,
-					prompt: prompt ?? "",
-					seed,
-					width,
-				},
-				{
+			const inputs = {
+				height,
+				prompt: prompt ?? "",
+				seed,
+				width,
+			};
+			let output: unknown;
+			try {
+				output = (await this.config.binding.run(this.modelId as keyof AiModels, inputs, {
 					gateway: this.config.gateway,
 					signal: abortSignal,
-				} as AiOptions,
-			)) as unknown;
+				} as AiOptions)) as unknown;
+			} catch (error) {
+				// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into
+				// a retryable APICallError so the AI SDK's maxRetries can engage.
+				throw normalizeBindingError(error, {
+					model: this.modelId,
+					requestBodyValues: inputs,
+				});
+			}
 
 			return toUint8Array(output);
 		};

--- a/packages/workers-ai-provider/src/workersai-reranking-model.ts
+++ b/packages/workers-ai-provider/src/workersai-reranking-model.ts
@@ -1,4 +1,5 @@
 import type { RerankingModelV3, SharedV3Warning } from "@ai-sdk/provider";
+import { normalizeBindingError } from "./workersai-error";
 import type { WorkersAIRerankingSettings } from "./workersai-reranking-settings";
 import type { RerankingModels } from "./workersai-models";
 
@@ -49,11 +50,21 @@ export class WorkersAIRerankingModel implements RerankingModelV3 {
 			inputs.top_k = topN;
 		}
 
-		const result = (await this.config.binding.run(
-			this.modelId as Parameters<Ai["run"]>[0],
-			inputs as Parameters<Ai["run"]>[1],
-			{ gateway: this.config.gateway, signal: abortSignal } as AiOptions,
-		)) as Record<string, unknown>;
+		let result: Record<string, unknown>;
+		try {
+			result = (await this.config.binding.run(
+				this.modelId as Parameters<Ai["run"]>[0],
+				inputs as Parameters<Ai["run"]>[1],
+				{ gateway: this.config.gateway, signal: abortSignal } as AiOptions,
+			)) as Record<string, unknown>;
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage.
+			throw normalizeBindingError(error, {
+				model: this.modelId,
+				requestBodyValues: inputs,
+			});
+		}
 
 		// Workers AI returns { response: [{ id, score }] }
 		const response = result.response as Array<{ id?: number; score?: number }> | undefined;

--- a/packages/workers-ai-provider/src/workersai-speech-model.ts
+++ b/packages/workers-ai-provider/src/workersai-speech-model.ts
@@ -1,4 +1,5 @@
 import type { SpeechModelV3, SharedV3Warning } from "@ai-sdk/provider";
+import { apiCallErrorFromResponse, normalizeBindingError } from "./workersai-error";
 import type { WorkersAISpeechSettings } from "./workersai-speech-settings";
 import type { SpeechModels } from "./workersai-models";
 
@@ -56,19 +57,40 @@ export class WorkersAISpeechModel implements SpeechModelV3 {
 		if (voice) inputs.voice = voice;
 		if (speed != null) inputs.speed = speed;
 
-		const result = await this.config.binding.run(
-			this.modelId as Parameters<Ai["run"]>[0],
-			inputs as Parameters<Ai["run"]>[1],
-			{
-				gateway: this.config.gateway,
-				signal: abortSignal,
-				// returnRawResponse prevents the createRun REST shim from trying
-				// to JSON.parse binary audio. Real env.AI bindings don't recognize
-				// this option — it has no effect, and the binding returns the normal
-				// binary result (Uint8Array/ReadableStream) which toUint8Array handles.
-				returnRawResponse: true,
-			} as AiOptions,
-		);
+		let result: unknown;
+		try {
+			result = await this.config.binding.run(
+				this.modelId as Parameters<Ai["run"]>[0],
+				inputs as Parameters<Ai["run"]>[1],
+				{
+					gateway: this.config.gateway,
+					signal: abortSignal,
+					// returnRawResponse prevents the createRun REST shim from trying
+					// to JSON.parse binary audio. Real env.AI bindings don't recognize
+					// this option — it has no effect, and the binding returns the normal
+					// binary result (Uint8Array/ReadableStream) which toUint8Array handles.
+					returnRawResponse: true,
+				} as AiOptions,
+			);
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage.
+			throw normalizeBindingError(error, {
+				model: this.modelId,
+				requestBodyValues: inputs,
+			});
+		}
+
+		// The REST shim uses `returnRawResponse`, so it does NOT throw on a non-OK
+		// status — it hands back the raw Response. Without this guard the error body
+		// would be decoded as "audio". Surface it as a (retryable-aware) APICallError.
+		if (result instanceof Response && !result.ok) {
+			const errorBody = await result.text().catch(() => "<unable to read response body>");
+			throw apiCallErrorFromResponse(result, errorBody, {
+				url: `workers-ai:run/${this.modelId}`,
+				requestBodyValues: inputs,
+			});
+		}
 
 		// Workers AI TTS returns binary audio in various formats:
 		// - Binding: Uint8Array, ArrayBuffer, ReadableStream, or { audio: base64 }

--- a/packages/workers-ai-provider/src/workersai-transcription-model.ts
+++ b/packages/workers-ai-provider/src/workersai-transcription-model.ts
@@ -2,6 +2,7 @@ import type { TranscriptionModelV3, SharedV3Warning } from "@ai-sdk/provider";
 import type { WorkersAITranscriptionSettings } from "./workersai-transcription-settings";
 import type { TranscriptionModels } from "./workersai-models";
 import { createRunBinary, type CreateRunConfig } from "./utils";
+import { normalizeBindingError } from "./workersai-error";
 
 export type WorkersAITranscriptionConfig = {
 	provider: string;
@@ -57,10 +58,20 @@ export class WorkersAITranscriptionModel implements TranscriptionModelV3 {
 
 		let rawResult: unknown;
 
-		if (isNova3) {
-			rawResult = await this.runNova3(audioBytes, mediaType, abortSignal);
-		} else {
-			rawResult = await this.runWhisper(audioBytes, abortSignal);
+		try {
+			if (isNova3) {
+				rawResult = await this.runNova3(audioBytes, mediaType, abortSignal);
+			} else {
+				rawResult = await this.runWhisper(audioBytes, abortSignal);
+			}
+		} catch (error) {
+			// Normalize binding failures (e.g. 3040 "out of capacity" → 429) into a
+			// retryable APICallError so the AI SDK's maxRetries can engage. The
+			// REST binary path already throws an APICallError, which passes through.
+			throw normalizeBindingError(error, {
+				model: this.modelId,
+				requestBodyValues: { mediaType },
+			});
 		}
 
 		const result = rawResult as Record<string, unknown>;

--- a/packages/workers-ai-provider/test/embeddings.test.ts
+++ b/packages/workers-ai-provider/test/embeddings.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { embed, embedMany } from "ai";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
@@ -152,5 +153,24 @@ describe("Binding - Embedding Tests", () => {
 				values: ["one", "two", "three"],
 			}),
 		).rejects.toThrow("Too many values");
+	});
+
+	it("normalizes an out-of-capacity binding error to a retryable 429 APICallError", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					throw new Error("3040: Capacity temporarily exceeded, please try again.");
+				},
+			} as any,
+		});
+
+		const err = await workersai
+			.embedding(TEST_EMBEDDING_MODEL)
+			.doEmbed({ values: ["x"] })
+			.catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
 	});
 });

--- a/packages/workers-ai-provider/test/image-generation.test.ts
+++ b/packages/workers-ai-provider/test/image-generation.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { generateImage } from "ai";
 import { describe, expect, it } from "vitest";
 import { createWorkersAI } from "../src/index";
@@ -169,5 +170,25 @@ describe("Image Generation - Binding", () => {
 				prompt: "A cat",
 			}),
 		).rejects.toThrow("Unexpected output type from image model");
+	});
+
+	it("normalizes an out-of-capacity binding error to a retryable 429 APICallError", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					throw new Error("3040: Capacity temporarily exceeded, please try again.");
+				},
+			} as any,
+		});
+
+		const err = await generateImage({
+			model: workersai.image("@cf/black-forest-labs/flux-1-schnell"),
+			prompt: "A cat",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
 	});
 });

--- a/packages/workers-ai-provider/test/reranking.test.ts
+++ b/packages/workers-ai-provider/test/reranking.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { rerank } from "ai";
 import { describe, expect, it } from "vitest";
 import { createWorkersAI } from "../src/index";
@@ -139,5 +140,27 @@ describe("Reranking - Provider", () => {
 
 		const model = workersai.reranking("@cf/baai/bge-reranker-v2-m3");
 		expect(model.modelId).toBe("@cf/baai/bge-reranker-v2-m3");
+	});
+
+	it("normalizes an out-of-capacity binding error to a retryable 429 APICallError", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					throw new Error("3040: Capacity temporarily exceeded, please try again.");
+				},
+			} as any,
+		});
+
+		const err = await workersai
+			.reranking("@cf/baai/bge-reranker-base")
+			.doRerank({
+				query: "q",
+				documents: { type: "text", values: ["a", "b"] },
+			})
+			.catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
 	});
 });

--- a/packages/workers-ai-provider/test/speech.test.ts
+++ b/packages/workers-ai-provider/test/speech.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { experimental_generateSpeech as generateSpeech } from "ai";
 import { describe, expect, it } from "vitest";
 import { createWorkersAI } from "../src/index";
@@ -149,6 +150,52 @@ describe("Speech - Binding", () => {
 				text: "Test",
 			}),
 		).rejects.toThrow(/Unexpected output type/);
+	});
+
+	it("normalizes an out-of-capacity binding error to a retryable 429 APICallError", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					throw new Error("3040: Capacity temporarily exceeded, please try again.");
+				},
+			} as any,
+		});
+
+		const err = await generateSpeech({
+			model: workersai.speech("@cf/deepgram/aura-1"),
+			text: "Test",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
+	});
+
+	it("surfaces a REST error instead of decoding the error body as audio", async () => {
+		// REST speech uses returnRawResponse, so the shim returns the raw (non-OK)
+		// Response. Without the guard, the error body would become "audio".
+		const workersai = createWorkersAI({
+			accountId: "acc",
+			apiKey: "key",
+			fetch: async () =>
+				new Response(
+					JSON.stringify({
+						errors: [{ code: 3040, message: "Capacity temporarily exceeded" }],
+					}),
+					{ status: 429, statusText: "Too Many Requests" },
+				),
+		});
+
+		const err = await generateSpeech({
+			model: workersai.speech("@cf/deepgram/aura-1"),
+			text: "Test",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
 	});
 });
 

--- a/packages/workers-ai-provider/test/text-generation.test.ts
+++ b/packages/workers-ai-provider/test/text-generation.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { generateText } from "ai";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
@@ -265,8 +266,72 @@ describe("REST API - Text Generation Tests", () => {
 			generateText({
 				model: workersai(TEST_MODEL),
 				prompt: "Hello",
+				// Disable retries so the (now retryable) error surfaces immediately.
+				maxRetries: 0,
 			}),
 		).rejects.toThrowError("Workers AI API error (500");
+	});
+
+	it("surfaces REST errors as APICallError (429 → retryable)", async () => {
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () =>
+					HttpResponse.json(
+						{ errors: [{ code: 3040, message: "Capacity temporarily exceeded" }] },
+						{ status: 429, headers: { "retry-after": "2" } },
+					),
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const err = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
+		expect((err as APICallError).responseHeaders?.["retry-after"]).toBe("2");
+	});
+
+	it("auto-retries a retryable REST error and succeeds", async () => {
+		let calls = 0;
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					calls++;
+					if (calls === 1) {
+						return HttpResponse.json(
+							{ errors: [{ code: 3040, message: "Capacity temporarily exceeded" }] },
+							{ status: 429, headers: { "retry-after": "0" } },
+						);
+					}
+					return HttpResponse.json({ result: { response: "Recovered" } });
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 2,
+		});
+
+		expect(result.text).toBe("Recovered");
+		expect(calls).toBe(2);
 	});
 });
 
@@ -931,5 +996,104 @@ describe("REST - reasoning passthrough", () => {
 
 		expect(capturedQuery).toHaveProperty("custom_flag", "yes");
 		expect(capturedQuery).not.toHaveProperty("reasoning_effort");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Binding mode — error normalization into APICallError (retryability)
+// https://developers.cloudflare.com/workers-ai/platform/errors/
+// ---------------------------------------------------------------------------
+
+describe("Binding - error normalization", () => {
+	const bindingThatThrows = (error: unknown) =>
+		createWorkersAI({
+			binding: {
+				run: async () => {
+					throw error;
+				},
+			} as any,
+		});
+
+	it("maps an out-of-capacity (3040) binding error to a retryable 429 APICallError", async () => {
+		const workersai = bindingThatThrows(
+			new Error("3040: Capacity temporarily exceeded, please try again."),
+		);
+
+		const err = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
+	});
+
+	it("maps a client error (5007) to a non-retryable 400 APICallError", async () => {
+		const workersai = bindingThatThrows(new Error("5007: No such model"));
+
+		const err = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(400);
+		expect((err as APICallError).isRetryable).toBe(false);
+	});
+
+	it("wraps an unrecognized binding error as a non-retryable APICallError", async () => {
+		const workersai = bindingThatThrows(new Error("totally unexpected"));
+
+		const err = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBeUndefined();
+		expect((err as APICallError).isRetryable).toBe(false);
+	});
+
+	it("propagates AbortError unchanged (no wrapping, no retry)", async () => {
+		const workersai = bindingThatThrows(
+			Object.assign(new Error("aborted"), { name: "AbortError" }),
+		);
+
+		const err = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 2,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(false);
+		expect((err as Error).name).toBe("AbortError");
+	});
+
+	it("auto-retries a retryable binding error and succeeds", async () => {
+		let calls = 0;
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					calls++;
+					if (calls === 1) {
+						throw new Error("3040: Capacity temporarily exceeded, please try again.");
+					}
+					return { response: "Recovered" };
+				},
+			} as any,
+		});
+
+		const result = await generateText({
+			model: workersai(TEST_MODEL),
+			prompt: "Hello",
+			maxRetries: 2,
+		});
+
+		expect(result.text).toBe("Recovered");
+		expect(calls).toBe(2);
 	});
 });

--- a/packages/workers-ai-provider/test/transcription.test.ts
+++ b/packages/workers-ai-provider/test/transcription.test.ts
@@ -1,3 +1,4 @@
+import { APICallError } from "@ai-sdk/provider";
 import { experimental_transcribe as transcribe } from "ai";
 import { describe, expect, it } from "vitest";
 import { createWorkersAI } from "../src/index";
@@ -231,5 +232,26 @@ describe("Transcription - Provider", () => {
 
 		expect(t1.modelId).toBe(t2.modelId);
 		expect(t1.provider).toBe("workersai.transcription");
+	});
+
+	it("normalizes an out-of-capacity binding error to a retryable 429 APICallError", async () => {
+		const workersai = createWorkersAI({
+			binding: {
+				run: async () => {
+					throw new Error("3040: Capacity temporarily exceeded, please try again.");
+				},
+			} as any,
+		});
+
+		const err = await transcribe({
+			model: workersai.transcription("@cf/openai/whisper"),
+			audio: new Uint8Array([0x52, 0x49, 0x46, 0x46]),
+			mediaType: "audio/wav",
+			maxRetries: 0,
+		}).catch((e) => e);
+
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect((err as APICallError).statusCode).toBe(429);
+		expect((err as APICallError).isRetryable).toBe(true);
 	});
 });

--- a/packages/workers-ai-provider/test/workersai-error.test.ts
+++ b/packages/workers-ai-provider/test/workersai-error.test.ts
@@ -1,0 +1,144 @@
+import { APICallError } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import {
+	apiCallErrorFromResponse,
+	normalizeBindingError,
+	parseWorkersAIErrorCode,
+	WORKERS_AI_ERROR_CODE_TO_STATUS,
+} from "../src/workersai-error";
+
+describe("parseWorkersAIErrorCode", () => {
+	it("reads a numeric `code` property", () => {
+		expect(parseWorkersAIErrorCode({ code: 3040 })).toBe(3040);
+		expect(parseWorkersAIErrorCode({ code: "3040" })).toBe(3040);
+	});
+
+	it("parses the `<code>: <message>` form from the message", () => {
+		expect(
+			parseWorkersAIErrorCode(
+				new Error("3040: Capacity temporarily exceeded, please try again."),
+			),
+		).toBe(3040);
+		expect(
+			parseWorkersAIErrorCode(new Error("InferenceUpstreamError: 3040: out of capacity")),
+		).toBe(3040);
+		expect(parseWorkersAIErrorCode("5007: No such model @cf/foo")).toBe(5007);
+	});
+
+	it("ignores unknown / unrecognized codes", () => {
+		expect(parseWorkersAIErrorCode(new Error("1101: Worker threw exception"))).toBeUndefined();
+		expect(parseWorkersAIErrorCode(new Error("boom"))).toBeUndefined();
+		expect(parseWorkersAIErrorCode({ code: 9999 })).toBeUndefined();
+		expect(parseWorkersAIErrorCode(undefined)).toBeUndefined();
+	});
+
+	it("skips a leading unrelated number and finds the real code", () => {
+		// A leading request id (not a known code) must not shadow the real code.
+		expect(parseWorkersAIErrorCode(new Error("12345: ctx 3040: out of capacity"))).toBe(3040);
+	});
+
+	it("reads the message from a DOMException / plain object", () => {
+		expect(parseWorkersAIErrorCode(new DOMException("3040: out of capacity", "Error"))).toBe(
+			3040,
+		);
+		expect(parseWorkersAIErrorCode({ message: "5007: no such model" })).toBe(5007);
+	});
+});
+
+describe("normalizeBindingError", () => {
+	const ctx = { model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", requestBodyValues: {} };
+
+	it("maps an out-of-capacity (3040) binding error to a retryable 429 APICallError", () => {
+		const err = normalizeBindingError(
+			new Error("3040: Capacity temporarily exceeded, please try again."),
+			ctx,
+		);
+		expect(APICallError.isInstance(err)).toBe(true);
+		const api = err as APICallError;
+		expect(api.statusCode).toBe(429);
+		expect(api.isRetryable).toBe(true);
+		expect(api.data).toEqual({ workersAIErrorCode: 3040 });
+	});
+
+	it("maps a client error (5007) to a non-retryable 400 APICallError", () => {
+		const err = normalizeBindingError(new Error("5007: No such model"), ctx) as APICallError;
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect(err.statusCode).toBe(400);
+		expect(err.isRetryable).toBe(false);
+	});
+
+	it("wraps an unrecognized error as a non-retryable APICallError (no status)", () => {
+		const err = normalizeBindingError(new Error("totally unexpected"), ctx) as APICallError;
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect(err.statusCode).toBeUndefined();
+		expect(err.isRetryable).toBe(false);
+		expect(err.message).toBe("totally unexpected");
+	});
+
+	it("passes AbortError / TimeoutError through unchanged", () => {
+		const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+		expect(normalizeBindingError(abort, ctx)).toBe(abort);
+		const timeout = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+		expect(normalizeBindingError(timeout, ctx)).toBe(timeout);
+	});
+
+	it("passes a DOMException abort through unchanged (real fetch/binding abort shape)", () => {
+		// A genuine abort is a DOMException, which is NOT `instanceof Error`.
+		const abort = new DOMException("The operation was aborted", "AbortError");
+		expect(normalizeBindingError(abort, ctx)).toBe(abort);
+		expect(APICallError.isInstance(normalizeBindingError(abort, ctx))).toBe(false);
+	});
+
+	it("wraps a non-abort DOMException with a readable message", () => {
+		const err = normalizeBindingError(
+			new DOMException("something broke", "DataError"),
+			ctx,
+		) as APICallError;
+		expect(APICallError.isInstance(err)).toBe(true);
+		expect(err.message).toBe("something broke");
+		expect(err.isRetryable).toBe(false);
+	});
+
+	it("passes an existing APICallError through unchanged", () => {
+		const original = new APICallError({
+			message: "already wrapped",
+			url: "u",
+			requestBodyValues: {},
+			statusCode: 500,
+		});
+		expect(normalizeBindingError(original, ctx)).toBe(original);
+	});
+});
+
+describe("apiCallErrorFromResponse", () => {
+	it("derives a retryable error from a 429 response and preserves headers", () => {
+		const resp = new Response("rate limited", {
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "retry-after": "3" },
+		});
+		const err = apiCallErrorFromResponse(resp, "rate limited", {
+			url: "u",
+			requestBodyValues: {},
+		});
+		expect(err.statusCode).toBe(429);
+		expect(err.isRetryable).toBe(true);
+		expect(err.responseHeaders?.["retry-after"]).toBe("3");
+		expect(err.message).toMatch(/Workers AI API error \(429/);
+	});
+
+	it("derives a non-retryable error from a 400 response", () => {
+		const resp = new Response("bad", { status: 400, statusText: "Bad Request" });
+		const err = apiCallErrorFromResponse(resp, "bad", { url: "u", requestBodyValues: {} });
+		expect(err.statusCode).toBe(400);
+		expect(err.isRetryable).toBe(false);
+	});
+});
+
+describe("WORKERS_AI_ERROR_CODE_TO_STATUS", () => {
+	it("maps the documented transient codes to retryable statuses", () => {
+		expect(WORKERS_AI_ERROR_CODE_TO_STATUS[3040]).toBe(429);
+		expect(WORKERS_AI_ERROR_CODE_TO_STATUS[3036]).toBe(429);
+		expect(WORKERS_AI_ERROR_CODE_TO_STATUS[3007]).toBe(408);
+	});
+});


### PR DESCRIPTION
## Summary

Native Workers AI failures previously threw plain `Error`s, so the AI SDK's built-in retry (`maxRetries`) never engaged. The most common pain point is the **"out of capacity"** failure (internal code `3040`, HTTP `429`) — a transient, server-side error that Cloudflare explicitly recommends retrying — but plain 5xx blips failed outright too.

This normalizes Workers AI failures into AI SDK `APICallError`s so `generateText`/`streamText` (and the other AI SDK entry points) retry transient errors automatically.

- **Binding path** (`env.AI.run`), across **all** models — chat, embedding, image, speech, transcription, reranking: errors are normalized into an `APICallError`. The Workers AI internal code is parsed (from the message or a numeric `code` property) and mapped to the [documented HTTP status](https://developers.cloudflare.com/workers-ai/platform/errors/) (e.g. `3040`/`3036` → `429`, `3007`/`3008` → `408`, `5007` → `400`). `APICallError` derives `isRetryable` from the status (408/409/429/5xx). Unrecognized errors get no status and stay non-retryable (prior behavior).
- **REST path**: non-OK responses throw an `APICallError` carrying the real `statusCode`, response headers (so `Retry-After` is honored), and body — keeping the historical `Workers AI API error (<status> <statusText>): <body>` message shape.
- **Cancellations** (`AbortError`/`TimeoutError`/`ResponseAborted`, including `DOMException` aborts) and already-wrapped `APICallError`s pass through untouched, matching the AI SDK's own `isAbortError`.
- **Speech REST path** (which uses `returnRawResponse`) now surfaces non-OK responses instead of silently decoding the error body as audio.

### Notable trade-offs

- **Behavior change** (hence `minor`): native Workers AI calls now retry transient errors by default (`maxRetries`, default 2). Set `maxRetries: 0` to opt out.
- `3036` (daily free-allocation exhausted) maps to `429` and is therefore retryable, consistent with standard 429 semantics — it burns the retry budget before failing. Happy to special-case it if reviewers prefer.
- Mid-stream drops on the native path are not retried (the AI SDK only retries the initial `doStream`; the gateway path handles resume separately).
- AI Search / AutoRAG is intentionally out of scope (different `AutoRAG` binding, different error semantics).

## Test plan

- [x] New unit tests for code→status mapping, message extraction, multi-number parsing, and `Error`/`DOMException` abort passthrough (`test/workersai-error.test.ts`).
- [x] Integration tests per model: out-of-capacity (3040 → retryable 429), client error (5007 → non-retryable 400), unknown error (non-retryable), abort passthrough, and retry-then-succeed on both binding and REST paths.
- [x] Speech REST error-surfacing test (no longer decodes error body as audio).
- [x] Full package suite green (444 tests), plus `tsc`, `oxlint`, `oxfmt`, and `build` clean.

Made with [Cursor](https://cursor.com)