### PR TITLE
feat(workers-ai-provider): support AI SDK v7

### DIFF
--- a/.changeset/witty-seas-attend.md
+++ b/.changeset/witty-seas-attend.md
@@ -1,0 +1,7 @@
+---
+"workers-ai-provider": major
+---
+
+Support the AI SDK v7. Peer dependencies now require `ai@^7`, `@ai-sdk/provider@^4`, and (for the AI Gateway sub-path plugins) `@ai-sdk/openai@^4`, `@ai-sdk/anthropic@^4`, and `@ai-sdk/google@^4`. AI SDK v6 is no longer supported.
+
+The Workers AI models (chat, embeddings, image, transcription, speech, reranking) continue to implement the `*ModelV3` specs, which AI SDK v7 still accepts unchanged, so their behavior is identical. The AI Gateway delegate — which wraps the third-party `@ai-sdk/*` providers routed through Gateway — is migrated from the `LanguageModelV3` spec to `LanguageModelV4` to match those providers on v7. No runtime behavior changes; the delegate remains a pass-through over the underlying provider models.

--- a/packages/workers-ai-provider/package.json
+++ b/packages/workers-ai-provider/package.json
@@ -65,21 +65,21 @@
 		"type-check": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@ai-sdk/anthropic": "^3.0.84",
-		"@ai-sdk/google": "^3.0.0",
-		"@ai-sdk/openai": "^3.0.71",
-		"@ai-sdk/provider": "^3.0.10",
+		"@ai-sdk/anthropic": "^4.0.0",
+		"@ai-sdk/google": "^4.0.0",
+		"@ai-sdk/openai": "^4.0.0",
+		"@ai-sdk/provider": "^4.0.0",
 		"@cloudflare/gateway-core": "workspace:*",
 		"@cloudflare/workers-types": "^4.20260628.1",
