### PR TITLE
fix(tanstack-ai): omit empty Workers AI tools arrays

### DIFF
--- a/.changeset/empty-workers-tools.md
+++ b/.changeset/empty-workers-tools.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+fix(tanstack-ai): omit empty Workers AI tools arrays

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -283,6 +283,9 @@ export function createGatewayFetch(
 			}
 			delete query.model;
 			delete query.instructions;
+			if (Array.isArray(query.tools) && query.tools.length === 0) {
+				delete query.tools;
+			}
 		}
 
 		if (config.apiKey) {
@@ -448,7 +451,9 @@ function buildBindingInputs(body: Record<string, unknown>): Record<string, unkno
 	if (body.messages) {
 		inputs.messages = normalizeMessagesForBinding(body.messages as Record<string, unknown>[]);
 	}
-	if (body.tools) inputs.tools = body.tools;
+	if (body.tools && (!Array.isArray(body.tools) || body.tools.length > 0)) {
+		inputs.tools = body.tools;
+	}
 	if (typeof body.temperature === "number") inputs.temperature = body.temperature;
 	if (typeof body.max_tokens === "number") inputs.max_tokens = body.max_tokens;
 	if (body.response_format) inputs.response_format = body.response_format;

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -347,6 +347,24 @@ describe("createWorkersAiBindingFetch", () => {
 		]);
 	});
 
+	it("should omit empty tools from binding inputs", async () => {
+		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
+
+		const fetcher = createWorkersAiBindingFetch(binding);
+
+		await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				messages: [],
+				tools: [],
+			}),
+		});
+
+		const [, inputs] = binding.run.mock.calls[0]!;
+		expect(inputs).not.toHaveProperty("tools");
+	});
+
 	it("should normalize null content to empty string in messages", async () => {
 		const binding = mockBinding(vi.fn().mockResolvedValue({ response: "ok" }));
 		const fetcher = createWorkersAiBindingFetch(binding);

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -136,6 +136,18 @@ describe("createGatewayFetch", () => {
 			const request = mockBinding.run.mock.calls[0]![0];
 			expect(request.query).toEqual({ _raw: "not-json-content" });
 		});
+
+		it("should preserve empty tools for non-Workers AI providers", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o", messages: [], tools: [] }),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.tools).toEqual([]);
+		});
 	});
 
 	describe("credentials config", () => {
@@ -357,6 +369,47 @@ describe("createGatewayFetch", () => {
 			const request = mockBinding.run.mock.calls[0]![0];
 			expect(request.query.instructions).toBeUndefined();
 			expect(request.query.messages).toEqual([]);
+		});
+
+		it("should omit empty tools from query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [],
+					tools: [],
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query).not.toHaveProperty("tools");
+		});
+
+		it("should preserve non-empty tools in query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+			const tools = [{ type: "function", function: { name: "add", parameters: {} } }];
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [],
+					tools,
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.tools).toEqual(tools);
 		});
 
 		it("should not double-prefix run/ when URL path already contains it", async () => {


### PR DESCRIPTION
`@cloudflare/tanstack-ai` could pass `tools: []` to Workers AI, which some vLLM-backed models reject. This omits those empty arrays from the direct binding and Workers AI gateway paths, while non-empty tools and other providers stay unchanged. I checked the red/green cases, then ran the package suite, typecheck, build, lint, format, and the affected targets. Fixes #577
