### PR TITLE
[workers-ai-provider] Route native unified-billing catalog slugs through the run path (#596)

### DIFF
--- a/.changeset/deepseek-run-catalog.md
+++ b/.changeset/deepseek-run-catalog.md
@@ -1,0 +1,11 @@
+---
+"workers-ai-provider": patch
+---
+
+fix: route native unified-billing catalog slugs (e.g. `deepseek/deepseek-v4-pro`) through the run path
+
+`workers-ai-provider@3.2.x` began treating any `"<vendor>/<model>"` id as a third-party AI Gateway catalog slug. This regressed models like `deepseek/deepseek-v4-pro` that Cloudflare serves natively on the unified-billing run path (`env.AI.run`): without `providers` the provider threw at construction, and with `providers: [openai]` it routed to the gateway universal `chat/completions` (BYOK) endpoint and returned auth errors.
+
+`deepseek/*` is now on the unified run catalog (defaults to `env.AI.run`), matching pre-3.2 behavior. Unified-billing eligibility is decided per-model by Cloudflare's catalog, so BYOK-only deepseek models (e.g. `deepseek/deepseek-chat`) still work by opting into the gateway path per call (`transport: "gateway"` / `byok`). The rest of the OpenAI-wire long tail (`mistral`, `perplexity`, `cerebras`, `openrouter`, `fireworks`) is not on Cloudflare's unified run catalog — `env.AI.run` returns model-not-found for those — so they remain BYOK gateway-path providers.
+
+When no `providers` are configured, a bare `"<vendor>/<model>"` id is now routed through the same hardened run path as `dynamic/*` routes: the gateway defaults to the account's `"default"` gateway (third-party unified billing needs one), `cacheTtl`/`skipCache`/`metadata`/`collectLog` are applied to the gateway options, and delegate-only options (`byok`, `transport: "gateway"`, `fallback`, `resume`, resume callbacks) now throw a clear error instead of being silently dropped.

--- a/.changeset/tanstack-catalog-gateway-default.md
+++ b/.changeset/tanstack-catalog-gateway-default.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+fix: default third-party catalog slugs to the account gateway on the Workers AI binding path
+
+`createWorkersAiChat` in plain binding mode (`{ binding: env.AI }`, no `gateway`) called `env.AI.run(model, inputs)` with no gateway. That works for `@cf/*` models, but third-party `"<vendor>/<model>"` unified-billing catalog slugs (e.g. `deepseek/deepseek-v4-pro`) must route through an AI Gateway, so they never engaged unified billing.
+
+The binding shim now detects a non-`@cf`/non-`dynamic` catalog slug and defaults it to the account `"default"` gateway (an explicitly configured `gateway` still wins). `@cf/*` and `dynamic/*` models keep the plain binding path unchanged. Resume only engages when a gateway was explicitly configured — the catalog auto-default is a routing concern, not a resume opt-in.

--- a/packages/gateway-core/src/gateway-providers.ts
+++ b/packages/gateway-core/src/gateway-providers.ts
@@ -16,10 +16,21 @@
  *
  * Slugs mirror the AI Gateway provider directory
  * (developers.cloudflare.com/ai-gateway/usage/providers/); endpoint transforms
- * mirror `ai-gateway-provider`'s provider table. `runCatalog` / `billing` flags
- * follow the documented unified-billing list (OpenAI, Anthropic, Google AI
- * Studio, Google Vertex, xAI/Grok, Groq) and are otherwise conservative — the
- * e2e suite confirms them live, since resume is undocumented upstream.
+ * mirror `ai-gateway-provider`'s provider table.
+ *
+ * `runCatalog` marks providers whose models Cloudflare actually serves on the
+ * unified-billing `env.AI.run` path (resumable, `cf-aig-run-id`). Membership is
+ * NOT "any OpenAI-wire provider" — it's empirically what the run router accepts:
+ * the headline unified providers (OpenAI, Anthropic, Google AI Studio, xAI, Groq),
+ * the DashScope/MiniMax run-only providers, and `deepseek/*` (issue #596). Within
+ * a run-catalog provider, unified-billing eligibility is still decided per-MODEL
+ * (e.g. `deepseek/deepseek-v4-pro` is unified while `deepseek/deepseek-chat`
+ * returns a clear "use BYOK" signal). Everything else — the OpenAI-wire long tail
+ * (mistral, perplexity, cerebras, openrouter, fireworks), the provider-native
+ * `wireFormat`-less providers, and Vertex — is `runCatalog:false` and reached via
+ * the BYOK gateway path. `env.AI.run` distinguishes the two cleanly: `7003
+ * model-not-found` for off-catalog slugs vs `2021 use-BYOK` for a recognized
+ * BYOK-only model. All of this is guarded live by the e2e run-path membership probe.
  */
 
 /** Response wire format the slug delegate can parse with a built-in `@ai-sdk/*` provider. */
@@ -242,18 +253,39 @@ export const GATEWAY_PROVIDERS: GatewayProviderInfo[] = [
 		transformEndpoint: hostStrip(VERTEX_HOST),
 	},
 
-	// ---- OpenAI-compatible long tail (gateway path, BYOK) ----
+	// ---- DeepSeek: OpenAI-wire long-tail provider that IS on the unified run catalog ----
+	// `deepseek/*` is served on the unified-billing run path (`env.AI.run`), unlike
+	// the rest of the OpenAI-wire long tail below (which the run router does not
+	// recognize). Eligibility is per-MODEL: `deepseek/deepseek-v4-pro` bills unified
+	// (#596), while `deepseek/deepseek-chat` returns "not available via unified
+	// billing; use BYOK" — a clear signal the caller answers with `byok`. So the run
+	// path is the correct DEFAULT (matches pre-3.2, unblocks #596); BYOK stays
+	// reachable per call via `transport:"gateway"` / `byok`, and
+	// `baseURL`/`transformEndpoint` keep that forced gateway path working.
+	// Verified live: v4-pro ⇒ 200, deepseek-chat ⇒ 402 use-BYOK (e2e probe).
 	{
 		resolverKey: "deepseek",
 		gatewayProviderId: "deepseek",
 		wireFormat: "openai",
 		baseURL: "https://api.deepseek.com",
-		runCatalog: false,
-		billing: "byok",
+		runCatalog: true,
+		billing: "unified",
 		authHeaders: ["authorization"],
 		hostPattern: DEEPSEEK_HOST,
 		transformEndpoint: hostStrip(DEEPSEEK_HOST),
 	},
+
+	// ---- OpenAI-compatible long tail: BYOK gateway path only ----
+	// These are OpenAI-wire providers reachable through the native gateway
+	// directory, but NOT on Cloudflare's unified-billing run catalog: `env.AI.run`
+	// returns `7003 model-not-found` for their canonical model ids (mistral,
+	// cerebras, openrouter, fireworks), and perplexity is recognized-but-BYOK
+	// (`2021 "use BYOK"`). None can be run unified, so they route through the BYOK
+	// gateway path (`env.AI.gateway().run`, no resume) — supply your provider key
+	// via `extraHeaders` + `byok`. `baseURL`/`transformEndpoint` shape that path.
+	// (Empirically classified by the e2e run-path membership probe; if Cloudflare
+	// adds any of these to unified billing, flip `runCatalog`/`billing` and the
+	// probe will confirm.)
 	{
 		resolverKey: "mistral",
 		gatewayProviderId: "mistral",
@@ -299,8 +331,6 @@ export const GATEWAY_PROVIDERS: GatewayProviderInfo[] = [
 		transformEndpoint: hostStrip(OPENROUTER_HOST),
 	},
 	{
-		// Fireworks is OpenAI-compatible. Present on ai-gateway-provider (#409) but
-		// not the current provider directory — treat as BYOK long-tail.
 		resolverKey: "fireworks",
 		gatewayProviderId: "fireworks",
 		wireFormat: "openai",

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -470,17 +470,35 @@ function buildBindingInputs(body: Record<string, unknown>): Record<string, unkno
 }
 
 /**
+ * True when a model id is a `"<vendor>/<model>"` third-party AI Gateway catalog
+ * slug (e.g. `deepseek/deepseek-v4-pro`) rather than a `@cf/*` Workers AI model
+ * or a `dynamic/*` route. These are billed through unified billing and MUST run
+ * through an AI Gateway, so `env.AI.run` needs a gateway for them.
+ */
+function isCatalogSlug(model: unknown): model is string {
+	return (
+		typeof model === "string" &&
+		!model.startsWith("@") &&
+		!model.startsWith("dynamic/") &&
+		model.includes("/")
+	);
+}
+
+/**
  * Creates a fetch function that intercepts OpenAI SDK requests and translates them
  * to Workers AI binding calls (env.AI.run). This allows the WorkersAiTextAdapter
  * to use the OpenAI SDK against a plain Workers AI binding.
  *
  * Two transports:
  *   - **Plain binding** (default): `binding.run(model, inputs)` — no run-id, not
- *     resumable.
- *   - **Run path** (when `options.gateway` is set): `binding.run(model, inputs,
- *     { gateway, returnRawResponse })` — surfaces `cf-aig-run-id`, so the stream
- *     can be wrapped with the resume engine. Works for `@cf/*` models and
- *     `"<provider>/<model>"` catalog slugs alike.
+ *     resumable. Used for `@cf/*` models with no gateway configured.
+ *   - **Run path** (when `options.gateway` is set, OR the model is a third-party
+ *     `"<provider>/<model>"` catalog slug): `binding.run(model, inputs,
+ *     { gateway, returnRawResponse })`. Third-party unified-billing models must
+ *     route through a gateway, so a catalog slug with no configured gateway
+ *     falls back to the account `"default"` gateway. Resume (`cf-aig-run-id`
+ *     wrapping) only engages when a gateway was explicitly configured — the
+ *     catalog auto-default is a routing concern, not a resume opt-in.
  *
  * NOTE: The `input` URL parameter is intentionally ignored. The model name and all
  * request parameters are extracted from the JSON body, matching Workers AI's
@@ -506,6 +524,14 @@ export function createWorkersAiBindingFetch(
 		const stream = body.stream as boolean | undefined;
 		const inputs = buildBindingInputs(body);
 
+		// A third-party catalog slug needs a gateway even when none was configured
+		// (unified billing routes through one) — default it to the account gateway.
+		// An explicitly configured gateway always wins and is the only case that
+		// opts into resume.
+		const explicitGateway = options?.gateway;
+		const effectiveGateway = explicitGateway ?? (isCatalogSlug(model) ? "default" : undefined);
+		const resumeEnabled = !!explicitGateway && options?.resume !== false;
+
 		// Context for the gpt-oss forced-tool-call salvage on the non-streaming
 		// (graceful-degradation) paths. See cloudflare/ai#560.
 		const salvageContext: SalvageContext = {
@@ -522,13 +548,13 @@ export function createWorkersAiBindingFetch(
 				},
 			});
 
-		// --- Run path (gateway set): resumable, surfaces cf-aig-run-id ---
-		if (options?.gateway) {
+		// --- Run path (gateway set or catalog slug): surfaces cf-aig-run-id ---
+		if (effectiveGateway) {
 			const runOptions: Record<string, unknown> = {
-				gateway: { id: options.gateway },
+				gateway: { id: effectiveGateway },
 				returnRawResponse: true,
 			};
-			if (options.extraHeaders) runOptions.extraHeaders = options.extraHeaders;
+			if (options?.extraHeaders) runOptions.extraHeaders = options.extraHeaders;
 			if (signal) runOptions.signal = signal;
 
 			let raw: Response;
@@ -551,19 +577,19 @@ export function createWorkersAiBindingFetch(
 
 			if (isStreamResponse) {
 				let byteStream = raw.body as ReadableStream<Uint8Array>;
-				if (options.resume !== false && runId) {
+				if (resumeEnabled && runId) {
 					// Wrap the RAW run-path bytes with the resume engine BEFORE the
 					// SSE transform, so the engine's event-offset bookkeeping (it
 					// counts `\n\n` on the raw stream) stays correct.
 					byteStream = createResumableStream({
 						binding: binding as unknown as Ai,
-						gateway: options.gateway,
+						gateway: effectiveGateway,
 						runId,
 						initial: byteStream,
-						onResumeExpired: options.onResumeExpired,
+						onResumeExpired: options?.onResumeExpired,
 						signal,
 					});
-				} else if (options.resume && !runId) {
+				} else if (options?.resume && !runId) {
 					if (!warnedNoRunId) {
 						warnedNoRunId = true;
 						console.warn(

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -998,3 +998,56 @@ describe("createWorkersAiBindingFetch", () => {
 		]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Third-party catalog slug gateway defaulting
+//
+// A `"<vendor>/<model>"` unified-billing model must route through an AI Gateway,
+// so even with no gateway configured the binding shim defaults it to the account
+// `"default"` gateway (parity with workers-ai-provider). `@cf/*` and `dynamic/*`
+// keep the plain binding path (no gateway) when none is configured.
+// ---------------------------------------------------------------------------
+
+describe("createWorkersAiBindingFetch — catalog slug gateway defaulting", () => {
+	/** A raw run-path Response (binding.run returns raw when returnRawResponse is set). */
+	function rawJson(): Response {
+		return new Response(JSON.stringify({ response: "hi" }), {
+			headers: { "content-type": "application/json" },
+		});
+	}
+
+	async function callWith(binding: MockBinding, model: string, gateway?: string) {
+		const fetcher = createWorkersAiBindingFetch(binding, gateway ? { gateway } : undefined);
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ model, messages: [{ role: "user", content: "Hi" }] }),
+		});
+		return binding.run.mock.calls[0]! as [string, Record<string, unknown>, unknown];
+	}
+
+	it("defaults a third-party catalog slug to the account gateway (run path)", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue(rawJson()));
+		const [model, , opts] = await callWith(binding, "deepseek/deepseek-v4-pro");
+		expect(model).toBe("deepseek/deepseek-v4-pro");
+		expect(opts).toMatchObject({ gateway: { id: "default" }, returnRawResponse: true });
+	});
+
+	it("keeps `@cf/*` models on the plain binding path (no gateway) when none is configured", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "hi" }));
+		const [, , opts] = await callWith(binding, "@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+		// Plain binding path passes `undefined` (or no gateway) as the options arg.
+		expect((opts as { gateway?: unknown } | undefined)?.gateway).toBeUndefined();
+	});
+
+	it("does NOT auto-default for `dynamic/*` routes", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "hi" }));
+		const [, , opts] = await callWith(binding, "dynamic/my-route");
+		expect((opts as { gateway?: unknown } | undefined)?.gateway).toBeUndefined();
+	});
+
+	it("respects an explicitly configured gateway over the catalog default", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue(rawJson()));
+		const [, , opts] = await callWith(binding, "deepseek/deepseek-v4-pro", "my-gw");
+		expect(opts).toMatchObject({ gateway: { id: "my-gw" } });
+	});
+});

