### PR TITLE
feat(tanstack-ai): retry transient Workers AI failures and normalize errors

### DIFF
--- a/.changeset/tanstack-ai-retryable-errors.md
+++ b/.changeset/tanstack-ai-retryable-errors.md
@@ -1,0 +1,20 @@
+---
+"@cloudflare/tanstack-ai": minor
+---
+
+Retry transient Workers AI failures and normalize errors across every adapter.
+
+- **Chat**: the binding shim now surfaces binding failures as HTTP responses
+  (e.g. "out of capacity" `3040` → `429`, "no such model" `5007` → `400`) so the
+  OpenAI SDK's status-based retry engages and honors `Retry-After`. Aborts and
+  unrecognized errors propagate untouched. Non-OK gateway run-path responses are
+  returned verbatim instead of being swallowed into an empty completion.
+- **Non-chat** adapters (embedding, image, TTS, transcription, summarize) gain a
+  bounded exponential-backoff retry (the OpenAI SDK isn't in play for these) and
+  normalize binding / REST / gateway failures into a single `WorkersAiRequestError`
+  carrying the HTTP `status` (and the raw Workers AI `code` when recognized). The
+  retry loop honors a server `Retry-After` header. Non-OK gateway responses are no
+  longer swallowed.
+- Add a `maxRetries` option to the adapter config: forwarded to the OpenAI SDK on
+  the chat path, and used by the non-chat retry loop. Defaults to `2`; set to `0`
+  to disable.

--- a/packages/gateway-core/src/index.ts
+++ b/packages/gateway-core/src/index.ts
@@ -48,3 +48,11 @@ export {
 	processText,
 	SSEDecoder,
 } from "./workers-ai";
+export {
+	isAbortError,
+	isRetryableStatus,
+	messageOf,
+	parseWorkersAIErrorCode,
+	WORKERS_AI_ERROR_CODE_TO_STATUS,
+	workersAIStatusFromError,
+} from "./workers-ai-errors";

--- a/packages/gateway-core/src/workers-ai-errors.ts
+++ b/packages/gateway-core/src/workers-ai-errors.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared, dependency-free Workers AI error classification used by every
+ * consumer of `@cloudflare/gateway-core` (`workers-ai-provider` and
+ * `@cloudflare/tanstack-ai`).
+ *
+ * The Workers AI **binding** (`env.AI.run`) throws plain `Error`s whose message
+ * carries an internal code (e.g. `"3040: Capacity temporarily exceeded"`) but
+ * no HTTP status. Retry machinery (the AI SDK's `APICallError` retry, the OpenAI
+ * SDK's status-based retry, and our own non-chat retry loop) all key off an HTTP
+ * status, so we translate the internal code into the documented status and let
+ * each layer derive retryability from it — this is what makes transient failures
+ * like "out of capacity" (3040 → 429) automatically retried.
+ *
+ * This module is intentionally free of any provider-SDK types so it can be
+ * inlined into each consumer's bundle.
+ */
+
+/**
+ * Workers AI internal error code → HTTP status code.
+ *
+ * Source: https://developers.cloudflare.com/workers-ai/platform/errors/
+ */
+export const WORKERS_AI_ERROR_CODE_TO_STATUS: Record<number, number> = {
+	5007: 400, // No such model
+	5004: 400, // Invalid data
+	3039: 400, // Finetune missing required files
+	3003: 400, // Incomplete request
+	5018: 403, // Account not allowed for private model
+	5016: 403, // Model agreement not accepted
+	3023: 403, // Account blocked
+	3041: 403, // Account not allowed for private model
+	5019: 405, // Deprecated SDK version
+	5005: 405, // LoRa unsupported
+	3042: 404, // Invalid model ID
+	3006: 413, // Request too large
+	3007: 408, // Timeout
+	3008: 408, // Aborted
+	3036: 429, // Account limited (daily free allocation used up)
+	3040: 429, // Out of capacity (no data center to forward to)
+};
+
+/** Read a human-readable message from any thrown value (Error, DOMException, plain object, string). */
+export function messageOf(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	if (error && typeof error === "object") {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+	return String(error);
+}
+
+/**
+ * Best-effort extraction of a Workers AI internal error code from a thrown
+ * binding error. Prefers a numeric `code` property when present, otherwise
+ * parses the `"<code>: <message>"` form the binding uses (optionally prefixed,
+ * e.g. `"InferenceUpstreamError: 3040: ..."`). Only recognized codes are
+ * returned, and when several `"<number>:"` groups appear (e.g. a leading
+ * request id) the first that maps to a known code wins, so unrelated numbers
+ * can't be misread as a code.
+ */
+export function parseWorkersAIErrorCode(error: unknown): number | undefined {
+	if (error && typeof error === "object") {
+		const code = (error as { code?: unknown }).code;
+		if (typeof code === "number" && code in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+			return code;
+		}
+		if (typeof code === "string") {
+			const parsed = Number.parseInt(code, 10);
+			if (Number.isFinite(parsed) && parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+				return parsed;
+			}
+		}
+	}
+
+	const message = messageOf(error);
+	for (const match of message.matchAll(/\b(\d{3,5})\s*:/g)) {
+		const parsed = Number.parseInt(match[1]!, 10);
+		if (parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
+			return parsed;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Map a thrown Workers AI binding error to its documented HTTP status, or
+ * `undefined` when the error isn't a recognized Workers AI code (so callers can
+ * decide how to treat unknown failures rather than fabricating a status).
+ */
+export function workersAIStatusFromError(error: unknown): number | undefined {
+	const code = parseWorkersAIErrorCode(error);
+	return code != null ? WORKERS_AI_ERROR_CODE_TO_STATUS[code] : undefined;
+}
+
+/**
+ * True for cancellation errors that must propagate untouched (never wrapped or
+ * retried, so each layer's own abort detection still fires). Mirrors the AI
+ * SDK's `isAbortError`: a real abort from `fetch`/the binding is a
+ * `DOMException`, which is NOT `instanceof Error`, so both must be checked.
+ */
+export function isAbortError(error: unknown): boolean {
+	return (
+		(error instanceof Error || error instanceof DOMException) &&
+		(error.name === "AbortError" ||
+			error.name === "ResponseAborted" ||
+			error.name === "TimeoutError")
+	);
+}
+
+/**
+ * Whether an HTTP status should be retried. Matches the set used by the AI SDK
+ * and the OpenAI SDK: request timeout (408), conflict (409), rate limit (429),
+ * and any server error (>= 500).
+ */
+export function isRetryableStatus(status: number): boolean {
+	return status === 408 || status === 409 || status === 429 || status >= 500;
+}

--- a/packages/tanstack-ai/src/adapters/workers-ai-embedding.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-embedding.ts
@@ -14,6 +14,7 @@ import {
 	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
+import { errorFromResponse, normalizeBindingError, withWorkersAiRetry } from "../utils/errors";
 
 // ---------------------------------------------------------------------------
 // Model type derived from @cloudflare/workers-types
@@ -45,24 +46,34 @@ export class WorkersAiEmbeddingAdapter {
 	}
 
 	async embed(texts: string[]): Promise<WorkersAiEmbeddingResult> {
-		if (isDirectBindingConfig(this.config)) {
-			return this.embedViaBinding(texts);
-		}
+		return withWorkersAiRetry(
+			() => {
+				if (isDirectBindingConfig(this.config)) {
+					return this.embedViaBinding(texts);
+				}
 
-		if (isDirectCredentialsConfig(this.config)) {
-			return this.embedViaRest(texts);
-		}
+				if (isDirectCredentialsConfig(this.config)) {
+					return this.embedViaRest(texts);
+				}
 
-		// Gateway mode
-		return this.embedViaGateway(texts);
+				// Gateway mode
+				return this.embedViaGateway(texts);
+			},
+			{ maxRetries: this.config.maxRetries },
+		);
 	}
 
 	private async embedViaBinding(texts: string[]): Promise<WorkersAiEmbeddingResult> {
 		const ai = (this.config as WorkersAiDirectBindingConfig).binding;
-		const result = (await ai.run(this.model, { text: texts })) as {
-			shape: number[];
-			data: number[][];
-		};
+		let result: { shape: number[]; data: number[][] };
+		try {
+			result = (await ai.run(this.model, { text: texts })) as {
+				shape: number[];
+				data: number[][];
+			};
+		} catch (error) {
+			throw normalizeBindingError(error, "Workers AI embedding");
+		}
 		return { embeddings: result.data };
 	}
 
@@ -97,6 +108,11 @@ export class WorkersAiEmbeddingAdapter {
 				text: texts,
 			}),
 		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw errorFromResponse(response, errorText, "Workers AI embedding gateway");
+		}
 
 		// Gateway returns Workers AI native format for embeddings
 		const json = (await response.json()) as {

--- a/packages/tanstack-ai/src/adapters/workers-ai-image.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-image.ts
@@ -13,6 +13,7 @@ import {
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 import { binaryToBase64, uint8ArrayToBase64 } from "../utils/binary";
+import { errorFromResponse, normalizeBindingError, withWorkersAiRetry } from "../utils/errors";
 import type { WorkersAiDirectCredentialsConfig } from "../utils/create-fetcher";
 
 // ---------------------------------------------------------------------------
@@ -61,16 +62,21 @@ export class WorkersAiImageAdapter extends BaseImageAdapter<WorkersAiImageModel>
 		// it down to its verbatim text (media parts are dropped).
 		const promptText = resolveMediaPrompt(prompt).text;
 
-		if (isDirectBindingConfig(this.adapterConfig)) {
-			return this.generateViaBinding(promptText, extra);
-		}
+		return withWorkersAiRetry(
+			() => {
+				if (isDirectBindingConfig(this.adapterConfig)) {
+					return this.generateViaBinding(promptText, extra);
+				}
 
-		if (isDirectCredentialsConfig(this.adapterConfig)) {
-			return this.generateViaRest(promptText, extra);
-		}
+				if (isDirectCredentialsConfig(this.adapterConfig)) {
+					return this.generateViaRest(promptText, extra);
+				}
 
-		// Gateway mode
-		return this.generateViaGateway(promptText, extra);
+				// Gateway mode
+				return this.generateViaGateway(promptText, extra);
+			},
+			{ maxRetries: this.adapterConfig.maxRetries },
+		);
 	}
 
 	private async generateViaBinding(
@@ -78,7 +84,12 @@ export class WorkersAiImageAdapter extends BaseImageAdapter<WorkersAiImageModel>
 		options: Record<string, unknown>,
 	): Promise<ImageGenerationResult> {
 		const ai = (this.adapterConfig as WorkersAiDirectBindingConfig).binding;
-		const result = await ai.run(this.model, { prompt, ...options });
+		let result: unknown;
+		try {
+			result = await ai.run(this.model, { prompt, ...options });
+		} catch (error) {
+			throw normalizeBindingError(error, "Workers AI image");
+		}
 
 		const b64 = await binaryToBase64(result, "image");
 		return this.wrapResult(b64);
@@ -124,9 +135,7 @@ export class WorkersAiImageAdapter extends BaseImageAdapter<WorkersAiImageModel>
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`Workers AI image gateway request failed (${response.status}): ${errorText}`,
-			);
+			throw errorFromResponse(response, errorText, "Workers AI image gateway");
 		}
 
 		const buffer = await response.arrayBuffer();

--- a/packages/tanstack-ai/src/adapters/workers-ai-summarize.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-summarize.ts
@@ -11,6 +11,7 @@ import {
 	validateWorkersAiConfig,
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
+import { errorFromResponse, normalizeBindingError, withWorkersAiRetry } from "../utils/errors";
 
 // ---------------------------------------------------------------------------
 // Model types
@@ -41,22 +42,32 @@ export class WorkersAiSummarizeAdapter extends BaseSummarizeAdapter<WorkersAiSum
 		const payload: Record<string, unknown> = { input_text: text };
 		if (maxLength != null) payload.max_length = maxLength;
 
-		if (isDirectBindingConfig(this.adapterConfig)) {
-			return this.summarizeViaBinding(payload);
-		}
+		return withWorkersAiRetry(
+			() => {
+				if (isDirectBindingConfig(this.adapterConfig)) {
+					return this.summarizeViaBinding(payload);
+				}
 
-		if (isDirectCredentialsConfig(this.adapterConfig)) {
-			return this.summarizeViaRest(payload);
-		}
+				if (isDirectCredentialsConfig(this.adapterConfig)) {
+					return this.summarizeViaRest(payload);
+				}
 
-		return this.summarizeViaGateway(payload);
+				return this.summarizeViaGateway(payload);
+			},
+			{ maxRetries: this.adapterConfig.maxRetries },
+		);
 	}
 
 	private async summarizeViaBinding(
 		payload: Record<string, unknown>,
 	): Promise<SummarizationResult> {
 		const ai = (this.adapterConfig as WorkersAiDirectBindingConfig).binding;
-		const result = (await ai.run(this.model, payload)) as Record<string, unknown>;
+		let result: Record<string, unknown>;
+		try {
+			result = (await ai.run(this.model, payload)) as Record<string, unknown>;
+		} catch (error) {
+			throw normalizeBindingError(error, "Workers AI summarize");
+		}
 		return this.wrapResult((result.summary as string) ?? "");
 	}
 
@@ -89,9 +100,7 @@ export class WorkersAiSummarizeAdapter extends BaseSummarizeAdapter<WorkersAiSum
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`Workers AI summarize gateway request failed (${response.status}): ${errorText}`,
-			);
+			throw errorFromResponse(response, errorText, "Workers AI summarize gateway");
 		}
 
 		const data = (await response.json()) as {

--- a/packages/tanstack-ai/src/adapters/workers-ai-transcription.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-transcription.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/create-fetcher";
 import { workersAiRestFetch, workersAiRestFetchBinary } from "../utils/workers-ai-rest";
 import { uint8ArrayToBase64 } from "../utils/binary";
+import { errorFromResponse, normalizeBindingError, withWorkersAiRetry } from "../utils/errors";
 
 // ---------------------------------------------------------------------------
 // Model types
@@ -66,19 +67,24 @@ export class WorkersAiTranscriptionAdapter extends BaseTranscriptionAdapter<Work
 		// - Other Whisper models (binding): { audio: number[] }
 		const audioPayload = this.buildAudioPayload(audioBytes, audio);
 
-		if (isDirectBindingConfig(this.adapterConfig)) {
-			return this.transcribeViaBinding(audioPayload, extra);
-		}
+		return withWorkersAiRetry(
+			() => {
+				if (isDirectBindingConfig(this.adapterConfig)) {
+					return this.transcribeViaBinding(audioPayload, extra);
+				}
 
-		if (isDirectCredentialsConfig(this.adapterConfig)) {
-			// Nova-3 REST requires raw binary audio, not JSON
-			if (this.model === "@cf/deepgram/nova-3") {
-				return this.transcribeViaRestBinary(audioBytes, audio, extra);
-			}
-			return this.transcribeViaRest(audioPayload, extra);
-		}
+				if (isDirectCredentialsConfig(this.adapterConfig)) {
+					// Nova-3 REST requires raw binary audio, not JSON
+					if (this.model === "@cf/deepgram/nova-3") {
+						return this.transcribeViaRestBinary(audioBytes, audio, extra);
+					}
+					return this.transcribeViaRest(audioPayload, extra);
+				}
 
-		return this.transcribeViaGateway(audioPayload, extra);
+				return this.transcribeViaGateway(audioPayload, extra);
+			},
+			{ maxRetries: this.adapterConfig.maxRetries },
+		);
 	}
 
 	/**
@@ -110,10 +116,15 @@ export class WorkersAiTranscriptionAdapter extends BaseTranscriptionAdapter<Work
 		options: Record<string, unknown>,
 	): Promise<TranscriptionResult> {
 		const ai = (this.adapterConfig as WorkersAiDirectBindingConfig).binding;
-		const result = (await ai.run(this.model, {
-			...audioPayload,
-			...options,
-		})) as Record<string, unknown>;
+		let result: Record<string, unknown>;
+		try {
+			result = (await ai.run(this.model, {
+				...audioPayload,
+				...options,
+			})) as Record<string, unknown>;
+		} catch (error) {
+			throw normalizeBindingError(error, "Workers AI transcription");
+		}
 		return this.normalizeResult(result);
 	}
 
@@ -194,9 +205,7 @@ export class WorkersAiTranscriptionAdapter extends BaseTranscriptionAdapter<Work
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`Workers AI transcription gateway request failed (${response.status}): ${errorText}`,
-			);
+			throw errorFromResponse(response, errorText, "Workers AI transcription gateway");
 		}
 
 		const data = (await response.json()) as Record<string, unknown>;

--- a/packages/tanstack-ai/src/adapters/workers-ai-tts.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai-tts.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/create-fetcher";
 import { workersAiRestFetch } from "../utils/workers-ai-rest";
 import { binaryToBase64, uint8ArrayToBase64 } from "../utils/binary";
+import { errorFromResponse, normalizeBindingError, withWorkersAiRetry } from "../utils/errors";
 
 // ---------------------------------------------------------------------------
 // Model types
@@ -52,15 +53,20 @@ export class WorkersAiTTSAdapter extends BaseTTSAdapter<WorkersAiTTSModel> {
 		if (voice) extra.voice = voice;
 		if (speed != null) extra.speed = speed;
 
-		if (isDirectBindingConfig(this.adapterConfig)) {
-			return this.generateViaBinding(text, format, extra);
-		}
+		return withWorkersAiRetry(
+			() => {
+				if (isDirectBindingConfig(this.adapterConfig)) {
+					return this.generateViaBinding(text, format, extra);
+				}
 
-		if (isDirectCredentialsConfig(this.adapterConfig)) {
-			return this.generateViaRest(text, format, extra);
-		}
+				if (isDirectCredentialsConfig(this.adapterConfig)) {
+					return this.generateViaRest(text, format, extra);
+				}
 
-		return this.generateViaGateway(text, format, extra);
+				return this.generateViaGateway(text, format, extra);
+			},
+			{ maxRetries: this.adapterConfig.maxRetries },
+		);
 	}
 
 	private async generateViaBinding(
@@ -69,7 +75,12 @@ export class WorkersAiTTSAdapter extends BaseTTSAdapter<WorkersAiTTSModel> {
 		options: Record<string, unknown>,
 	): Promise<TTSResult> {
 		const ai = (this.adapterConfig as WorkersAiDirectBindingConfig).binding;
-		const result = await ai.run(this.model, { text, ...options });
+		let result: unknown;
+		try {
+			result = await ai.run(this.model, { text, ...options });
+		} catch (error) {
+			throw normalizeBindingError(error, "Workers AI TTS");
+		}
 
 		return this.normalizeResult(result, format);
 	}
@@ -117,9 +128,7 @@ export class WorkersAiTTSAdapter extends BaseTTSAdapter<WorkersAiTTSModel> {
 
 		if (!response.ok) {
 			const errorText = await response.text();
-			throw new Error(
-				`Workers AI TTS gateway request failed (${response.status}): ${errorText}`,
-			);
+			throw errorFromResponse(response, errorText, "Workers AI TTS gateway");
 		}
 
 		const buffer = await response.arrayBuffer();

--- a/packages/tanstack-ai/src/adapters/workers-ai.ts
+++ b/packages/tanstack-ai/src/adapters/workers-ai.ts
@@ -93,6 +93,12 @@ function buildWorkersAiClient(config: WorkersAiAdapterConfig): OpenAI {
 		? { "x-session-affinity": config.sessionAffinity }
 		: undefined;
 
+	// Forward the retry budget to the OpenAI SDK, which performs the actual
+	// retrying on the chat path (status-based: 408 / 409 / 429 / >= 500, honoring
+	// Retry-After). When unset, the SDK's own default (2) applies.
+	const retryOptions: { maxRetries?: number } =
+		config.maxRetries !== undefined ? { maxRetries: config.maxRetries } : {};
+
 	if (isDirectBindingConfig(config)) {
 		if (config.resume && !config.gateway) {
 			console.warn(
@@ -103,6 +109,7 @@ function buildWorkersAiClient(config: WorkersAiAdapterConfig): OpenAI {
 		// Plain binding mode: shim translates OpenAI fetch calls to env.AI.run().
 		// When `gateway` is set, the shim uses the resumable run path instead.
 		return new OpenAI({
+			...retryOptions,
 			apiKey: "unused",
 			fetch: createWorkersAiBindingFetch(config.binding, {
 				...(sessionHeaders ? { extraHeaders: sessionHeaders } : {}),
@@ -118,6 +125,7 @@ function buildWorkersAiClient(config: WorkersAiAdapterConfig): OpenAI {
 	if (isDirectCredentialsConfig(config)) {
 		// Plain REST mode: point OpenAI SDK at Workers AI's OpenAI-compatible endpoint
 		return new OpenAI({
+			...retryOptions,
 			baseURL: `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/ai/v1`,
 			apiKey: config.apiKey,
 			defaultHeaders: sessionHeaders,
@@ -127,6 +135,7 @@ function buildWorkersAiClient(config: WorkersAiAdapterConfig): OpenAI {
 	// Gateway mode (existing): use createGatewayFetch
 	const gatewayConfig = config as AiGatewayAdapterConfig;
 	return new OpenAI({
+		...retryOptions,
 		fetch: createGatewayFetch("workers-ai", gatewayConfig, sessionHeaders),
 		apiKey: gatewayConfig.apiKey ?? "unused",
 	});

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -10,6 +10,7 @@ import {
 	type ResumeExpiredPolicy,
 	SSEDecoder,
 } from "@cloudflare/gateway-core";
+import { bindingErrorToResponse } from "./errors";
 
 // ---------------------------------------------------------------------------
 // AI Gateway types (for third-party providers + Workers AI through gateway)
@@ -152,6 +153,17 @@ export type WorkersAiAdapterConfig = (
 	 * Routes requests with the same key to the same backend replica.
 	 */
 	sessionAffinity?: string;
+	/**
+	 * Maximum number of automatic retries for transient failures (HTTP 408 /
+	 * 409 / 429 / >= 500, including the Workers AI "out of capacity" 3040 code).
+	 *
+	 * - **Chat** (`createWorkersAi`): forwarded to the OpenAI SDK client, which
+	 *   does the retrying. Defaults to the OpenAI SDK default (2).
+	 * - **Non-chat** adapters (embedding, image, TTS, transcription, summarize):
+	 *   used by this package's own bounded exponential-backoff retry. Defaults
+	 *   to 2. Set to `0` to disable retries.
+	 */
+	maxRetries?: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -519,7 +531,19 @@ export function createWorkersAiBindingFetch(
 			if (options.extraHeaders) runOptions.extraHeaders = options.extraHeaders;
 			if (signal) runOptions.signal = signal;
 
-			const raw = (await binding.run(model, inputs, runOptions)) as Response;
+			let raw: Response;
+			try {
+				raw = (await binding.run(model, inputs, runOptions)) as Response;
+			} catch (error) {
+				return bindingErrorToResponse(error);
+			}
+
+			// A non-OK response is an error, never a valid stream. Return it as-is so
+			// the OpenAI SDK sees the status (and any `Retry-After`) and retries
+			// 4xx/5xx appropriately, instead of us swallowing it via `raw.json()`
+			// into an empty "successful" completion.
+			if (!raw.ok) return raw;
+
 			const runId = raw.headers?.get?.("cf-aig-run-id") ?? null;
 			const contentType = raw.headers?.get?.("content-type") ?? "";
 			const isStreamResponse =
@@ -563,11 +587,18 @@ export function createWorkersAiBindingFetch(
 		if (options?.extraHeaders) runOptions.extraHeaders = options.extraHeaders;
 		if (signal) runOptions.signal = signal;
 
-		const result = await binding.run(
-			model,
-			inputs,
-			Object.keys(runOptions).length > 0 ? runOptions : undefined,
-		);
+		let result: unknown;
+		try {
+			result = await binding.run(
+				model,
+				inputs,
+				Object.keys(runOptions).length > 0 ? runOptions : undefined,
+			);
+		} catch (error) {
+			// Surface binding failures as HTTP responses so the OpenAI SDK's
+			// status-based retry engages (e.g. 3040 "out of capacity" → 429).
+			return bindingErrorToResponse(error);
+		}
 
 		if (stream && result instanceof ReadableStream) {
 			// Workers AI returns an SSE stream with `data: {"response":"chunk"}` format.

--- a/packages/tanstack-ai/src/utils/errors.ts
+++ b/packages/tanstack-ai/src/utils/errors.ts
@@ -1,0 +1,211 @@
+import {
+	isAbortError,
+	isRetryableStatus,
+	messageOf,
+	parseWorkersAIErrorCode,
+	workersAIStatusFromError,
+} from "@cloudflare/gateway-core";
+
+/**
+ * Default number of automatic retries for the non-chat adapters' bounded retry
+ * loop. Matches the OpenAI SDK default used on the chat path so behavior is
+ * consistent across activities.
+ */
+export const DEFAULT_MAX_RETRIES = 2;
+
+/** Hard cap on a server-provided `Retry-After` so a hostile/huge value can't hang a request. */
+const MAX_RETRY_AFTER_MS = 60_000;
+
+/**
+ * Error thrown by the non-chat Workers AI adapters (embedding, image, TTS,
+ * transcription, summarize) when a request fails.
+ *
+ * Unlike the chat path — which runs through the OpenAI SDK and surfaces
+ * `OpenAI.APIError` — these adapters talk to the binding / REST / gateway
+ * directly, so we normalize failures into this single shape. The `status`
+ * (when known) drives {@link withWorkersAiRetry}; `code` carries the raw
+ * Workers AI internal error code when one was recognized; `retryAfterMs` carries
+ * a parsed `Retry-After` so the retry loop can honor the server's hint.
+ */
+export class WorkersAiRequestError extends Error {
+	override readonly name = "WorkersAiRequestError";
+	readonly status?: number;
+	readonly code?: number;
+	readonly responseBody?: string;
+	readonly retryAfterMs?: number;
+	override readonly cause?: unknown;
+
+	constructor(
+		message: string,
+		options?: {
+			status?: number;
+			code?: number;
+			responseBody?: string;
+			retryAfterMs?: number;
+			cause?: unknown;
+		},
+	) {
+		super(message);
+		this.status = options?.status;
+		this.code = options?.code;
+		this.responseBody = options?.responseBody;
+		this.retryAfterMs = options?.retryAfterMs;
+		this.cause = options?.cause;
+	}
+}
+
+/**
+ * Parse an HTTP `Retry-After` header value into milliseconds. Supports both
+ * forms from RFC 7231: delta-seconds (e.g. `"3"`) and an HTTP-date. Returns
+ * `undefined` when absent or unparseable.
+ */
+export function parseRetryAfterMs(
+	value: string | null,
+	now: number = Date.now(),
+): number | undefined {
+	if (value == null) return undefined;
+	const trimmed = value.trim();
+	if (trimmed === "") return undefined;
+	// delta-seconds
+	if (/^\d+$/.test(trimmed)) {
+		return Number(trimmed) * 1000;
+	}
+	// HTTP-date
+	const date = Date.parse(trimmed);
+	if (Number.isFinite(date)) {
+		return Math.max(0, date - now);
+	}
+	return undefined;
+}
+
+/**
+ * Best-effort HTTP status for any thrown value: prefers an explicit `status`
+ * (our own {@link WorkersAiRequestError} or an HTTP-shaped error), otherwise
+ * derives one from a recognized Workers AI binding error code.
+ */
+function statusOf(error: unknown): number | undefined {
+	if (error && typeof error === "object") {
+		const status = (error as { status?: unknown }).status;
+		if (typeof status === "number") return status;
+	}
+	return workersAIStatusFromError(error);
+}
+
+/**
+ * Normalize an error thrown by a Workers AI **binding** call into a
+ * {@link WorkersAiRequestError}. Cancellations (`AbortError` / `TimeoutError` /
+ * `ResponseAborted`, including `DOMException` aborts) and errors that are
+ * already a `WorkersAiRequestError` propagate untouched. Recognized internal
+ * codes get the documented HTTP `status` (so the retry loop can classify them);
+ * unrecognized failures get no status and are therefore not retried.
+ */
+export function normalizeBindingError(error: unknown, label: string): unknown {
+	if (isAbortError(error) || error instanceof WorkersAiRequestError) {
+		return error;
+	}
+	const code = parseWorkersAIErrorCode(error);
+	const status = workersAIStatusFromError(error);
+	const message = messageOf(error);
+	return new WorkersAiRequestError(`${label} request failed: ${message}`, {
+		status,
+		...(code != null ? { code } : {}),
+		cause: error,
+	});
+}
+
+/**
+ * Build a {@link WorkersAiRequestError} from a non-OK Workers AI **REST** /
+ * **gateway** `Response`. The HTTP status is authoritative, so it drives
+ * retryability directly, and `Retry-After` is preserved so the retry loop can
+ * honor it. The message keeps the historical
+ * `"<label> request failed (<status>): <body>"` shape that callers (and tests)
+ * already rely on.
+ */
+export function errorFromResponse(
+	response: Response,
+	body: string,
+	label: string,
+): WorkersAiRequestError {
+	const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+	return new WorkersAiRequestError(`${label} request failed (${response.status}): ${body}`, {
+		status: response.status,
+		responseBody: body,
+		...(retryAfterMs != null ? { retryAfterMs } : {}),
+	});
+}
+
+/**
+ * Convert an error thrown by the Workers AI **binding** inside the OpenAI chat
+ * shim into an HTTP `Response`, so the OpenAI SDK's status-based retry/error
+ * handling engages (it retries 408 / 409 / 429 / >= 500, honoring `Retry-After`).
+ *
+ * Aborts are re-thrown so the SDK's cancellation handling fires. Errors with no
+ * recognized Workers AI code are also re-thrown: the SDK wraps them as a
+ * retryable `APIConnectionError`, preserving the original error/stack rather
+ * than fabricating a misleading HTTP status.
+ */
+export function bindingErrorToResponse(error: unknown): Response {
+	if (isAbortError(error)) throw error;
+	const status = workersAIStatusFromError(error);
+	if (status == null) throw error;
+	const message = messageOf(error);
+	const code = parseWorkersAIErrorCode(error);
+	// OpenAI-shaped error body so the SDK surfaces `error.message` cleanly.
+	const body = JSON.stringify({
+		error: {
+			message,
+			type: "workers_ai_error",
+			...(code != null ? { code } : {}),
+		},
+	});
+	return new Response(body, {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/** Sleep helper that resolves after `ms` milliseconds (overridable in tests). */
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn`, retrying on transient failures with exponential backoff + full
+ * jitter. A failure is retryable when its (explicit or derived) HTTP status is
+ * in the retryable set (408 / 409 / 429 / >= 500). Aborts are never retried.
+ *
+ * This is the non-chat counterpart to the OpenAI SDK's built-in retry: the chat
+ * adapter gets retries for free from the SDK, while embedding / image / TTS /
+ * transcription / summarize call the binding, REST, or gateway directly and
+ * have no such layer.
+ */
+export async function withWorkersAiRetry<T>(
+	fn: () => Promise<T>,
+	options?: { maxRetries?: number; baseDelayMs?: number },
+): Promise<T> {
+	const maxRetries = Math.max(0, options?.maxRetries ?? DEFAULT_MAX_RETRIES);
+	const baseDelayMs = options?.baseDelayMs ?? 250;
+
+	let attempt = 0;
+	for (;;) {
+		try {
+			return await fn();
+		} catch (error) {
+			if (isAbortError(error)) throw error;
+			const status = statusOf(error);
+			const retryable = status != null && isRetryableStatus(status);
+			if (!retryable || attempt >= maxRetries) throw error;
+
+			// Prefer a server-provided Retry-After (capped); otherwise exponential
+			// backoff with full jitter, capped at 2s.
+			const retryAfterMs =
+				error instanceof WorkersAiRequestError ? error.retryAfterMs : undefined;
+			const wait =
+				retryAfterMs != null
+					? Math.min(retryAfterMs, MAX_RETRY_AFTER_MS)
+					: Math.random() * Math.min(baseDelayMs * 2 ** attempt, 2000);
+			await delay(wait);
+			attempt++;
+		}
+	}
+}

--- a/packages/tanstack-ai/src/utils/workers-ai-rest.ts
+++ b/packages/tanstack-ai/src/utils/workers-ai-rest.ts
@@ -1,4 +1,5 @@
 import type { WorkersAiDirectCredentialsConfig } from "./create-fetcher";
+import { errorFromResponse } from "./errors";
 
 /**
  * Workers AI REST API base URL.
@@ -41,7 +42,7 @@ export async function workersAiRestFetch(
 	if (!response.ok) {
 		const errorText = await response.text();
 		const label = options?.label ?? "Workers AI";
-		throw new Error(`${label} request failed (${response.status}): ${errorText}`);
+		throw errorFromResponse(response, errorText, label);
 	}
 
 	return response;
@@ -81,7 +82,7 @@ export async function workersAiRestFetchBinary(
 	if (!response.ok) {
 		const errorText = await response.text();
 		const label = options?.label ?? "Workers AI";
-		throw new Error(`${label} request failed (${response.status}): ${errorText}`);
+		throw errorFromResponse(response, errorText, label);
 	}
 
 	return response;

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -579,6 +579,118 @@ describe("createWorkersAiBindingFetch", () => {
 		expect(doneCount).toBe(1);
 	});
 
+	// -------------------------------------------------------------------------
+	// Error handling — binding throws should surface as HTTP responses so the
+	// OpenAI SDK's status-based retry/error handling engages.
+	// -------------------------------------------------------------------------
+
+	it("should surface a 3040 (out of capacity) binding error as a 429 response", async () => {
+		const binding = mockBinding(
+			vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+		);
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		const response = await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [{ role: "user", content: "Hi" }],
+			}),
+		});
+
+		expect(response.status).toBe(429);
+		expect(await response.text()).toContain("3040");
+	});
+
+	it("should surface a 5007 (no such model) binding error as a 400 response", async () => {
+		const binding = mockBinding(vi.fn().mockRejectedValue(new Error("5007: No such model")));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		const response = await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [{ role: "user", content: "Hi" }],
+			}),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("should re-throw an abort (DOMException) instead of returning a response", async () => {
+		const abort = new DOMException("The operation was aborted", "AbortError");
+		const binding = mockBinding(vi.fn().mockRejectedValue(abort));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await expect(
+			fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [{ role: "user", content: "Hi" }],
+				}),
+			}),
+		).rejects.toBe(abort);
+	});
+
+	it("should re-throw an unrecognized binding error (no fabricated status)", async () => {
+		const boom = new Error("unexpected kaboom");
+		const binding = mockBinding(vi.fn().mockRejectedValue(boom));
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await expect(
+			fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [{ role: "user", content: "Hi" }],
+				}),
+			}),
+		).rejects.toBe(boom);
+	});
+
+	it("should return a non-OK gateway run-path response as-is (not swallow it)", async () => {
+		// Run path (gateway set) uses returnRawResponse. A non-OK response must be
+		// returned verbatim so the OpenAI SDK sees the status + Retry-After and
+		// retries, instead of being parsed into an empty "successful" completion.
+		const binding = mockBinding(
+			vi.fn().mockResolvedValue(
+				new Response("rate limited", {
+					status: 429,
+					headers: { "retry-after": "2" },
+				}),
+			),
+		);
+		const fetcher = createWorkersAiBindingFetch(binding, { gateway: "my-gateway" });
+
+		const response = await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [{ role: "user", content: "Hi" }],
+			}),
+		});
+
+		expect(response.status).toBe(429);
+		expect(response.headers.get("retry-after")).toBe("2");
+		expect(await response.text()).toBe("rate limited");
+	});
+
+	it("should surface a thrown gateway run-path binding error as a mapped response", async () => {
+		const binding = mockBinding(vi.fn().mockRejectedValue(new Error("3040: out of capacity")));
+		const fetcher = createWorkersAiBindingFetch(binding, { gateway: "my-gateway" });
+
+		const response = await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [{ role: "user", content: "Hi" }],
+			}),
+		});
+
+		expect(response.status).toBe(429);
+	});
+
 	it("should return 400 when no body is provided", async () => {
 		const binding = mockBinding(vi.fn());
 		const fetcher = createWorkersAiBindingFetch(binding);

--- a/packages/tanstack-ai/test/embedding-adapter.test.ts
+++ b/packages/tanstack-ai/test/embedding-adapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { WorkersAiRequestError } from "../src/utils/errors";
 
 // ---------------------------------------------------------------------------
 // WorkersAiEmbeddingAdapter
@@ -50,6 +51,80 @@ describe("WorkersAiEmbeddingAdapter", () => {
 		expect(request.query.text).toEqual(["hello", "world"]);
 		expect(request.query.input).toBeUndefined();
 		expect(result.embeddings).toEqual([[0.1], [0.2]]);
+	});
+
+	// -----------------------------------------------------------------------
+	// Error normalization + retry
+	// -----------------------------------------------------------------------
+
+	it("normalizes an out-of-capacity (3040) binding error to a 429 WorkersAiRequestError", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		const mockBinding = {
+			run: vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiEmbeddingAdapter(
+			// maxRetries: 0 keeps the test instant — we only assert normalization here.
+			{ binding: mockBinding, maxRetries: 0 } as any,
+			"@cf/baai/bge-base-en-v1.5" as any,
+		);
+
+		await expect(adapter.embed(["hi"])).rejects.toMatchObject({
+			name: "WorkersAiRequestError",
+			status: 429,
+		});
+	});
+
+	it("retries a transient (3040) binding failure and then succeeds", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		const run = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("3040: out of capacity"))
+			.mockResolvedValue({ shape: [1, 1], data: [[0.5]] });
+		const mockBinding = {
+			run,
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiEmbeddingAdapter(
+			{ binding: mockBinding } as any,
+			"@cf/baai/bge-base-en-v1.5" as any,
+		);
+
+		const result = await adapter.embed(["hi"]);
+		expect(run).toHaveBeenCalledTimes(2);
+		expect(result.embeddings).toEqual([[0.5]]);
+	});
+
+	it("does not retry a non-retryable (5007) binding error", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		const run = vi.fn().mockRejectedValue(new Error("5007: No such model"));
+		const mockBinding = {
+			run,
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiEmbeddingAdapter(
+			{ binding: mockBinding } as any,
+			"@cf/baai/bge-base-en-v1.5" as any,
+		);
+
+		await expect(adapter.embed(["hi"])).rejects.toBeInstanceOf(WorkersAiRequestError);
+		expect(run).toHaveBeenCalledOnce();
+	});
+
+	it("embedViaGateway: throws a structured error on a non-ok gateway response", async () => {
+		const { WorkersAiEmbeddingAdapter } = await import("../src/adapters/workers-ai-embedding");
+		const mockGatewayBinding = {
+			run: vi.fn().mockResolvedValue(new Response("rate limited", { status: 429 })),
+		};
+		const adapter = new WorkersAiEmbeddingAdapter(
+			{ binding: mockGatewayBinding, maxRetries: 0 } as any,
+			"@cf/baai/bge-base-en-v1.5" as any,
+		);
+
+		await expect(adapter.embed(["hi"])).rejects.toMatchObject({
+			name: "WorkersAiRequestError",
+			status: 429,
+		});
 	});
 
 	it("embedViaRest: throws on non-ok response", async () => {

--- a/packages/tanstack-ai/test/errors.test.ts
+++ b/packages/tanstack-ai/test/errors.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	bindingErrorToResponse,
+	DEFAULT_MAX_RETRIES,
+	errorFromResponse,
+	normalizeBindingError,
+	parseRetryAfterMs,
+	WorkersAiRequestError,
+	withWorkersAiRetry,
+} from "../src/utils/errors";
+
+// ---------------------------------------------------------------------------
+// normalizeBindingError
+// ---------------------------------------------------------------------------
+
+describe("normalizeBindingError", () => {
+	it("maps an out-of-capacity (3040) binding error to a 429 WorkersAiRequestError", () => {
+		const err = normalizeBindingError(
+			new Error("3040: Capacity temporarily exceeded, please try again."),
+			"Workers AI embedding",
+		);
+		expect(err).toBeInstanceOf(WorkersAiRequestError);
+		const e = err as WorkersAiRequestError;
+		expect(e.status).toBe(429);
+		expect(e.message).toContain("Workers AI embedding request failed");
+		expect(e.message).toContain("3040");
+	});
+
+	it("maps a client error (5007) to a 400 WorkersAiRequestError", () => {
+		const err = normalizeBindingError(
+			new Error("5007: No such model"),
+			"x",
+		) as WorkersAiRequestError;
+		expect(err.status).toBe(400);
+	});
+
+	it("captures the recognized internal code", () => {
+		const err = normalizeBindingError(
+			new Error("3040: out of capacity"),
+			"x",
+		) as WorkersAiRequestError;
+		expect(err.code).toBe(3040);
+	});
+
+	it("leaves unrecognized errors without a status (so they are not retried)", () => {
+		const err = normalizeBindingError(
+			new Error("totally unexpected"),
+			"x",
+		) as WorkersAiRequestError;
+		expect(err).toBeInstanceOf(WorkersAiRequestError);
+		expect(err.status).toBeUndefined();
+	});
+
+	it("passes AbortError / DOMException aborts through unchanged", () => {
+		const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+		expect(normalizeBindingError(abort, "x")).toBe(abort);
+
+		const domAbort = new DOMException("The operation was aborted", "AbortError");
+		expect(normalizeBindingError(domAbort, "x")).toBe(domAbort);
+	});
+
+	it("passes an existing WorkersAiRequestError through unchanged", () => {
+		const original = new WorkersAiRequestError("already wrapped", { status: 500 });
+		expect(normalizeBindingError(original, "x")).toBe(original);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// errorFromResponse
+// ---------------------------------------------------------------------------
+
+describe("errorFromResponse", () => {
+	it("captures status + body and keeps the historical message shape", () => {
+		const err = errorFromResponse(
+			new Response("rate limited", { status: 429 }),
+			"rate limited",
+			"Workers AI embedding",
+		);
+		expect(err.status).toBe(429);
+		expect(err.responseBody).toBe("rate limited");
+		expect(err.message).toBe("Workers AI embedding request failed (429): rate limited");
+	});
+
+	it("parses Retry-After (delta-seconds) into retryAfterMs", () => {
+		const err = errorFromResponse(
+			new Response("rate limited", { status: 429, headers: { "retry-after": "2" } }),
+			"rate limited",
+			"Workers AI embedding",
+		);
+		expect(err.retryAfterMs).toBe(2000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseRetryAfterMs
+// ---------------------------------------------------------------------------
+
+describe("parseRetryAfterMs", () => {
+	it("parses delta-seconds", () => {
+		expect(parseRetryAfterMs("3")).toBe(3000);
+		expect(parseRetryAfterMs("0")).toBe(0);
+	});
+
+	it("parses an HTTP-date relative to now", () => {
+		const now = Date.parse("2026-01-01T00:00:00Z");
+		expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:05 GMT", now)).toBe(5000);
+		// A past date clamps to 0 rather than going negative.
+		expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:00 GMT", now + 10_000)).toBe(0);
+	});
+
+	it("returns undefined for missing / unparseable values", () => {
+		expect(parseRetryAfterMs(null)).toBeUndefined();
+		expect(parseRetryAfterMs("")).toBeUndefined();
+		expect(parseRetryAfterMs("   ")).toBeUndefined();
+		expect(parseRetryAfterMs("soon")).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// bindingErrorToResponse (chat shim)
+// ---------------------------------------------------------------------------
+
+describe("bindingErrorToResponse", () => {
+	it("turns a 3040 binding error into a 429 Response", () => {
+		const res = bindingErrorToResponse(new Error("3040: out of capacity"));
+		expect(res.status).toBe(429);
+	});
+
+	it("turns a 5007 binding error into a 400 Response", () => {
+		const res = bindingErrorToResponse(new Error("5007: No such model"));
+		expect(res.status).toBe(400);
+	});
+
+	it("re-throws aborts so the OpenAI SDK's cancellation handling fires", () => {
+		const abort = new DOMException("aborted", "AbortError");
+		expect(() => bindingErrorToResponse(abort)).toThrow(abort);
+	});
+
+	it("re-throws unrecognized errors (preserving the original, no fabricated status)", () => {
+		const boom = new Error("unexpected kaboom");
+		expect(() => bindingErrorToResponse(boom)).toThrow(boom);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// withWorkersAiRetry
+// ---------------------------------------------------------------------------
+
+describe("withWorkersAiRetry", () => {
+	it("returns the result without retrying on success", async () => {
+		const fn = vi.fn().mockResolvedValue("ok");
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).resolves.toBe("ok");
+		expect(fn).toHaveBeenCalledOnce();
+	});
+
+	it("retries retryable failures (429) then succeeds", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new WorkersAiRequestError("rate limited", { status: 429 }))
+			.mockResolvedValue("recovered");
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).resolves.toBe("recovered");
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it("honors a server Retry-After hint when retrying", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(
+				new WorkersAiRequestError("rate limited", { status: 429, retryAfterMs: 5 }),
+			)
+			.mockResolvedValue("recovered");
+		await expect(withWorkersAiRetry(fn)).resolves.toBe("recovered");
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it("derives retryability from a raw binding 3040 error message", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("3040: out of capacity"))
+			.mockResolvedValue("recovered");
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).resolves.toBe("recovered");
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
+	it("gives up after maxRetries and throws the last error", async () => {
+		const error = new WorkersAiRequestError("still failing", { status: 503 });
+		const fn = vi.fn().mockRejectedValue(error);
+		await expect(withWorkersAiRetry(fn, { maxRetries: 2, baseDelayMs: 0 })).rejects.toBe(error);
+		// 1 initial + 2 retries
+		expect(fn).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not retry non-retryable failures (e.g. 400)", async () => {
+		const error = new WorkersAiRequestError("bad request", { status: 400 });
+		const fn = vi.fn().mockRejectedValue(error);
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).rejects.toBe(error);
+		expect(fn).toHaveBeenCalledOnce();
+	});
+
+	it("never retries aborts", async () => {
+		const abort = new DOMException("aborted", "AbortError");
+		const fn = vi.fn().mockRejectedValue(abort);
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).rejects.toBe(abort);
+		expect(fn).toHaveBeenCalledOnce();
+	});
+
+	it("respects maxRetries: 0 (no retries)", async () => {
+		const error = new WorkersAiRequestError("rate limited", { status: 429 });
+		const fn = vi.fn().mockRejectedValue(error);
+		await expect(withWorkersAiRetry(fn, { maxRetries: 0, baseDelayMs: 0 })).rejects.toBe(error);
+		expect(fn).toHaveBeenCalledOnce();
+	});
+
+	it("defaults to DEFAULT_MAX_RETRIES retries", async () => {
+		const error = new WorkersAiRequestError("rate limited", { status: 429 });
+		const fn = vi.fn().mockRejectedValue(error);
+		await expect(withWorkersAiRetry(fn, { baseDelayMs: 0 })).rejects.toBe(error);
+		expect(fn).toHaveBeenCalledTimes(DEFAULT_MAX_RETRIES + 1);
+	});
+});

--- a/packages/tanstack-ai/test/image-adapter.test.ts
+++ b/packages/tanstack-ai/test/image-adapter.test.ts
@@ -170,6 +170,26 @@ describe("WorkersAiImageAdapter", () => {
 		}
 	});
 
+	it("normalizes an out-of-capacity (3040) binding error to a retryable 429 error", async () => {
+		const { WorkersAiImageAdapter } = await import("../src/adapters/workers-ai-image");
+		const mockBinding = {
+			run: vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiImageAdapter(
+			{ binding: mockBinding, maxRetries: 0 } as any,
+			"@cf/stabilityai/stable-diffusion-xl-base-1.0" as any,
+		);
+
+		await expect(
+			adapter.generateImages({
+				model: "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+				prompt: "a cat",
+				logger,
+			}),
+		).rejects.toMatchObject({ name: "WorkersAiRequestError", status: 429 });
+	});
+
 	it("generateViaRest: throws on non-ok response", async () => {
 		const { WorkersAiImageAdapter } = await import("../src/adapters/workers-ai-image");
 		const originalFetch = globalThis.fetch;
@@ -231,9 +251,13 @@ describe("WorkersAiImageAdapter", () => {
 	});
 
 	it("generateViaGateway: throws on non-ok response", async () => {
+		// 502 is retryable, so return a fresh Response per attempt (a single
+		// Response instance can only have its body read once).
 		const mockGatewayFetch = vi
 			.fn()
-			.mockResolvedValue(new Response("Gateway error", { status: 502 }));
+			.mockImplementation(() =>
+				Promise.resolve(new Response("Gateway error", { status: 502 })),
+			);
 
 		vi.resetModules();
 		vi.doMock("../src/utils/create-fetcher", async (importOriginal) => {

--- a/packages/tanstack-ai/test/summarize-adapter.test.ts
+++ b/packages/tanstack-ai/test/summarize-adapter.test.ts
@@ -107,6 +107,22 @@ describe("WorkersAiSummarizeAdapter", () => {
 		expect(callArgs).not.toHaveProperty("max_length");
 	});
 
+	it("normalizes an out-of-capacity (3040) binding error to a retryable 429 error", async () => {
+		const { WorkersAiSummarizeAdapter } = await import("../src/adapters/workers-ai-summarize");
+		const mockBinding = {
+			run: vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiSummarizeAdapter(
+			{ binding: mockBinding, maxRetries: 0 } as any,
+			"@cf/facebook/bart-large-cnn",
+		);
+
+		await expect(
+			adapter.summarize({ model: "@cf/facebook/bart-large-cnn", text: "x", logger }),
+		).rejects.toMatchObject({ name: "WorkersAiRequestError", status: 429 });
+	});
+
 	// -----------------------------------------------------------------------
 	// REST path
 	// -----------------------------------------------------------------------
@@ -249,9 +265,13 @@ describe("WorkersAiSummarizeAdapter", () => {
 	});
 
 	it("summarize via gateway: throws on non-ok response", async () => {
+		// 502 is retryable, so return a fresh Response per attempt (a single
+		// Response instance can only have its body read once).
 		const mockGatewayFetch = vi
 			.fn()
-			.mockResolvedValue(new Response("Gateway error", { status: 502 }));
+			.mockImplementation(() =>
+				Promise.resolve(new Response("Gateway error", { status: 502 })),
+			);
 
 		vi.resetModules();
 		vi.doMock("../src/utils/create-fetcher", async (importOriginal) => {

--- a/packages/tanstack-ai/test/transcription-adapter.test.ts
+++ b/packages/tanstack-ai/test/transcription-adapter.test.ts
@@ -42,6 +42,23 @@ describe("WorkersAiTranscriptionAdapter", () => {
 		expect(result.words![0]!.word).toBe("Hello");
 	});
 
+	it("normalizes an out-of-capacity (3040) binding error to a retryable 429 error", async () => {
+		const { WorkersAiTranscriptionAdapter } =
+			await import("../src/adapters/workers-ai-transcription");
+		const mockBinding = {
+			run: vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiTranscriptionAdapter(
+			{ binding: mockBinding, maxRetries: 0 } as any,
+			"@cf/openai/whisper",
+		);
+
+		await expect(
+			adapter.transcribe({ model: "@cf/openai/whisper", audio: new ArrayBuffer(10), logger }),
+		).rejects.toMatchObject({ name: "WorkersAiRequestError", status: 429 });
+	});
+
 	it("transcribeViaBinding: handles whisper-large-v3-turbo with segments", async () => {
 		const { WorkersAiTranscriptionAdapter } =
 			await import("../src/adapters/workers-ai-transcription");
@@ -239,9 +256,13 @@ describe("WorkersAiTranscriptionAdapter", () => {
 	});
 
 	it("transcribeViaGateway: throws on non-ok response", async () => {
+		// 502 is retryable, so return a fresh Response per attempt (a single
+		// Response instance can only have its body read once).
 		const mockGatewayFetch = vi
 			.fn()
-			.mockResolvedValue(new Response("Gateway error", { status: 502 }));
+			.mockImplementation(() =>
+				Promise.resolve(new Response("Gateway error", { status: 502 })),
+			);
 
 		vi.resetModules();
 		vi.doMock("../src/utils/create-fetcher", async (importOriginal) => {

--- a/packages/tanstack-ai/test/tts-adapter.test.ts
+++ b/packages/tanstack-ai/test/tts-adapter.test.ts
@@ -37,6 +37,22 @@ describe("WorkersAiTTSAdapter", () => {
 		expect(decoded.charCodeAt(0)).toBe(0x49); // 'I'
 	});
 
+	it("normalizes an out-of-capacity (3040) binding error to a retryable 429 error", async () => {
+		const { WorkersAiTTSAdapter } = await import("../src/adapters/workers-ai-tts");
+		const mockBinding = {
+			run: vi.fn().mockRejectedValue(new Error("3040: Capacity temporarily exceeded")),
+			gateway: () => ({ run: () => Promise.resolve(new Response("ok")) }),
+		};
+		const adapter = new WorkersAiTTSAdapter(
+			{ binding: mockBinding, maxRetries: 0 } as any,
+			"@cf/deepgram/aura-1",
+		);
+
+		await expect(
+			adapter.generateSpeech({ model: "@cf/deepgram/aura-1", text: "hi", logger }),
+		).rejects.toMatchObject({ name: "WorkersAiRequestError", status: 429 });
+	});
+
 	it("generateSpeech via binding: handles ArrayBuffer result", async () => {
 		const { WorkersAiTTSAdapter } = await import("../src/adapters/workers-ai-tts");
 
@@ -237,9 +253,13 @@ describe("WorkersAiTTSAdapter", () => {
 	});
 
 	it("generateSpeech via gateway: throws on non-ok response", async () => {
+		// 502 is retryable, so return a fresh Response per attempt (a single
+		// Response instance can only have its body read once).
 		const mockGatewayFetch = vi
 			.fn()
-			.mockResolvedValue(new Response("Gateway error", { status: 502 }));
+			.mockImplementation(() =>
+				Promise.resolve(new Response("Gateway error", { status: 502 })),
+			);
 
 		vi.resetModules();
 		vi.doMock("../src/utils/create-fetcher", async (importOriginal) => {

--- a/packages/workers-ai-provider/src/workersai-error.ts
+++ b/packages/workers-ai-provider/src/workersai-error.ts
@@ -1,105 +1,16 @@
 import { APICallError } from "@ai-sdk/provider";
+import {
+	headersToObject,
+	isAbortError,
+	messageOf,
+	parseWorkersAIErrorCode,
+	WORKERS_AI_ERROR_CODE_TO_STATUS,
+} from "@cloudflare/gateway-core";
 
-/**
- * Workers AI internal error code → HTTP status code.
- *
- * The Workers AI **binding** (`env.AI.run`) throws plain `Error`s whose message
- * carries the internal code (e.g. `"3040: Capacity temporarily exceeded"`) but
- * no HTTP status. The AI SDK's retry machinery only retries `APICallError`s
- * whose `statusCode` is retryable (408 / 409 / 429 / >= 500), so we translate
- * the internal code into the documented HTTP status and let `APICallError`
- * derive retryability from it — this is what makes transient failures like
- * "out of capacity" (3040 → 429) automatically retried.
- *
- * Source: https://developers.cloudflare.com/workers-ai/platform/errors/
- */
-export const WORKERS_AI_ERROR_CODE_TO_STATUS: Record<number, number> = {
-	5007: 400, // No such model
-	5004: 400, // Invalid data
-	3039: 400, // Finetune missing required files
-	3003: 400, // Incomplete request
-	5018: 403, // Account not allowed for private model
-	5016: 403, // Model agreement not accepted
-	3023: 403, // Account blocked
-	3041: 403, // Account not allowed for private model
-	5019: 405, // Deprecated SDK version
-	5005: 405, // LoRa unsupported
-	3042: 404, // Invalid model ID
-	3006: 413, // Request too large
-	3007: 408, // Timeout
-	3008: 408, // Aborted
-	3036: 429, // Account limited (daily free allocation used up)
-	3040: 429, // Out of capacity (no data center to forward to)
-};
-
-/**
- * Best-effort extraction of a Workers AI internal error code from a thrown
- * binding error. Prefers a numeric `code` property when present, otherwise
- * parses the `"<code>: <message>"` form the binding uses (optionally prefixed,
- * e.g. `"InferenceUpstreamError: 3040: ..."`). Only recognized codes are
- * returned, and when several `"<number>:"` groups appear (e.g. a leading
- * request id) the first that maps to a known code wins, so unrelated numbers
- * can't be misread as a code.
- */
-export function parseWorkersAIErrorCode(error: unknown): number | undefined {
-	if (error && typeof error === "object") {
-		const code = (error as { code?: unknown }).code;
-		if (typeof code === "number" && code in WORKERS_AI_ERROR_CODE_TO_STATUS) {
-			return code;
-		}
-		if (typeof code === "string") {
-			const parsed = Number.parseInt(code, 10);
-			if (Number.isFinite(parsed) && parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
-				return parsed;
-			}
-		}
-	}
-
-	const message = messageOf(error);
-	for (const match of message.matchAll(/\b(\d{3,5})\s*:/g)) {
-		const parsed = Number.parseInt(match[1]!, 10);
-		if (parsed in WORKERS_AI_ERROR_CODE_TO_STATUS) {
-			return parsed;
-		}
-	}
-
-	return undefined;
-}
-
-/** Read a human-readable message from any thrown value (Error, DOMException, plain object, string). */
-function messageOf(error: unknown): string {
-	if (error instanceof Error) return error.message;
-	if (typeof error === "string") return error;
-	if (error && typeof error === "object") {
-		const message = (error as { message?: unknown }).message;
-		if (typeof message === "string") return message;
-	}
-	return String(error);
-}
-
-/**
- * True for cancellation errors that must propagate untouched (never wrapped, so
- * the AI SDK's own abort detection still fires). Mirrors the AI SDK's
- * `isAbortError`: a real abort from `fetch`/the binding is a `DOMException`,
- * which is NOT `instanceof Error`, so both must be checked.
- */
-function isAbortError(error: unknown): boolean {
-	return (
-		(error instanceof Error || error instanceof DOMException) &&
-		(error.name === "AbortError" ||
-			error.name === "ResponseAborted" ||
-			error.name === "TimeoutError")
-	);
-}
-
-/** Serialize `Headers` to the plain object shape `APICallError` expects. */
-function headersToObject(headers: Headers): Record<string, string> {
-	const out: Record<string, string> = {};
-	headers.forEach((value, key) => {
-		out[key] = value;
-	});
-	return out;
-}
+// Re-exported from `@cloudflare/gateway-core` (single source of truth, shared
+// with `@cloudflare/tanstack-ai`) so existing importers of this module keep
+// working unchanged.
+export { parseWorkersAIErrorCode, WORKERS_AI_ERROR_CODE_TO_STATUS };
 
 /**
  * Normalize an error thrown by the Workers AI **binding** (`env.AI.run`) into an


### PR DESCRIPTION
## Summary

Mirrors the retry/error-normalization work landed in `workers-ai-provider` (#593) for `@cloudflare/tanstack-ai`, covering **every** adapter (not just chat). Transient Workers AI failures — most importantly "out of capacity" (`3040` → HTTP `429`) — are now retried, and binding / REST / gateway errors are normalized into a single, inspectable shape.

The two adapter families need different machinery:

- **Chat** uses the OpenAI SDK, which already has status-based retry. The fix is to make sure failures reach it as proper HTTP responses.
- **Non-chat** adapters (embedding, image, TTS, transcription, summarize) call the binding / REST directly, so they get a small bounded-retry wrapper of our own.

## What changed

### Chat (`createWorkersAi`)
- The binding shim (`createWorkersAiBindingFetch`) now converts binding `run()` failures into HTTP `Response`s (`3040 → 429`, `5007 → 400`, etc.) so the OpenAI SDK's retry engages and honors `Retry-After`.
- Aborts (`AbortError` / `DOMException`) and unrecognized errors propagate untouched.
- **Bug fix:** non-OK gateway run-path responses were being swallowed into an empty "successful" completion via `raw.json()`. They are now returned verbatim so the SDK sees the status.

### Non-chat adapters (embedding, image, TTS, transcription, summarize)
- New `withWorkersAiRetry` bounded exponential-backoff wrapper (honors server `Retry-After`).
- Binding / REST / gateway failures are normalized into a single `WorkersAiRequestError` carrying the HTTP `status` (and the raw Workers AI `code` when recognized).
- Non-OK gateway responses are no longer swallowed.

### Config
- New `maxRetries` option on the adapter config. Forwarded to the OpenAI SDK on the chat path; used by the non-chat retry loop. Defaults to `2`, set to `0` to disable.

### Shared core (`@cloudflare/gateway-core`)
- Lifted the error classification (code→status map, message/code parsing, abort + retryable-status detection, `Retry-After` parsing) into `gateway-core` so both `tanstack-ai` and `workers-ai-provider` share one implementation.
- `workers-ai-provider/src/workersai-error.ts` now imports those helpers and re-exports the previously-local symbols for back-compat. **No behavior change** for `workers-ai-provider`.

## Test plan

Unit (all green):
- `@cloudflare/gateway-core` — 55 passed
- `@cloudflare/tanstack-ai` — 304 passed (new `test/errors.test.ts`; expanded `binding-fetch` + per-adapter normalization/retry tests)
- `workers-ai-provider` — 444 passed (back-compat after the refactor)
- `oxlint` clean, `oxfmt --check` clean, `tsc --noEmit` clean on all three packages

E2E (live Cloudflare account; failures are all environmental, **none from this change**):
- `tanstack-ai` REST — failures limited to GLM 5.2 real-API timeouts + a pre-existing `resolveMediaPrompt` test-mock gap; BART `410` correctly surfaced as a non-retryable `WorkersAiRequestError`
- `tanstack-ai` binding — 74 passed; 6 failures all GLM 5.2 latency timeouts. Binding-error normalization verified live (Nova-3 `5006`, BART `5028`)
- `workers-ai-provider` binding — 102/102 passed
- `workers-ai-provider` REST — 95 passed; failures are a GLM 5.2 timeout + Flux 2 Dev backend `multipart` contract change (our normalizer correctly produced a non-retryable `400`, no spurious retry)

## Changeset
`@cloudflare/tanstack-ai`: minor.

Made with [Cursor](https://cursor.com)