### PR TITLE
fix(workers-ai-provider): don't duplicate streaming text on dual-format chunks

### DIFF
--- a/.changeset/workers-ai-provider-streaming-no-double-text.md
+++ b/.changeset/workers-ai-provider-streaming-no-double-text.md
@@ -1,0 +1,5 @@
+---
+"workers-ai-provider": patch
+---
+
+Fix doubled streaming text. Workers AI's OpenAI-compatible streaming emits both the native top-level `response` field and `choices[0].delta.content` in the same SSE chunk with identical content; the stream mapper emitted a `text-delta` for each, doubling every token (e.g. `"Hello world"` → `"HelloHello world world"`). The two are now treated as mutually exclusive — `choices[0].delta.content` is used only when the native `response` field is absent for that chunk.

--- a/packages/workers-ai-provider/src/streaming.ts
+++ b/packages/workers-ai-provider/src/streaming.ts
@@ -221,7 +221,16 @@ export function getMappedStream(
 						});
 					}
 
-					const textDelta = delta.content as string | undefined;
+					// Workers AI's OpenAI-compatible streaming emits BOTH the native
+					// top-level `response` field and `choices[0].delta.content` in the same
+					// chunk, with identical content. Emitting a text-delta for each doubles
+					// the output (e.g. "Hello" -> "HelloHello"). Treat them as mutually
+					// exclusive: only use `choices[].delta.content` when the native
+					// `response` field was absent for this chunk.
+					const textDelta =
+						nativeResponse != null && nativeResponse !== ""
+							? undefined
+							: (delta.content as string | undefined);
 					if (textDelta && textDelta.length > 0) {
 						if (bufferContentForSalvage) {
 							contentBuffer += textDelta;

--- a/packages/workers-ai-provider/test/stream-text.test.ts
+++ b/packages/workers-ai-provider/test/stream-text.test.ts
@@ -57,6 +57,52 @@ describe("REST API - Streaming Text Tests", () => {
 		expect(accumulatedText).toBe("Hello chunk1Hello chunk2");
 	});
 
+	it("should not duplicate text when a chunk carries BOTH `response` and `choices[].delta.content`", async () => {
+		// Workers AI's OpenAI-compatible streaming emits both the native `response`
+		// field and `choices[0].delta.content` in the same chunk, with identical
+		// content. The mapper must treat them as mutually exclusive, otherwise every
+		// token is emitted twice ("Hello world" -> "HelloHello world world").
+		server.use(
+			http.post(
+				`https://api.cloudflare.com/client/v4/accounts/${TEST_ACCOUNT_ID}/ai/run/${TEST_MODEL}`,
+				async () => {
+					return new Response(
+						[
+							`data: {"response":"Hello ","choices":[{"delta":{"content":"Hello "},"finish_reason":null}]}\n\n`,
+							`data: {"response":"world","choices":[{"delta":{"content":"world"},"finish_reason":null}]}\n\n`,
+							`data: {"response":"","choices":[{"delta":{},"finish_reason":"stop"}]}\n\n`,
+							"data: [DONE]\n\n",
+						].join(""),
+						{
+							headers: {
+								"Content-Type": "text/event-stream",
+								"Transfer-Encoding": "chunked",
+							},
+							status: 200,
+						},
+					);
+				},
+			),
+		);
+
+		const workersai = createWorkersAI({
+			accountId: TEST_ACCOUNT_ID,
+			apiKey: TEST_API_KEY,
+		});
+
+		const result = streamText({
+			model: workersai(TEST_MODEL),
+			prompt: "Say hello world",
+		});
+
+		let accumulatedText = "";
+		for await (const chunk of result.textStream) {
+			accumulatedText += chunk;
+		}
+
+		expect(accumulatedText).toBe("Hello world");
+	});
+
 	it("should handle chunk without 'response' field gracefully", async () => {
 		server.use(
 			http.post(


### PR DESCRIPTION
## Problem
Workers AI's OpenAI-compatible streaming emits **both** the native top-level `response` field **and** `choices[0].delta.content` in the **same** SSE chunk, with identical content (observed with `@cf/meta/llama-3.3-70b-instruct-fp8-fast`).

In `streaming.ts`, `getMappedStream()` handles the two formats in **two independent `if` blocks** (native `response` ~L168, OpenAI `choices[0].delta.content` ~L224), each `enqueue`-ing a `text-delta`. When a chunk carries both, every token is emitted **twice**, so streamed output is doubled and the doubled text is what consumers persist/render:

```
"Hello world"  ->  "HelloHello world world"
```

This reproduces reliably for any model whose streaming response includes both fields.

## Fix
Treat the native and OpenAI text fields as **mutually exclusive**: use `choices[0].delta.content` only when the native `response` field is absent for that chunk (they're redundant duplicates when both present). One-line behavioral change plus a comment.

## Test
Adds a regression test in `stream-text.test.ts` that streams a chunk carrying both `response` and `choices[].delta.content`:
- **Before** the fix it fails with `Received: "Hello Hello worldworld"`.
- **After** the fix it passes (`"Hello world"`).

Full `workers-ai-provider` suite green (455 tests). Formatted with `oxfmt`, lint-clean.

## Changeset
`patch` for `workers-ai-provider`.

---
_Found while integrating `workers-ai-provider` into a Cloudflare-Workers app; happy to adjust the approach if you'd prefer the guard on the native branch instead._