--- a/packages/workers-ai-provider/README.md
+++ b/packages/workers-ai-provider/README.md
@@ -373,7 +373,7 @@ const result = streamText({
 // result.response.headers["cf-aig-run-id"] is set — resume from there.
 ```
 
-The settings argument is **typed from the model id**: pass a `"<provider>/<model>"` catalog slug and the second argument autocompletes the per-call gateway options (`resume`, `fallback`, `cacheTtl`, `byok`, `metadata`, …, i.e. `DelegateCallOptions`); pass a `@cf/...` id and it autocompletes the usual `WorkersAIChatSettings`. `providers` is optional and **additive**: leave it unset and `createWorkersAI` behaves exactly as before; passing a catalog slug without it throws a helpful error pointing you here.
+The settings argument is **typed from the model id**: pass a `"<provider>/<model>"` catalog slug and the second argument autocompletes the per-call gateway options (`resume`, `fallback`, `cacheTtl`, `byok`, `metadata`, …, i.e. `DelegateCallOptions`); pass a `@cf/...` id and it autocompletes the usual `WorkersAIChatSettings`. `providers` is optional and **additive**: leave it unset and `createWorkersAI` behaves exactly as before — `@cf/...` ids work as always, and a `"<provider>/<model>"` catalog slug still routes through the unified-billing run path (defaulting to your account's `"default"` gateway, with the built-in OpenAI-compatible parser). Configure `providers` to unlock higher-fidelity parsing plus the per-call delegate options (BYOK, caching, fallback, resume); requesting one of those without `providers` throws a helpful error pointing you here.
 
 `gateway` is optional for catalog routing — when unset, requests use your account's `"default"` AI Gateway. Set `gateway: { id: "…" }` (here or per call) to use a specific gateway.
 
@@ -385,7 +385,7 @@ One plugin per **wire format** serves every provider of that format. The `openai
 
 The registry covers every provider in the [AI Gateway provider directory](https://developers.cloudflare.com/ai-gateway/usage/providers/) — OpenAI, Anthropic, Google AI Studio, Google Vertex AI, xAI/Grok, Groq, DeepSeek, Mistral, Perplexity, Cerebras, OpenRouter, Cohere, Baseten, Parallel, Azure OpenAI, Amazon Bedrock, HuggingFace, Replicate, Fal, Ideogram, Cartesia, Deepgram, ElevenLabs (plus Fireworks) — so `createGatewayFetch` can auto-detect them from the request URL.
 
-**Coverage maturity varies** (the whole feature is experimental). Only the unified-billing run-catalog providers — OpenAI, Anthropic, Google, xAI/Grok, Groq, Alibaba/Qwen, MiniMax — are exercised end-to-end against a live gateway. The remaining registry entries (BYOK gateway-path providers like DeepSeek/Mistral/Perplexity/Cerebras/OpenRouter/Fireworks, and bring-your-own-provider-only ones like Cohere/Baseten/Parallel/Azure OpenAI/Bedrock/HuggingFace/Replicate/Fal/Ideogram/Cartesia/Deepgram/ElevenLabs) are registry-level wiring (gateway id, host pattern, endpoint transform) that is **not yet live-verified** — the routing is in place, but a provider's exact request shape may need adjustment. Please file issues for any that misbehave.
+**Coverage maturity varies** (the whole feature is experimental). Only the unified-billing run-catalog providers — OpenAI, Anthropic, Google, xAI/Grok, Groq, DeepSeek, Alibaba/Qwen, MiniMax — are exercised end-to-end against a live gateway. The remaining registry entries (BYOK gateway-path providers like Mistral/Perplexity/Cerebras/OpenRouter/Fireworks, and bring-your-own-provider-only ones like Cohere/Baseten/Parallel/Azure OpenAI/Bedrock/HuggingFace/Replicate/Fal/Ideogram/Cartesia/Deepgram/ElevenLabs) are registry-level wiring (gateway id, host pattern, endpoint transform) that is **not yet live-verified** — the routing is in place, but a provider's exact request shape may need adjustment. Please file issues for any that misbehave.
 
 > **Run-path wire format is per-provider — not always OpenAI.** On the resumable run path (`env.AI.run`), Cloudflare's unified catalog **normalizes most providers to OpenAI chat-completions** (so `google/…` is parsed with the `openai` plugin on the run path, even though the gateway path uses the native `google` plugin), but **passes Anthropic through natively** — so `anthropic/…` uses the `anthropic` plugin on both paths. In practice: include `openai` for the openai-wire run-path providers (openai, google, xai/grok, groq), and `anthropic` to use `anthropic/…`. The native `google` plugin is only needed if you force google onto the **gateway path**. If a plugin a transport needs is missing, the delegate throws a `GatewayDelegateError` naming it.
 
@@ -398,13 +398,13 @@ The transport is chosen automatically from the options you pass:
 | **run** (default) | `env.AI.run(...)`            | ✅                                       | ❌      | ❌              | Unified billing   |
 | **gateway**       | `env.AI.gateway(id).run([])` | ❌                                       | ✅      | ✅              | BYOK / stored key |
 
-Run-catalog providers (OpenAI, Anthropic, Google, xAI, Groq, plus the unified-catalog chat providers Alibaba/Qwen and MiniMax) default to the resumable **run path**. BYOK-only providers (deepseek, mistral, perplexity, …) always use the **gateway path**. Asking for an impossible combination (e.g. `resume: true` with `fallback.mode: "server"`) throws a `GatewayDelegateError`.
+Run-catalog providers (OpenAI, Anthropic, Google, xAI, Groq, DeepSeek, plus the unified-catalog chat providers Alibaba/Qwen and MiniMax) default to the resumable **run path**. BYOK-only providers (mistral, perplexity, cerebras, …) always use the **gateway path**. Asking for an impossible combination (e.g. `resume: true` with `fallback.mode: "server"`) throws a `GatewayDelegateError`.
 
 > Alibaba and MiniMax are **run-path only** — they're on the unified catalog but not the native gateway directory, so there's no gateway path. Requesting `transport: "gateway"`, caching, or server-side fallback on them throws a clear `GatewayDelegateError` at build time (rather than failing upstream); use the default run path or `fallback.mode: "client"`.
 
 ### BYOK (bring your own key)
 
-On the gateway path, set `byok: true` and supply the upstream key via `extraHeaders`:
+Set `byok: true` to forward your own upstream key via `extraHeaders`. BYOK is a gateway-path feature, so it forces the gateway path even for a run-catalog provider like DeepSeek (resume isn't available on that leg):
 
 ```ts
 streamText({

--- a/packages/workers-ai-provider/src/gateway-delegate.ts
+++ b/packages/workers-ai-provider/src/gateway-delegate.ts
@@ -271,13 +271,18 @@ export function selectTransport(
 	// Run-path-only providers (on the run catalog, but not native gateway
 	// providers) have no gateway path at all — reject anything that would need it
 	// here, with a clear message, rather than letting it fail upstream.
-	if (runCatalog && !gatewayAvailable && (opts.transport === "gateway" || gatewayOnly)) {
-		const what = opts.transport === "gateway" ? 'transport:"gateway"' : feature;
+	if (
+		runCatalog &&
+		!gatewayAvailable &&
+		(opts.transport === "gateway" || opts.byok || gatewayOnly)
+	) {
+		const what =
+			opts.transport === "gateway" ? 'transport:"gateway"' : opts.byok ? "byok" : feature;
 		throw new GatewayDelegateError(
 			"config",
 			`${what} is unavailable: this provider is on the unified run catalog but is not a ` +
 				"native gateway provider, so it has no gateway path (no caching, server-side " +
-				'fallback, or transport:"gateway"). Use the default run path, or fallback.mode:"client".',
+				'fallback, BYOK, or transport:"gateway"). Use the default run path, or fallback.mode:"client".',
 		);
 	}
 
@@ -296,6 +301,26 @@ export function selectTransport(
 				"config",
 				"resume:true is unavailable: this provider is not on the resumable run catalog " +
 					"(cf-aig-run-id requires the unified-billing run path).",
+			);
+		}
+		return { transport: "gateway", resumeEnabled: false, warnings };
+	}
+
+	// BYOK forwards the caller's own provider key, which only the gateway path
+	// supports — treat it like an explicit gateway transport (no resume-disabled
+	// warning; the caller opted into a gateway-only mode).
+	if (opts.byok) {
+		if (opts.transport === "run") {
+			throw new GatewayDelegateError(
+				"config",
+				'transport:"run" cannot forward a BYOK key — BYOK is a gateway-path feature. ' +
+					'Drop transport:"run" (or set transport:"gateway").',
+			);
+		}
+		if (resumeExplicitlyTrue) {
+			throw new GatewayDelegateError(
+				"config",
+				"byok cannot provide resume — cf-aig-run-id is only on the unified-billing run path.",
 			);
 		}
 		return { transport: "gateway", resumeEnabled: false, warnings };

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -309,9 +309,21 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 		gateway: GatewayOptions | string | undefined,
 	): GatewayOptions | undefined => (typeof gateway === "string" ? { id: gateway } : gateway);
 
-	const createDynamicRouteModel = (
+	// The bare unified-billing run path (`env.AI.run(model, …)`) shared by two
+	// callers that both hit it WITHOUT the gateway delegate:
+	//   - `dynamic/<route>` AI Gateway dynamic routes, and
+	//   - `"<vendor>/<model>"` catalog slugs when no `providers` are configured
+	//     (the #596 passthrough).
+	// Neither has a transport choice, resume engine, or BYOK forwarding — those
+	// only exist once `providers` are set and the delegate takes over — so this
+	// path defaults the gateway (third-party run models need one), folds
+	// cache/metadata into the gateway options, and rejects delegate-only options
+	// loudly instead of letting `WorkersAIChatLanguageModel` spread them as junk
+	// into `binding.run`'s options arg.
+	const createRunPathModel = (
 		modelId: TextGenerationModels,
 		settings: WorkersAIChatSettings & DelegateCallOptions = {},
+		kind: "dynamic" | "catalog",
 	) => {
 		if (
 			settings.fallback ||
@@ -321,11 +333,16 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 			settings.onResumeExpired ||
 			settings.byok
 		) {
+			const subject =
+				kind === "dynamic"
+					? `"${modelId}" is an AI Gateway dynamic route`
+					: `"${modelId}" routes through the bare unified-billing run path because no \`providers\` are configured`;
 			throw new Error(
-				`"${modelId}" is an AI Gateway dynamic route. Dynamic routes use AI.run with ` +
-					"OpenAI-compatible chat-completions wire format; fallback, gateway transport, " +
-					"resume, BYOK, and resume callbacks must be configured on the dynamic route or " +
-					"gateway instead of per call.",
+				`${subject}. It uses AI.run with OpenAI-compatible chat-completions wire format; ` +
+					"fallback, gateway transport, resume, BYOK, and resume callbacks are gateway-delegate " +
+					"features — configure provider plugins to use them " +
+					"(createWorkersAI({ binding: env.AI, providers: [openai] })), and for dynamic routes " +
+					"set caching/fallback on the route or gateway instead of per call.",
 			);
 		}
 
@@ -367,7 +384,12 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 
 		const plugin = options.providers?.find((p) => p.wireFormat === DYNAMIC_ROUTE_WIRE_FORMAT);
 		if (!plugin) {
-			if (options.providers?.length) {
+			// Dynamic routes with providers configured but no OpenAI plugin can't be
+			// parsed (they always return openai-wire), so guide the user. The
+			// catalog passthrough only reaches here with no providers at all, where
+			// the built-in `WorkersAIChatLanguageModel` parser is the intended
+			// fallback (#596) — so let it through.
+			if (kind === "dynamic" && options.providers?.length) {
 				throw new Error(
 					`"${modelId}" is an AI Gateway dynamic route. Dynamic routes return OpenAI-compatible ` +
 						"chat-completions wire format on the AI.run path, so configure the OpenAI " +
@@ -465,12 +487,27 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 		settings?: WorkersAIChatSettings | DelegateCallOptions,
 	): WorkersAIChatLanguageModel => {
 		if (typeof modelId === "string" && modelId.startsWith("dynamic/")) {
-			return createDynamicRouteModel(
+			return createRunPathModel(
 				modelId,
 				settings as (WorkersAIChatSettings & DelegateCallOptions) | undefined,
+				"dynamic",
 			);
 		}
 		if (isGatewaySlug(modelId)) {
+			// Without provider plugins there's no gateway/BYOK routing to do, and a
+			// bare `"<vendor>/<model>"` id is a valid Workers AI unified-billing run
+			// model — `env.AI.run("deepseek/deepseek-v4-pro")`. Route it through the
+			// same bare run path as dynamic routes (defaults the gateway, folds
+			// cache/metadata, rejects delegate-only options) instead of erroring.
+			// Catalog routing (resume, fallback, caching, BYOK) only kicks in once
+			// `providers` are set. (#596)
+			if (!options.providers?.length) {
+				return createRunPathModel(
+					modelId,
+					settings as (WorkersAIChatSettings & DelegateCallOptions) | undefined,
+					"catalog",
+				);
+			}
 			// The delegate returns a `LanguageModelV3` built by the configured plugin.
 			// It's structurally compatible with the AI SDK consumers this provider is
 			// used with; the cast keeps the public return type unchanged.

--- a/packages/workers-ai-provider/test/create-workers-ai.test.ts
+++ b/packages/workers-ai-provider/test/create-workers-ai.test.ts
@@ -357,22 +357,28 @@ describe("createWorkersAI implicit gateway routing", () => {
 			workersai("dynamic/gemma-4-fallback", {
 				fallback: { mode: "client", models: ["openai/gpt-5-mini"] },
 			}),
-		).toThrow(/must be configured on the dynamic route/);
+		).toThrow(/gateway-delegate features/);
 		expect(() => workersai("dynamic/gemma-4-fallback", { transport: "gateway" })).toThrow(
-			/must be configured on the dynamic route/,
+			/gateway-delegate features/,
 		);
 		expect(() => workersai("dynamic/gemma-4-fallback", { resume: true })).toThrow(
-			/must be configured on the dynamic route/,
+			/gateway-delegate features/,
+		);
+		// The dynamic-route message still names the dynamic route specifically.
+		expect(() => workersai("dynamic/gemma-4-fallback", { resume: true })).toThrow(
+			/is an AI Gateway dynamic route/,
 		);
 	});
 
-	it("throws a helpful error for a catalog slug when providers are NOT configured", () => {
+	it("builds a plain Workers AI run model for a catalog slug when providers are NOT configured (#596)", () => {
 		const { binding } = makeBinding();
 		const workersai = createWorkersAI({ binding, gateway: { id: "default" } });
-		expect(() => workersai("openai/gpt-5-mini")).toThrow(
-			/third-party AI Gateway catalog model/,
-		);
-		expect(() => workersai("openai/gpt-5-mini")).toThrow(/workers-ai-provider\/openai/);
+		// Without provider plugins there's no gateway/BYOK routing to do, so a bare
+		// "<vendor>/<model>" id is treated as a Workers AI unified-billing run model
+		// (env.AI.run) — matching pre-3.2 behavior — rather than throwing.
+		const model = workersai("openai/gpt-5-mini");
+		expect(model.modelId).toBe("openai/gpt-5-mini");
+		expect(model.provider).toBe("workersai.chat");
 	});
 
 	it("treats `@cf/` ids as Workers AI even without providers (no routing)", () => {
@@ -438,5 +444,152 @@ describe("createWorkersAI implicit gateway routing", () => {
 		workersai.chat("openai/gpt-5-mini", { resume: false });
 
 		expect(true).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Regression: deepseek/deepseek-v4-pro unified-billing run path (#596)
+//
+// `deepseek/deepseek-v4-pro` is a unified-billing model on the `env.AI.run`
+// catalog (verified live: 200). It *looks* like a `<provider>/<model>` catalog
+// slug, so 3.2.x routed it to the BYOK gateway universal endpoint (401). It must
+// default to the unified run path instead. (deepseek-chat, by contrast, is a
+// recognized-but-BYOK deepseek model — 402 "use BYOK" — reachable via `byok`.)
+// ---------------------------------------------------------------------------
+
+describe("createWorkersAI — deepseek/deepseek-v4-pro run path (#596)", () => {
+	it("without providers: builds a plain Workers AI run model (env.AI.run)", () => {
+		const { binding } = makeBinding();
+		const workersai = createWorkersAI({ binding, gateway: { id: "default" } });
+		const model = workersai("deepseek/deepseek-v4-pro");
+		// Passed straight through to env.AI.run — full slug preserved, no prefix strip.
+		expect(model.modelId).toBe("deepseek/deepseek-v4-pro");
+		expect(model.provider).toBe("workersai.chat");
+	});
+
+	it("with providers: dispatches through the unified run path, not the BYOK gateway", async () => {
+		const run = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						id: "chatcmpl-ds",
+						object: "chat.completion",
+						created: 0,
+						model: "deepseek-v4-pro",
+						choices: [
+							{
+								index: 0,
+								message: { role: "assistant", content: "Hello from deepseek" },
+								finish_reason: "stop",
+							},
+						],
+						usage: { prompt_tokens: 3, completion_tokens: 3, total_tokens: 6 },
+					}),
+					{ headers: { "content-type": "application/json", "cf-aig-log-id": "log-ds" } },
+				),
+		);
+		const gatewayRun = vi.fn(async () => new Response("unused"));
+		const binding = {
+			run,
+			gateway: vi.fn(() => ({ run: gatewayRun })),
+		} as unknown as Parameters<typeof createWorkersAI>[0] extends { binding: infer B }
+			? B
+			: never;
+
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [openaiWirePlugin],
+		});
+
+		let dispatch: { transport?: string } | undefined;
+		const result = await generateText({
+			model: workersai("deepseek/deepseek-v4-pro", {
+				onDispatch: (info) => {
+					dispatch = info;
+				},
+			}),
+			prompt: "Say hello.",
+		});
+
+		expect(result.text).toBe("Hello from deepseek");
+		// Unified-billing run path: the FULL slug goes to env.AI.run …
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0][0]).toBe("deepseek/deepseek-v4-pro");
+		// … and NOT the BYOK gateway universal (chat/completions) endpoint.
+		expect(gatewayRun).not.toHaveBeenCalled();
+		expect(dispatch?.transport).toBe("run");
+	});
+
+	it("without providers: defaults the run to the account gateway for a catalog slug", async () => {
+		// A bare "<vendor>/<model>" run model needs a gateway (third-party unified
+		// billing routes through one). Even with no `gateway` configured, the run
+		// path must default to "default" — otherwise env.AI.run gets no gateway and
+		// unified billing never engages.
+		const run = vi.fn(async () => ({ response: "hi from deepseek" }));
+		const binding = { run } as unknown as Parameters<typeof createWorkersAI>[0] extends {
+			binding: infer B;
+		}
+			? B
+			: never;
+		const workersai = createWorkersAI({ binding });
+
+		await generateText({
+			model: workersai("deepseek/deepseek-v4-pro"),
+			prompt: "hi",
+		});
+
+		expect(run).toHaveBeenCalledTimes(1);
+		expect(run.mock.calls[0][0]).toBe("deepseek/deepseek-v4-pro");
+		expect(run.mock.calls[0][2]).toMatchObject({ gateway: { id: "default" } });
+	});
+
+	it("without providers: rejects delegate-only options instead of silently dropping them", () => {
+		const { binding } = makeBinding();
+		const workersai = createWorkersAI({ binding, gateway: { id: "default" } });
+		// byok/transport/fallback/resume can't be honored on the bare run path — a
+		// silent drop would send a BYOK request out on unified billing. Throw.
+		expect(() => workersai("deepseek/deepseek-chat", { byok: true })).toThrow(
+			/gateway-delegate features/,
+		);
+		expect(() => workersai("deepseek/deepseek-v4-pro", { transport: "gateway" })).toThrow(
+			/no `providers` are configured/,
+		);
+		expect(() =>
+			workersai("deepseek/deepseek-v4-pro", {
+				fallback: { mode: "client", models: ["openai/gpt-4.1-mini"] },
+			}),
+		).toThrow(/gateway-delegate features/);
+	});
+
+	it("still allows explicit BYOK via the gateway path", () => {
+		const { binding, gwCalls } = (() => {
+			const gwCalls: unknown[] = [];
+			const b = {
+				run: vi.fn(async () => new Response("ok")),
+				gateway: vi.fn(() => ({
+					run: vi.fn(async (entries: unknown) => {
+						gwCalls.push(entries);
+						return new Response("ok");
+					}),
+				})),
+			} as unknown as Parameters<typeof createWorkersAI>[0] extends { binding: infer B }
+				? B
+				: never;
+			return { binding: b, gwCalls };
+		})();
+
+		const workersai = createWorkersAI({
+			binding,
+			gateway: { id: "default" },
+			providers: [openaiWirePlugin],
+		});
+		// byok opts into the gateway path even though deepseek defaults to run.
+		const model = workersai("deepseek/deepseek-chat", {
+			byok: true,
+			extraHeaders: { authorization: "Bearer real-key" },
+		});
+		expect(model.modelId).toBe("deepseek-chat");
+		void gwCalls;
 	});
 });

--- a/packages/workers-ai-provider/test/e2e/fixtures/gateway-worker/src/index.ts
+++ b/packages/workers-ai-provider/test/e2e/fixtures/gateway-worker/src/index.ts
@@ -89,6 +89,50 @@ export default {
 
 		try {
 			switch (url.pathname) {
+				// --- Run-path capability probe (issue #596) ---
+				// Drives a slug through the PURE run path (`env.AI.run`, unified
+				// billing, NO BYOK key, no delegate) to empirically determine which
+				// `<provider>/<model>` slugs Cloudflare's unified catalog serves via
+				// `/run`. Reports status + the `cf-aig-*` log headers (provider, path,
+				// wholesale/unified-billing) so we can classify `runCatalog` from real
+				// calls rather than a conservative guess.
+				case "/probe/run": {
+					const slug = body.slug ?? "openai/gpt-4.1-mini";
+					const ai = env.AI as unknown as {
+						run(m: string, i: unknown, o: unknown): Promise<Response>;
+					};
+					const started = Date.now();
+					try {
+						const resp = await ai.run(
+							slug,
+							{ messages: [{ role: "user", content: prompt }], max_tokens: 8 },
+							{ gateway: { id: gateway }, returnRawResponse: true },
+						);
+						const text = await resp.text();
+						const headers: Record<string, string> = {};
+						for (const [k, v] of resp.headers) {
+							if (k.startsWith("cf-aig")) headers[k] = v;
+						}
+						return json({
+							slug,
+							ok: resp.ok,
+							status: resp.status,
+							ms: Date.now() - started,
+							headers,
+							bodySnippet: text.slice(0, 400),
+						});
+					} catch (e) {
+						return json({
+							slug,
+							ok: false,
+							status: 0,
+							ms: Date.now() - started,
+							error: e instanceof Error ? e.message : String(e),
+							name: (e as Error)?.name,
+						});
+					}
+				}
+
 				// --- Run path: unified-billing, resumable (cf-aig-run-id) ---
 				case "/run/chat": {
 					let dispatch: DispatchInfo | undefined;

--- a/packages/workers-ai-provider/test/e2e/workers-ai-gateway.e2e.test.ts
+++ b/packages/workers-ai-provider/test/e2e/workers-ai-gateway.e2e.test.ts
@@ -332,4 +332,96 @@ describe.skipIf(!RUN)("AI Gateway delegate E2E", () => {
 			})();
 		});
 	});
+
+	// --- Run-path catalog membership (issue #596) ---
+	// The pure run path (`env.AI.run`, no BYOK key) cleanly distinguishes what
+	// Cloudflare serves on the unified run catalog from what it does not:
+	//   • unified, recognized ⇒ 200 (with credits) / 402 "insufficient balance"
+	//   • recognized, BYOK-only ⇒ 402 err 2021 "not available via unified billing"
+	//   • off-catalog ⇒ 404 err 7003 "model not found"
+	// This membership drives the `runCatalog`/`billing` flags in the provider
+	// registry, so we probe it live. Guards the #596 regression (deepseek/* — a
+	// real unified-billing run model — was misclassified as an off-catalog BYOK
+	// slug and forced onto the gateway universal endpoint) AND the follow-up
+	// correction (the rest of the OpenAI-wire long tail is genuinely off-catalog:
+	// mistral/cerebras/… return 7003, so they must stay `runCatalog:false`). See
+	// the `/probe/run` endpoint in the fixture worker.
+	describe("run-path catalog membership (#596)", () => {
+		/** err 7003 / "model not found" ⇒ the run router does not know this slug. */
+		function isModelNotFound(status: number, body: string): boolean {
+			return (
+				status === 404 ||
+				/"code"\s*:\s*7003|model not found|no such model|model_not_found/i.test(body)
+			);
+		}
+
+		// On the unified run catalog (recognized by the run router — NOT 7003).
+		// deepseek-v4-pro is the exact model from #596; deepseek-chat is a
+		// recognized-but-BYOK deepseek id (402 err 2021, still not a 7003); openai
+		// is a headline control.
+		const ON_CATALOG = [
+			"deepseek/deepseek-v4-pro",
+			"deepseek/deepseek-chat",
+			"openai/gpt-4.1-mini",
+		];
+		for (const slug of ON_CATALOG) {
+			it(`${slug} is recognized on the run path (not model-not-found)`, (ctx) => {
+				if (!ready) return ctx.skip("server not ready");
+				return (async () => {
+					const data = await post("/probe/run", { slug });
+					if (data.status === 0) {
+						return ctx.skip(`probe threw: ${String(data.error).slice(0, 80)}`);
+					}
+					const body = String(data.bodySnippet ?? "");
+					expect(
+						isModelNotFound(data.status as number, body),
+						`expected ${slug} to be a known run-catalog model, got ` +
+							`[${data.status}] ${body.slice(0, 140)}`,
+					).toBe(false);
+				})();
+			});
+		}
+
+		// OFF the unified run catalog: the OpenAI-wire long tail we reclassified back
+		// to `runCatalog:false` (BYOK gateway path only). Canonical model ids return
+		// 7003 model-not-found on the run path — which is precisely why they must not
+		// default to `env.AI.run`. If Cloudflare later adds any to unified billing,
+		// this flips to a failure that prompts a registry reclassification.
+		const OFF_CATALOG = [
+			"mistral/mistral-large-latest",
+			"cerebras/llama-3.3-70b",
+			"fireworks/llama-v3p1-8b-instruct",
+		];
+		for (const slug of OFF_CATALOG) {
+			it(`${slug} is NOT on the run catalog (model-not-found)`, (ctx) => {
+				if (!ready) return ctx.skip("server not ready");
+				return (async () => {
+					const data = await post("/probe/run", { slug });
+					if (data.status === 0) {
+						return ctx.skip(`probe threw: ${String(data.error).slice(0, 80)}`);
+					}
+					const body = String(data.bodySnippet ?? "");
+					expect(
+						isModelNotFound(data.status as number, body),
+						`expected ${slug} to be off the run catalog (7003), got ` +
+							`[${data.status}] ${body.slice(0, 140)}`,
+					).toBe(true);
+				})();
+			});
+		}
+
+		it("an unknown model id IS model-not-found (probe sanity)", (ctx) => {
+			if (!ready) return ctx.skip("server not ready");
+			return (async () => {
+				const data = await post("/probe/run", {
+					slug: "deepseek/definitely-not-a-real-model-xyz",
+				});
+				if (data.status === 0) {
+					return ctx.skip(`probe threw: ${String(data.error).slice(0, 80)}`);
+				}
+				const body = String(data.bodySnippet ?? "");
+				expect(isModelNotFound(data.status as number, body)).toBe(true);
+			})();
+		});
+	});
 });

--- a/packages/workers-ai-provider/test/gateway-delegate.test.ts
+++ b/packages/workers-ai-provider/test/gateway-delegate.test.ts
@@ -121,6 +121,30 @@ describe("selectTransport", () => {
 	it("throws when resume:true is requested for a non-run-catalog provider", () => {
 		expect(() => selectTransport({}, true, false)).toThrow(/resume:true is unavailable/);
 	});
+
+	// byok forwards the caller's own key — a gateway-path-only feature
+	it("routes byok through the gateway path with resume disabled", () => {
+		const s = selectTransport({ byok: true }, false);
+		expect(s.transport).toBe("gateway");
+		expect(s.resumeEnabled).toBe(false);
+		expect(s.warnings).toHaveLength(0);
+	});
+
+	it('throws when byok is combined with transport:"run"', () => {
+		expect(() => selectTransport({ byok: true, transport: "run" }, false)).toThrow(
+			/cannot forward a BYOK key/,
+		);
+	});
+
+	it("throws when byok is combined with resume:true", () => {
+		expect(() => selectTransport({ byok: true }, true)).toThrow(/byok cannot provide resume/);
+	});
+
+	it("throws when byok targets a run-path-only provider (no gateway path)", () => {
+		expect(() => selectTransport({ byok: true }, false, true, false)).toThrow(
+			/byok is unavailable/,
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -440,7 +464,8 @@ describe("createGatewayDelegate", () => {
 		const { binding, gwCalls } = makeBinding();
 		const { plugin, getFetch } = capturePlugin("openai");
 		const wai = createGatewayDelegate({ binding, gateway: "gw-1", providers: [plugin] });
-		// deepseek is BYOK (gateway path only)
+		// `byok` forces the gateway path (forwarding the caller's key), even for a
+		// run-catalog provider like deepseek that otherwise defaults to the run path.
 		wai("deepseek/deepseek-chat", {
 			byok: true,
 			extraHeaders: { authorization: "Bearer real" },

--- a/packages/workers-ai-provider/test/gateway-providers.test.ts
+++ b/packages/workers-ai-provider/test/gateway-providers.test.ts
@@ -33,14 +33,37 @@ describe("gateway provider registry", () => {
 		expect(findProviderBySlug("openai")?.runWireFormat).toBeUndefined();
 	});
 
-	it("maps the OpenAI-compatible long tail to the openai wire format (BYOK)", () => {
-		for (const slug of ["deepseek", "mistral", "perplexity", "openrouter", "cerebras"]) {
+	it("maps the whole OpenAI-compatible long tail to the openai wire format + a baseURL", () => {
+		for (const slug of [
+			"deepseek",
+			"mistral",
+			"perplexity",
+			"openrouter",
+			"cerebras",
+			"fireworks",
+		]) {
 			const info = findProviderBySlug(slug);
-			expect(info?.wireFormat).toBe("openai");
-			expect(info?.runCatalog).toBe(false);
-			expect(info?.billing).toBe("byok");
-			// shared openai plugin ⇒ must carry a baseURL so the URL host-strips right
-			expect(info?.baseURL).toBeTruthy();
+			expect(info?.wireFormat, slug).toBe("openai");
+			// shared openai plugin ⇒ must carry a baseURL so the gateway-path URL
+			// host-strips right
+			expect(info?.baseURL, slug).toBeTruthy();
+		}
+	});
+
+	it("classifies the long tail by real run-catalog membership (deepseek unified, rest BYOK)", () => {
+		// deepseek/* is the one long-tail provider Cloudflare serves on the unified
+		// run path (#596; env.AI.run 200 for deepseek-v4-pro) — defaults to run.
+		const deepseek = findProviderBySlug("deepseek");
+		expect(deepseek?.runCatalog).toBe(true);
+		expect(deepseek?.billing).toBe("unified");
+
+		// The rest are NOT on the unified run catalog — env.AI.run returns
+		// 7003 model-not-found (mistral/cerebras/openrouter/fireworks) or 2021
+		// use-BYOK (perplexity). They route through the BYOK gateway path.
+		for (const slug of ["mistral", "perplexity", "cerebras", "openrouter", "fireworks"]) {
+			const info = findProviderBySlug(slug);
+			expect(info?.runCatalog, slug).toBe(false);
+			expect(info?.billing, slug).toBe("byok");
 		}
 	});
 
@@ -177,15 +200,19 @@ describe("gateway provider registry", () => {
 		);
 	});
 
-	it("only flags run-catalog providers as the documented unified-billing set", () => {
+	it("lists exactly the providers Cloudflare serves on the unified run catalog", () => {
 		const catalog = GATEWAY_PROVIDERS.filter((p) => p.runCatalog)
 			.map((p) => p.resolverKey)
 			.sort();
-		// openai/anthropic/google/xai/groq are the original directory set; alibaba +
-		// minimax are unified-catalog chat providers verified live on the run path.
+		// The headline directory set (openai/anthropic/google/xai/groq), the
+		// run-only unified chat providers alibaba + minimax, and deepseek — the one
+		// OpenAI-wire long-tail provider actually on the unified `env.AI.run` catalog
+		// (#596). The rest of the long tail (mistral/perplexity/cerebras/openrouter/
+		// fireworks) is BYOK gateway-path only, verified by the e2e run-path probe.
 		expect(catalog).toEqual([
 			"alibaba",
 			"anthropic",
+			"deepseek",
 			"google",
 			"groq",
 			"minimax",


### PR DESCRIPTION
## Summary

Fixes #596. `workers-ai-provider@3.2.x` started treating **any** `"<vendor>/<model>"` id as a third-party BYOK AI Gateway slug. This regressed models like `deepseek/deepseek-v4-pro` that Cloudflare serves natively on the unified-billing **run path** (`env.AI.run`): without `providers` the provider threw at construction, and with `providers: [openai]` it routed to the gateway universal `chat/completions` (BYOK) endpoint and returned auth errors.

The fix restores run-path routing for natively-served catalog slugs, hardens the no-providers passthrough, and closes a parity gap in `tanstack-ai`.

### What changed

**`@cloudflare/gateway-core` — registry**
- Reclassify `deepseek/*` as `runCatalog: true` / `billing: "unified"` so it defaults to the resumable `env.AI.run` path (matching pre-3.2 behavior).
- The reclassification is **empirically driven**: `env.AI.run` returns distinct signals — `7003 model-not-found` for off-catalog slugs vs `2021 use-BYOK` for a recognized BYOK-only model. The rest of the OpenAI-wire long tail (`mistral`, `perplexity`, `cerebras`, `openrouter`, `fireworks`) genuinely returns model-not-found, so they stay `runCatalog: false` / BYOK gateway-path. Unified-billing eligibility is still decided **per-model** by Cloudflare's catalog (`deepseek/deepseek-v4-pro` is unified; `deepseek/deepseek-chat` still needs BYOK).

**`workers-ai-provider` — hardened run path**
- Unify the no-providers catalog-slug path with `dynamic/*` routes into a single `createRunPathModel` helper. It now:
  - defaults the gateway to the account `"default"` gateway (third-party unified billing needs one),
  - folds `cacheTtl` / `skipCache` / `metadata` / `collectLog` into the gateway options, and
  - **throws** on delegate-only options (`byok`, `transport: "gateway"`, `fallback`, `resume`, resume callbacks) instead of silently dropping them.
- `selectTransport`: treat `byok` as a gateway-path-only feature — it forces the gateway path and throws when combined with `transport: "run"`, `resume: true`, or a run-path-only provider.

**`@cloudflare/tanstack-ai` — binding-path parity**
- `createWorkersAiChat` in plain binding mode (`{ binding: env.AI }`, no `gateway`) now detects a non-`@cf`/non-`dynamic` third-party catalog slug and defaults it to the account `"default"` gateway, so unified billing engages. `@cf/*` and `dynamic/*` keep the plain binding path unchanged. Resume stays opt-in behind an explicit gateway (follow-up: #598).

**Docs**
- Updated the `workers-ai-provider` README routing/coverage/BYOK sections to reflect DeepSeek on the run catalog and the new no-providers behavior.

## Test plan

- [x] `nx run-many -t lint test:ci type-check build` across the 3 affected projects (`gateway-core`, `workers-ai-provider`, `tanstack-ai`) — green (454 unit tests in workers-ai-provider).
- [x] `oxfmt --check` + `oxlint` clean on all changed files.
- [x] **Live e2e** (`RUN_E2E=1 pnpm test:e2e:gateway`) against a real AI Gateway: the new "run-path catalog membership (#596)" probe passes — `deepseek/*` is recognized on the run catalog; `mistral`/`cerebras`/`fireworks` correctly return model-not-found. (The one unrelated failure was the pre-existing gateway-cache `MISS`/`HIT` flake, which passes in isolation.)
- [x] Added unit coverage for the new `selectTransport` `byok` branches and the `createRunPathModel` gateway-default / option-guard behavior.

## Changesets

- `workers-ai-provider`: patch — route native unified-billing catalog slugs through the run path.
- `@cloudflare/tanstack-ai`: patch — default third-party catalog slugs to the account gateway on the binding path.

Made with [Cursor](https://cursor.com)