-		"ai": "^6.0.204",
+		"ai": "^7.0.0",
 		"zod": "^4.4.3"
 	},
 	"peerDependencies": {
-		"@ai-sdk/anthropic": "^3.0.0",
-		"@ai-sdk/google": "^3.0.0",
-		"@ai-sdk/openai": "^3.0.0",
-		"@ai-sdk/provider": "^3.0.0",
-		"ai": "^6.0.0"
+		"@ai-sdk/anthropic": "^4.0.0",
+		"@ai-sdk/google": "^4.0.0",
+		"@ai-sdk/openai": "^4.0.0",
+		"@ai-sdk/provider": "^4.0.0",
+		"ai": "^7.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@ai-sdk/anthropic": {

--- a/packages/workers-ai-provider/src/client-fallback.ts
+++ b/packages/workers-ai-provider/src/client-fallback.ts
@@ -1,8 +1,8 @@
 import type {
-	LanguageModelV3,
-	LanguageModelV3CallOptions,
-	LanguageModelV3GenerateResult,
-	LanguageModelV3StreamResult,
+	LanguageModelV4,
+	LanguageModelV4CallOptions,
+	LanguageModelV4GenerateResult,
+	LanguageModelV4StreamResult,
 } from "@ai-sdk/provider";
 import { type FallbackAttempt, WorkersAIFallbackError, WorkersAIGatewayError } from "./errors";
 import type { Transport } from "./gateway-delegate";
@@ -12,7 +12,7 @@ export interface FallbackLeg {
 	/** The model slug this leg dispatches. */
 	slug: string;
 	/** The built AI SDK model. */
-	model: LanguageModelV3;
+	model: LanguageModelV4;
 	/** Transport the leg uses. */
 	transport: Transport;
 }
@@ -26,13 +26,13 @@ export interface FallbackLeg {
  * produced a stream). Errors that surface *mid-stream* — after content has
  * already been emitted — are not recoverable here and propagate as-is.
  */
-export function createClientFallbackModel(legs: FallbackLeg[]): LanguageModelV3 {
+export function createClientFallbackModel(legs: FallbackLeg[]): LanguageModelV4 {
 	if (legs.length === 0) {
 		throw new Error("createClientFallbackModel requires at least one model leg.");
 	}
 	const primary = legs[0].model;
 
-	async function attempt<T>(run: (model: LanguageModelV3) => PromiseLike<T>): Promise<T> {
+	async function attempt<T>(run: (model: LanguageModelV4) => PromiseLike<T>): Promise<T> {
 		const attempts: FallbackAttempt[] = [];
 		for (const leg of legs) {
 			try {
@@ -54,16 +54,16 @@ export function createClientFallbackModel(legs: FallbackLeg[]): LanguageModelV3 
 	}
 
 	return {
-		specificationVersion: "v3",
+		specificationVersion: "v4",
 		provider: primary.provider,
 		modelId: primary.modelId,
 		supportedUrls: primary.supportedUrls,
 		doGenerate(
-			options: LanguageModelV3CallOptions,
-		): PromiseLike<LanguageModelV3GenerateResult> {
+			options: LanguageModelV4CallOptions,
+		): PromiseLike<LanguageModelV4GenerateResult> {
 			return attempt((m) => m.doGenerate(options));
 		},
-		doStream(options: LanguageModelV3CallOptions): PromiseLike<LanguageModelV3StreamResult> {
+		doStream(options: LanguageModelV4CallOptions): PromiseLike<LanguageModelV4StreamResult> {
 			return attempt((m) => m.doStream(options));
 		},
 	};

--- a/packages/workers-ai-provider/src/gateway-delegate.ts
+++ b/packages/workers-ai-provider/src/gateway-delegate.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import type { LanguageModelV4, LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import {
 	asText,
 	buildGatewayEntry,
@@ -154,7 +154,7 @@ export interface ProviderPlugin {
 		modelId: string;
 		fetch: typeof globalThis.fetch;
 		baseURL?: string;
-	}): LanguageModelV3;
+	}): LanguageModelV4;
 }
 
 // ---------------------------------------------------------------------------
@@ -401,7 +401,7 @@ export interface GatewayDelegateConfig {
 }
 
 export interface GatewayDelegate {
-	(slug: string, options?: DelegateCallOptions): LanguageModelV3;
+	(slug: string, options?: DelegateCallOptions): LanguageModelV4;
 }
 
 /**
@@ -431,7 +431,7 @@ export function createGatewayDelegate(config: GatewayDelegateConfig): GatewayDel
 	const buildOne = (
 		slug: string,
 		options: DelegateCallOptions,
-	): { model: LanguageModelV3; transport: Transport } => {
+	): { model: LanguageModelV4; transport: Transport } => {
 		const parsed = parseSlug(slug);
 		const info = resolveProvider(slug, parsed);
 
@@ -816,7 +816,7 @@ function makeServerFallbackModel(params: {
 	opts: DelegateCallOptions;
 	selection: Selection;
 	callOptions: DelegateCallOptions;
-}): LanguageModelV3 {
+}): LanguageModelV4 {
 	const { binding, gatewayId, gatewayOptions, legs, opts, selection, callOptions } = params;
 	const first = legs[0]!;
 
@@ -834,7 +834,7 @@ function makeServerFallbackModel(params: {
 
 	const dispatch = async (
 		method: "doGenerate" | "doStream",
-		options: LanguageModelV3CallOptions,
+		options: LanguageModelV4CallOptions,
 	): Promise<unknown> => {
 		// 1) Capture each leg's native request without hitting the network.
 		const entries: GatewayEntry[] = [];
@@ -854,7 +854,7 @@ function makeServerFallbackModel(params: {
 				...(leg.info.baseURL ? { baseURL: leg.info.baseURL } : {}),
 			});
 			try {
-				await (model[method] as (o: LanguageModelV3CallOptions) => Promise<unknown>)(
+				await (model[method] as (o: LanguageModelV4CallOptions) => Promise<unknown>)(
 					options,
 				);
 			} catch (e) {
@@ -905,21 +905,21 @@ function makeServerFallbackModel(params: {
 			fetch: (async () => resp) as typeof globalThis.fetch,
 			...(winner.info.baseURL ? { baseURL: winner.info.baseURL } : {}),
 		});
-		return (winnerModel[method] as (o: LanguageModelV3CallOptions) => Promise<unknown>)(
+		return (winnerModel[method] as (o: LanguageModelV4CallOptions) => Promise<unknown>)(
 			options,
 		);
 	};
 
 	return {
-		specificationVersion: "v3",
+		specificationVersion: "v4",
 		provider: refModel.provider,
 		modelId: refModel.modelId,
 		supportedUrls: refModel.supportedUrls,
 		doGenerate(options) {
-			return dispatch("doGenerate", options) as ReturnType<LanguageModelV3["doGenerate"]>;
+			return dispatch("doGenerate", options) as ReturnType<LanguageModelV4["doGenerate"]>;
 		},
 		doStream(options) {
-			return dispatch("doStream", options) as ReturnType<LanguageModelV3["doStream"]>;
+			return dispatch("doStream", options) as ReturnType<LanguageModelV4["doStream"]>;
 		},
-	} as LanguageModelV3;
+	} as LanguageModelV4;
 }

--- a/packages/workers-ai-provider/src/index.ts
+++ b/packages/workers-ai-provider/src/index.ts
@@ -508,7 +508,7 @@ export function createWorkersAI(options: WorkersAISettings): WorkersAI {
 					"catalog",
 				);
 			}
-			// The delegate returns a `LanguageModelV3` built by the configured plugin.
+			// The delegate returns a `LanguageModelV4` built by the configured plugin.
 			// It's structurally compatible with the AI SDK consumers this provider is
 			// used with; the cast keeps the public return type unchanged.
 			return getDelegate(modelId)(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1777,17 +1777,17 @@ importers:
   packages/workers-ai-provider:
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.84
-        version: 3.0.84(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.12(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^3.0.0
-        version: 3.0.82(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.12(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.71
-        version: 3.0.71(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.11(zod@4.4.3)
       '@ai-sdk/provider':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: ^4.0.0
+        version: 4.0.3
       '@cloudflare/gateway-core':
         specifier: workspace:*
         version: link:../gateway-core
@@ -1795,8 +1795,8 @@ importers:
         specifier: ^4.20260628.1
         version: 4.20260628.1
       ai:
-        specifier: ^6.0.204
-        version: 6.0.204(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.22(zod@4.4.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1815,6 +1815,12 @@ packages:
   '@ai-sdk/anthropic@3.0.84':
     resolution: {integrity: sha512-BIDaHmCHs6Sr5VUsEkTbbVlAN4GWjg97X9x/IfXyviLtzsXvffui9XIcZugkAi1Ri6FnvI5T5qDGh5YLnSuzRg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@4.0.12':
+    resolution: {integrity: sha512-IquWNkGRSF2ulYJ6YIIUqMsNAIDeZFB3/4W92aSOtCxH1TfuVoq3qw4M4TxTxIw4As9cnkeRLe7b9LDMzPDsnA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1866,6 +1872,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.16':
+    resolution: {integrity: sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google-vertex@4.0.145':
     resolution: {integrity: sha512-48wlju7ksjARn6aa1vUZtPFDp+PXadHDpOsE8YHvi4wKVUf7Sxma+WYZNkIDts1b9Alv0BBZlkn5azLNciHD6g==}
     engines: {node: '>=18'}
@@ -1875,6 +1887,12 @@ packages:
   '@ai-sdk/google@3.0.82':
     resolution: {integrity: sha512-md+M92ZJuPIMU2p4v1rGLpJJWTmTh/vpJPkMnQbEdcLaPTZxRaroIKSnmL/9UGJV0BORJlHNDJegkcnhVpTmDA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@4.0.12':
+    resolution: {integrity: sha512-4Rw4viFwH2Wprx6OssZzhV/KgNWaA7qYr5Kg28AlZ7r3sEvyXH0kDZtZok7onPjr0RuFTg2EjCjTIeoCesg0Ww==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1902,6 +1920,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@4.0.11':
+    resolution: {integrity: sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/perplexity@3.0.35':
     resolution: {integrity: sha512-TAWWUF2W+qJrjtWhKN61o0dNguqS7NTDpILlsa39TTeCBZghlyLtiEIGjeclWzP/P/InicXza8ebw+dkGN36lg==}
     engines: {node: '>=18'}
@@ -1914,9 +1938,19 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/react@3.0.206':
     resolution: {integrity: sha512-26gbPT876BZVXJlSNjqkCDOFiqfxAAhYn+a/ryV6ce5TWo6EfWQZeEiLrZOS6bxaOi7xxkB5uPZaZKFaIJndjQ==}
@@ -3992,6 +4026,9 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@workos-inc/node@10.7.0':
     resolution: {integrity: sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ==}
     engines: {node: '>=22.11.0'}
@@ -4055,6 +4092,12 @@ packages:
   ai@6.0.204:
     resolution: {integrity: sha512-SudB8rUwaVhpWF8+qTJcxUptXPIdN9rWMknzTT3WbKa2QwiGRshyepFKNkDILWm882LgqlEyRZgKhNT14j0jpQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.22:
+    resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -6601,6 +6644,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/anthropic@4.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/azure@3.0.74(zod@4.4.3)':
     dependencies:
       '@ai-sdk/deepseek': 2.0.38(zod@4.4.3)
@@ -6661,6 +6710,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/google-vertex@4.0.145(patch_hash=5015d8c7ff40e99b6b6d204430f0750dda43beda4beda4e6817b38cd2b057184)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.84(zod@4.4.3)
@@ -6678,6 +6734,13 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      zod: 4.4.3
+    optional: true
+
+  '@ai-sdk/google@4.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/groq@3.0.41(zod@4.4.3)':
@@ -6706,6 +6769,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/openai@4.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/perplexity@3.0.35(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -6720,7 +6789,19 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -8725,6 +8806,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
   '@workos-inc/node@10.7.0': {}
 
   '@yarnpkg/lockfile@1.1.0': {}
@@ -8786,6 +8869,13 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
+
+  ai@7.0.22(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.18.0):


### PR DESCRIPTION
## What

Upgrades `workers-ai-provider` to support **AI SDK v7** (now GA / npm `latest`).

- Peer + dev deps bumped: `ai@^7`, `@ai-sdk/provider@^4`, and the optional AI Gateway plugin peers `@ai-sdk/openai@^4`, `@ai-sdk/anthropic@^4`, `@ai-sdk/google@^4`.
- The AI Gateway **delegate** (which wraps third-party `@ai-sdk/*` providers routed through Gateway) is migrated from the `LanguageModelV3` model spec to `LanguageModelV4`.
- The **Workers AI models** (chat, embeddings, image, transcription, speech, reranking) are left on the `*ModelV3` specs — unchanged.

This is a **major** for the package: AI SDK v6 is no longer supported (see "Why v7-only", below). A changeset is included.

## Why

The Cloudflare Agents SDK now ships AI SDK v7 tracing support, but `workers-ai-provider` peered `ai@^6` only, which blocked using real Workers AI models on a v7 app. This unblocks that.

## Spec delta (v6 → v7)

`ai@7` depends on `@ai-sdk/provider@4`, which introduces the `*ModelV4` specs. Two facts made this migration small:

1. **`@ai-sdk/provider@4` is a superset of `@ai-sdk/provider@3`.** It adds the V4 specs while re-exporting the V3 specs *byte-identical* (verified by diffing the `.d.ts`), so the existing V3 model implementations compile against provider@4 with no changes.
2. **AI SDK v7 still accepts V3 models.** Every public model-type alias in `ai@7` is a union that includes V3:
   - `LanguageModel = … | LanguageModelV4 | LanguageModelV3 | LanguageModelV2`
   - `EmbeddingModel`, `ImageModel`, `SpeechModel`, `TranscriptionModel`, `RerankingModel` likewise include their `…V3`.

So the Workers AI models need **no** spec migration — they remain V3 and are accepted by v7 unchanged. The only code that had to move is the gateway delegate, because under v7 the wrapped `@ai-sdk/*` sub-providers (e.g. `createOpenAI(...).chat(...)`) return `LanguageModelV4`, which is not assignable to the delegate's `LanguageModelV3`-typed slots (`ProviderPlugin.create()`, `FallbackLeg.model`, the server-fallback model). Those are all **pure pass-throughs** — they forward call options and results without inspecting content parts — so the migration is a mechanical `V3 → V4` retype (`specificationVersion: "v3" → "v4"` and the referenced `LanguageModelV3* → LanguageModelV4*` option/result types). No runtime behavior changes.

### Why v7-only rather than `^6 || ^7`

The delegate now references `LanguageModelV4`, a type that does not exist in `@ai-sdk/provider@3`. A single published `.d.mts` can't type-serve both majors for that subsystem, so keeping v6 in the peer range would leave v6 consumers with a dangling type reference. Dropping v6 keeps the type surface honest. Happy to revisit if maintainers prefer a spec-agnostic delegate typing to preserve dual support.

## Files changed

- `package.json` — peer/dev dep bumps.
- `src/gateway-delegate.ts`, `src/client-fallback.ts` — `LanguageModelV3 → LanguageModelV4` (pass-through retype).
- `src/index.ts` — one stale comment updated (`V3 → V4`).
- Native model files (chat/embedding/image/speech/transcription/reranking) — untouched.

## Verification (against `ai@7.0.22`, `@ai-sdk/provider@4.0.3`, `@ai-sdk/openai@4.0.11`)

- `tsc --noEmit` — clean.
- `tsdown` build — clean (all `.mjs` + `.d.mts` entries emit).
- Unit tests — **454 passed (22 files)**.
- Extra scratch assertion (not committed): `createWorkersAI(...)` chat / embedding / image / speech / transcription / reranking models each `satisfies` the corresponding `ai@7` model-type alias — compiles clean.

E2E tests (`test/e2e/**`, real bindings/network) were not run here.

## Left for maintainers

- Confirm the **v7-only** (major) direction vs. dual `^6 || ^7`.
- Decide whether to also migrate the native Workers AI models to the V4 specs for uniformity (not required for v7 support; would be a larger, higher-risk diff touching content/part shapes).
