### PR TITLE
Preserve OpenAI-shaped Workers AI responses

### DIFF
--- a/.changeset/plain-bindings-preserve.md
+++ b/.changeset/plain-bindings-preserve.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/tanstack-ai": patch
+---
+
+Preserve OpenAI-compatible response objects returned by Workers AI bindings.

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -363,6 +363,16 @@ function wrapWorkersAiResultAsOpenAI(
 	model: string,
 	salvageContext?: SalvageContext,
 ): Response {
+	if (
+		typeof result === "object" &&
+		result !== null &&
+		Array.isArray((result as Record<string, unknown>).choices)
+	) {
+		return new Response(JSON.stringify(result), {
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
 	const responseObj =
 		typeof result === "object" && result !== null
 			? (result as Record<string, unknown>)

--- a/packages/tanstack-ai/test/binding-fetch.test.ts
+++ b/packages/tanstack-ai/test/binding-fetch.test.ts
@@ -49,6 +49,32 @@ describe("createWorkersAiBindingFetch", () => {
 		expect(json.choices[0]!.finish_reason).toBe("stop");
 	});
 
+	it("should preserve OpenAI-shaped non-streaming binding responses", async () => {
+		const openAiResponse = {
+			id: "chatcmpl-openai-shaped",
+			object: "chat.completion",
+			choices: [
+				{
+					index: 0,
+					message: { role: "assistant", content: '{"id":"A1"}' },
+					finish_reason: "stop",
+				},
+			],
+		};
+		const binding = mockBinding(vi.fn().mockResolvedValue(openAiResponse));
+
+		const fetcher = createWorkersAiBindingFetch(binding);
+		const response = await fetcher("https://api.openai.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "@cf/meta/llama-4-scout-17b-16e-instruct",
+				messages: [{ role: "user", content: "Return an id" }],
+			}),
+		});
+
+		expect(await response.json()).toEqual(openAiResponse);
+	});
+
 	it("should stringify object responses in non-streaming mode", async () => {
 		const binding = mockBinding(
 			vi.fn().mockResolvedValue({ response: { key: "value", nested: { a: 1 } } }),


### PR DESCRIPTION
Fixes #628

Non-streaming Workers AI bindings can return an OpenAI-shaped chat.completion response with a choices array. The existing wrapper assumed the native { response } shape, discarded the content, and caused structured output validation to receive an empty string.

This change preserves OpenAI-shaped responses unchanged and adds a regression test for structured JSON content.

Validation:
- corepack pnpm --filter @cloudflare/tanstack-ai test -- --run test/binding-fetch.test.ts (309 tests passed)
- corepack pnpm --filter @cloudflare/tanstack-ai type-check