### PR TITLE
fix(ai-gateway-provider): document createUnified structured outputs

### DIFF
--- a/packages/ai-gateway-provider/README.md
+++ b/packages/ai-gateway-provider/README.md
@@ -78,6 +78,21 @@ const { text } = await generateText({
 });
 ```
 
+If you're routing a model that supports structured outputs through
+`createUnified()`, enable them explicitly:
+
+```typescript
+const unified = createUnified({
+	apiKey: "{UPSTREAM_PROVIDER_API_KEY}",
+	supportsStructuredOutputs: true,
+});
+```
+
+`createUnified()` wraps `@ai-sdk/openai-compatible`, so structured outputs stay
+opt-in. Without `supportsStructuredOutputs: true`, schema output can be downgraded
+to plain JSON mode instead of sending the full JSON schema to the upstream
+provider.
+
 ## Automatic Fallback Example
 
 ```typescript


### PR DESCRIPTION
## Summary
- document that `createUnified()` needs `supportsStructuredOutputs: true` when routing structured-output-capable upstream models
- add the note directly under the unified dynamic-route example in the README

## Why
- issue #540 showed the behavior already worked, but the required option only existed in issue comments
- without the flag, schema output can fall back to plain JSON mode instead of forwarding the full JSON schema upstream

## Validation
- ran `pnpm exec oxfmt --write packages/ai-gateway-provider/README.md`
- no tests run (docs-only change)

Closes #540
