### PR TITLE
feat(tanstack-ai): add REST-only byokAlias for stored BYOK keys

### DIFF
--- a/.changeset/tanstack-ai-byok-alias.md
+++ b/.changeset/tanstack-ai-byok-alias.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/tanstack-ai": minor
+---
+
+Add `byokAlias` on AI Gateway **credentials / REST** config so OpenAI, Anthropic, Grok, OpenRouter, and Workers AI (gateway REST) can select a stored BYOK key via `cf-aig-byok-alias`. The AI binding does not honor this header for third-party models. Gemini is unchanged — it does not go through `createGatewayFetch`.

--- a/.changeset/tanstack-ai-byok-alias.md
+++ b/.changeset/tanstack-ai-byok-alias.md
@@ -2,4 +2,4 @@
 "@cloudflare/tanstack-ai": minor
 ---
 
-Add `byokAlias` on AI Gateway **credentials / REST** config so OpenAI, Anthropic, Gemini, Grok, OpenRouter, and Workers AI (gateway REST) can select a stored BYOK key via `cf-aig-byok-alias`. The AI binding does not honor this header for third-party models. Gemini maps the header through `httpOptions.headers` (it does not use `createGatewayFetch`).
+Add `byokAlias` on the shared `AiGatewayConfig` so every gateway adapter (OpenAI, Anthropic, Gemini, Grok, OpenRouter, Workers AI) can select a stored BYOK key via `cf-aig-byok-alias`. `createGatewayFetch` forwards it on REST; Gemini maps the same field through `httpOptions.headers`. The AI binding ignores the header for third-party models.

--- a/.changeset/tanstack-ai-byok-alias.md
+++ b/.changeset/tanstack-ai-byok-alias.md
@@ -2,4 +2,4 @@
 "@cloudflare/tanstack-ai": minor
 ---
 
-Add `byokAlias` on AI Gateway **credentials / REST** config so OpenAI, Anthropic, Grok, OpenRouter, and Workers AI (gateway REST) can select a stored BYOK key via `cf-aig-byok-alias`. The AI binding does not honor this header for third-party models. Gemini is unchanged — it does not go through `createGatewayFetch`.
+Add `byokAlias` on AI Gateway **credentials / REST** config so OpenAI, Anthropic, Gemini, Grok, OpenRouter, and Workers AI (gateway REST) can select a stored BYOK key via `cf-aig-byok-alias`. The AI binding does not honor this header for third-party models. Gemini maps the header through `httpOptions.headers` (it does not use `createGatewayFetch`).

--- a/docs/concepts/binding-vs-rest.md
+++ b/docs/concepts/binding-vs-rest.md
@@ -35,7 +35,8 @@ const provider = createWorkersAI({
 | ------------------------------------------------- | ------- | ---- |
 | Chat / generate / stream                          | ✅      | ✅   |
 | Image / embeddings / transcription / TTS / rerank | ✅      | ✅   |
-| Gateway routing (caching, metadata, BYOK)         | ✅      | ✅   |
+| Gateway routing (caching, metadata)               | ✅      | ✅   |
+| BYOK stored-key alias (`cf-aig-byok-alias`)       | ❌      | ✅   |
 | Server-side fallback                              | ✅      | ✅   |
 | **Resumable streaming** _(coming soon)_           | ✅      | ❌   |
 

--- a/docs/tanstack-ai/README.md
+++ b/docs/tanstack-ai/README.md
@@ -166,8 +166,9 @@ const adapter = createOpenAiChat("gpt-5", {
 });
 ```
 
-`byokAlias` (`cf-aig-byok-alias`) is credentials / REST only. The AI binding
-does not select a non-`default` stored key for third-party models:
+`byokAlias` (`cf-aig-byok-alias`) is credentials / REST only — including
+Gemini (`createGeminiChat` via `httpOptions.headers`). The AI binding does
+not select a non-`default` stored key for third-party models:
 
 ```ts
 const adapter = createOpenAiChat("gpt-5", {

--- a/docs/tanstack-ai/README.md
+++ b/docs/tanstack-ai/README.md
@@ -166,6 +166,18 @@ const adapter = createOpenAiChat("gpt-5", {
 });
 ```
 
+`byokAlias` (`cf-aig-byok-alias`) is credentials / REST only. The AI binding
+does not select a non-`default` stored key for third-party models:
+
+```ts
+const adapter = createOpenAiChat("gpt-5", {
+	accountId: env.CF_ACCOUNT_ID,
+	gatewayId: "my-gateway",
+	cfApiKey: env.CF_AIG_TOKEN,
+	byokAlias: "development",
+});
+```
+
 See the [package README](../../packages/tanstack-ai/README.md) for the full list
 of provider factories (chat / summarize / image / transcription / TTS / video)
 and the four Workers AI configuration modes.

--- a/packages/tanstack-ai/README.md
+++ b/packages/tanstack-ai/README.md
@@ -234,6 +234,23 @@ const adapter = createOpenAiChat("gpt-4o", {
 });
 ```
 
+**BYOK alias (credentials / REST only):**
+
+`cf-aig-byok-alias` is a provider-passthrough header. The AI binding does not
+honor it for third-party models — only the `default` stored key is consulted
+there. Same option on `createAnthropicChat` / `createGrokChat` /
+`createOpenRouterChat` / `createWorkersAiChat` (gateway REST). Gemini does not
+use `createGatewayFetch`.
+
+```typescript
+const adapter = createOpenRouterChat("openai/gpt-4o", {
+	accountId: "your-account-id",
+	gatewayId: "your-gateway-id",
+	cfApiKey: "your-cf-api-key",
+	byokAlias: "development",
+});
+```
+
 ### Workers AI through Gateway
 
 ```typescript

--- a/packages/tanstack-ai/README.md
+++ b/packages/tanstack-ai/README.md
@@ -239,8 +239,8 @@ const adapter = createOpenAiChat("gpt-4o", {
 `cf-aig-byok-alias` is a provider-passthrough header. The AI binding does not
 honor it for third-party models — only the `default` stored key is consulted
 there. Same option on `createAnthropicChat` / `createGrokChat` /
-`createOpenRouterChat` / `createWorkersAiChat` (gateway REST). Gemini does not
-use `createGatewayFetch`.
+`createOpenRouterChat` / `createWorkersAiChat` (gateway REST) /
+`createGeminiChat` (credentials / `httpOptions.headers`).
 
 ```typescript
 const adapter = createOpenRouterChat("openai/gpt-4o", {

--- a/packages/tanstack-ai/src/adapters/gemini.ts
+++ b/packages/tanstack-ai/src/adapters/gemini.ts
@@ -1,14 +1,14 @@
 import {
-	GeminiTextAdapter,
-	GeminiImageAdapter,
-	createGeminiSummarize as createGeminiSummarizeAdapter,
-	GeminiTTSAdapter,
-	GeminiTextModels,
-	GeminiImageModels,
-	GeminiTTSModels,
-	type GeminiTextModel,
-	type GeminiImageModel,
-	type GeminiSummarizeModel,
+  GeminiTextAdapter,
+  GeminiImageAdapter,
+  createGeminiSummarize as createGeminiSummarizeAdapter,
+  GeminiTTSAdapter,
+  GeminiTextModels,
+  GeminiImageModels,
+  GeminiTTSModels,
+  type GeminiTextModel,
+  type GeminiImageModel,
+  type GeminiSummarizeModel,
 } from "@tanstack/ai-gemini";
 
 /** Derived from GeminiTTSModels since @tanstack/ai-gemini doesn't export a GeminiTTSModel type. */
@@ -21,7 +21,14 @@ import type { AiGatewayCredentialsConfig, AiGatewayConfig } from "../utils/creat
  * Includes cache control options from AiGatewayConfig.
  * See {@link https://github.com/googleapis/js-genai/issues/999 | googleapis/js-genai#999}.
  */
-export type GeminiGatewayConfig = AiGatewayCredentialsConfig & AiGatewayConfig;
+export type GeminiGatewayConfig = AiGatewayCredentialsConfig &
+  AiGatewayConfig & {
+    /**
+     * BYOK stored-key alias (`cf-aig-byok-alias`). Gemini is credentials /
+     * provider-passthrough only, so this header is honored.
+     */
+    byokAlias?: string;
+  };
 
 /**
  * Build Gemini client config that routes through AI Gateway.
@@ -34,54 +41,57 @@ export type GeminiGatewayConfig = AiGatewayCredentialsConfig & AiGatewayConfig;
  * Tracking issue: https://github.com/googleapis/js-genai/issues/999
  */
 function buildGeminiGatewayConfig(config: GeminiGatewayConfig) {
-	// Runtime guard: catch binding configs that bypass TypeScript (JS callers, `as any`, etc.)
-	// We integrate with the Gemini SDK via `httpOptions` (baseUrl + headers), which allows
-	// gateway routing and cache control but not request interception. A binding config
-	// requires a custom `fetch` to route through the AI Gateway binding, and the Google
-	// GenAI SDK doesn't support that yet.
-	if ("binding" in config) {
-		throw new Error(
-			"Gemini adapters do not support binding config. " +
-				"The Google GenAI SDK does not support a custom fetch function — " +
-				"only credential-based config ({ accountId, gatewayId }) is supported. " +
-				"See https://github.com/googleapis/js-genai/issues/999",
-		);
-	}
+  // Runtime guard: catch binding configs that bypass TypeScript (JS callers, `as any`, etc.)
+  // We integrate with the Gemini SDK via `httpOptions` (baseUrl + headers), which allows
+  // gateway routing and cache control but not request interception. A binding config
+  // requires a custom `fetch` to route through the AI Gateway binding, and the Google
+  // GenAI SDK doesn't support that yet.
+  if ("binding" in config) {
+    throw new Error(
+      "Gemini adapters do not support binding config. " +
+        "The Google GenAI SDK does not support a custom fetch function — " +
+        "only credential-based config ({ accountId, gatewayId }) is supported. " +
+        "See https://github.com/googleapis/js-genai/issues/999",
+    );
+  }
 
-	const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {};
 
-	if (config.apiKey && config.cfApiKey) {
-		headers["cf-aig-authorization"] = `Bearer ${config.cfApiKey}`;
-	}
+  if (config.apiKey && config.cfApiKey) {
+    headers["cf-aig-authorization"] = `Bearer ${config.cfApiKey}`;
+  }
 
-	if (config.skipCache) {
-		headers["cf-aig-skip-cache"] = "true";
-	}
-	if (typeof config.cacheTtl === "number") {
-		headers["cf-aig-cache-ttl"] = String(config.cacheTtl);
-	}
-	if (typeof config.customCacheKey === "string") {
-		headers["cf-aig-cache-key"] = config.customCacheKey;
-	}
-	if (typeof config.metadata === "object") {
-		headers["cf-aig-metadata"] = JSON.stringify(config.metadata);
-	}
+  if (config.skipCache) {
+    headers["cf-aig-skip-cache"] = "true";
+  }
+  if (typeof config.cacheTtl === "number") {
+    headers["cf-aig-cache-ttl"] = String(config.cacheTtl);
+  }
+  if (typeof config.customCacheKey === "string") {
+    headers["cf-aig-cache-key"] = config.customCacheKey;
+  }
+  if (typeof config.metadata === "object") {
+    headers["cf-aig-metadata"] = JSON.stringify(config.metadata);
+  }
+  if (typeof config.byokAlias === "string") {
+    headers["cf-aig-byok-alias"] = config.byokAlias;
+  }
 
-	const apiKey = config.apiKey ?? config.cfApiKey;
+  const apiKey = config.apiKey ?? config.cfApiKey;
 
-	if (!apiKey) {
-		throw new Error(
-			"If you want to use BYOK or unified billing, you need to pass the Cloudflare AI Gateway API key.",
-		);
-	}
+  if (!apiKey) {
+    throw new Error(
+      "If you want to use BYOK or unified billing, you need to pass the Cloudflare AI Gateway API key.",
+    );
+  }
 
-	return {
-		apiKey,
-		httpOptions: {
-			baseUrl: `https://gateway.ai.cloudflare.com/v1/${config.accountId}/${config.gatewayId}/google-ai-studio`,
-			headers: Object.keys(headers).length > 0 ? headers : undefined,
-		},
-	};
+  return {
+    apiKey,
+    httpOptions: {
+      baseUrl: `https://gateway.ai.cloudflare.com/v1/${config.accountId}/${config.gatewayId}/google-ai-studio`,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    },
+  };
 }
 
 /** Alias for consistency with other providers (AnthropicChatModel, GrokChatModel, etc.) */
@@ -95,10 +105,10 @@ export type GeminiChatModel = GeminiTextModel;
  * @param config Configuration options (credentials only)
  */
 export function createGeminiChat(
-	model: GeminiChatModel,
-	config: GeminiGatewayConfig,
+  model: GeminiChatModel,
+  config: GeminiGatewayConfig,
 ): AnyTextAdapter {
-	return new GeminiTextAdapter(buildGeminiGatewayConfig(config), model);
+  return new GeminiTextAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 /**
@@ -109,7 +119,7 @@ export function createGeminiChat(
  * @param config Configuration options (credentials only)
  */
 export function createGeminiImage(model: GeminiImageModel, config: GeminiGatewayConfig) {
-	return new GeminiImageAdapter(buildGeminiGatewayConfig(config), model);
+  return new GeminiImageAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 /**
@@ -120,11 +130,11 @@ export function createGeminiImage(model: GeminiImageModel, config: GeminiGateway
  * @param config Configuration options (credentials only)
  */
 export function createGeminiSummarize(
-	model: GeminiSummarizeModel,
-	config: GeminiGatewayConfig,
+  model: GeminiSummarizeModel,
+  config: GeminiGatewayConfig,
 ): AnySummarizeAdapter {
-	const { apiKey, httpOptions } = buildGeminiGatewayConfig(config);
-	return createGeminiSummarizeAdapter(apiKey, model, { httpOptions });
+  const { apiKey, httpOptions } = buildGeminiGatewayConfig(config);
+  return createGeminiSummarizeAdapter(apiKey, model, { httpOptions });
 }
 
 /**
@@ -137,14 +147,14 @@ export function createGeminiSummarize(
  * @param config Configuration options (credentials only)
  */
 export function createGeminiTts(model: GeminiTTSModel, config: GeminiGatewayConfig) {
-	return new GeminiTTSAdapter(buildGeminiGatewayConfig(config), model);
+  return new GeminiTTSAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 export {
-	GeminiTextModels,
-	GeminiImageModels,
-	GeminiTTSModels,
-	type GeminiTextModel,
-	type GeminiImageModel,
-	type GeminiSummarizeModel,
+  GeminiTextModels,
+  GeminiImageModels,
+  GeminiTTSModels,
+  type GeminiTextModel,
+  type GeminiImageModel,
+  type GeminiSummarizeModel,
 };

--- a/packages/tanstack-ai/src/adapters/gemini.ts
+++ b/packages/tanstack-ai/src/adapters/gemini.ts
@@ -21,14 +21,7 @@ import type { AiGatewayCredentialsConfig, AiGatewayConfig } from "../utils/creat
  * Includes cache control options from AiGatewayConfig.
  * See {@link https://github.com/googleapis/js-genai/issues/999 | googleapis/js-genai#999}.
  */
-export type GeminiGatewayConfig = AiGatewayCredentialsConfig &
-	AiGatewayConfig & {
-		/**
-		 * BYOK stored-key alias (`cf-aig-byok-alias`). Gemini is credentials /
-		 * provider-passthrough only, so this header is honored.
-		 */
-		byokAlias?: string;
-	};
+export type GeminiGatewayConfig = AiGatewayCredentialsConfig & AiGatewayConfig;
 
 /**
  * Build Gemini client config that routes through AI Gateway.
@@ -73,7 +66,7 @@ function buildGeminiGatewayConfig(config: GeminiGatewayConfig) {
 	if (typeof config.metadata === "object") {
 		headers["cf-aig-metadata"] = JSON.stringify(config.metadata);
 	}
-	if (typeof config.byokAlias === "string") {
+	if (typeof config.byokAlias === "string" && config.byokAlias.length > 0) {
 		headers["cf-aig-byok-alias"] = config.byokAlias;
 	}
 

--- a/packages/tanstack-ai/src/adapters/gemini.ts
+++ b/packages/tanstack-ai/src/adapters/gemini.ts
@@ -1,14 +1,14 @@
 import {
-  GeminiTextAdapter,
-  GeminiImageAdapter,
-  createGeminiSummarize as createGeminiSummarizeAdapter,
-  GeminiTTSAdapter,
-  GeminiTextModels,
-  GeminiImageModels,
-  GeminiTTSModels,
-  type GeminiTextModel,
-  type GeminiImageModel,
-  type GeminiSummarizeModel,
+	GeminiTextAdapter,
+	GeminiImageAdapter,
+	createGeminiSummarize as createGeminiSummarizeAdapter,
+	GeminiTTSAdapter,
+	GeminiTextModels,
+	GeminiImageModels,
+	GeminiTTSModels,
+	type GeminiTextModel,
+	type GeminiImageModel,
+	type GeminiSummarizeModel,
 } from "@tanstack/ai-gemini";
 
 /** Derived from GeminiTTSModels since @tanstack/ai-gemini doesn't export a GeminiTTSModel type. */
@@ -22,13 +22,13 @@ import type { AiGatewayCredentialsConfig, AiGatewayConfig } from "../utils/creat
  * See {@link https://github.com/googleapis/js-genai/issues/999 | googleapis/js-genai#999}.
  */
 export type GeminiGatewayConfig = AiGatewayCredentialsConfig &
-  AiGatewayConfig & {
-    /**
-     * BYOK stored-key alias (`cf-aig-byok-alias`). Gemini is credentials /
-     * provider-passthrough only, so this header is honored.
-     */
-    byokAlias?: string;
-  };
+	AiGatewayConfig & {
+		/**
+		 * BYOK stored-key alias (`cf-aig-byok-alias`). Gemini is credentials /
+		 * provider-passthrough only, so this header is honored.
+		 */
+		byokAlias?: string;
+	};
 
 /**
  * Build Gemini client config that routes through AI Gateway.
@@ -41,57 +41,57 @@ export type GeminiGatewayConfig = AiGatewayCredentialsConfig &
  * Tracking issue: https://github.com/googleapis/js-genai/issues/999
  */
 function buildGeminiGatewayConfig(config: GeminiGatewayConfig) {
-  // Runtime guard: catch binding configs that bypass TypeScript (JS callers, `as any`, etc.)
-  // We integrate with the Gemini SDK via `httpOptions` (baseUrl + headers), which allows
-  // gateway routing and cache control but not request interception. A binding config
-  // requires a custom `fetch` to route through the AI Gateway binding, and the Google
-  // GenAI SDK doesn't support that yet.
-  if ("binding" in config) {
-    throw new Error(
-      "Gemini adapters do not support binding config. " +
-        "The Google GenAI SDK does not support a custom fetch function — " +
-        "only credential-based config ({ accountId, gatewayId }) is supported. " +
-        "See https://github.com/googleapis/js-genai/issues/999",
-    );
-  }
+	// Runtime guard: catch binding configs that bypass TypeScript (JS callers, `as any`, etc.)
+	// We integrate with the Gemini SDK via `httpOptions` (baseUrl + headers), which allows
+	// gateway routing and cache control but not request interception. A binding config
+	// requires a custom `fetch` to route through the AI Gateway binding, and the Google
+	// GenAI SDK doesn't support that yet.
+	if ("binding" in config) {
+		throw new Error(
+			"Gemini adapters do not support binding config. " +
+				"The Google GenAI SDK does not support a custom fetch function — " +
+				"only credential-based config ({ accountId, gatewayId }) is supported. " +
+				"See https://github.com/googleapis/js-genai/issues/999",
+		);
+	}
 
-  const headers: Record<string, string> = {};
+	const headers: Record<string, string> = {};
 
-  if (config.apiKey && config.cfApiKey) {
-    headers["cf-aig-authorization"] = `Bearer ${config.cfApiKey}`;
-  }
+	if (config.apiKey && config.cfApiKey) {
+		headers["cf-aig-authorization"] = `Bearer ${config.cfApiKey}`;
+	}
 
-  if (config.skipCache) {
-    headers["cf-aig-skip-cache"] = "true";
-  }
-  if (typeof config.cacheTtl === "number") {
-    headers["cf-aig-cache-ttl"] = String(config.cacheTtl);
-  }
-  if (typeof config.customCacheKey === "string") {
-    headers["cf-aig-cache-key"] = config.customCacheKey;
-  }
-  if (typeof config.metadata === "object") {
-    headers["cf-aig-metadata"] = JSON.stringify(config.metadata);
-  }
-  if (typeof config.byokAlias === "string") {
-    headers["cf-aig-byok-alias"] = config.byokAlias;
-  }
+	if (config.skipCache) {
+		headers["cf-aig-skip-cache"] = "true";
+	}
+	if (typeof config.cacheTtl === "number") {
+		headers["cf-aig-cache-ttl"] = String(config.cacheTtl);
+	}
+	if (typeof config.customCacheKey === "string") {
+		headers["cf-aig-cache-key"] = config.customCacheKey;
+	}
+	if (typeof config.metadata === "object") {
+		headers["cf-aig-metadata"] = JSON.stringify(config.metadata);
+	}
+	if (typeof config.byokAlias === "string") {
+		headers["cf-aig-byok-alias"] = config.byokAlias;
+	}
 
-  const apiKey = config.apiKey ?? config.cfApiKey;
+	const apiKey = config.apiKey ?? config.cfApiKey;
 
-  if (!apiKey) {
-    throw new Error(
-      "If you want to use BYOK or unified billing, you need to pass the Cloudflare AI Gateway API key.",
-    );
-  }
+	if (!apiKey) {
+		throw new Error(
+			"If you want to use BYOK or unified billing, you need to pass the Cloudflare AI Gateway API key.",
+		);
+	}
 
-  return {
-    apiKey,
-    httpOptions: {
-      baseUrl: `https://gateway.ai.cloudflare.com/v1/${config.accountId}/${config.gatewayId}/google-ai-studio`,
-      headers: Object.keys(headers).length > 0 ? headers : undefined,
-    },
-  };
+	return {
+		apiKey,
+		httpOptions: {
+			baseUrl: `https://gateway.ai.cloudflare.com/v1/${config.accountId}/${config.gatewayId}/google-ai-studio`,
+			headers: Object.keys(headers).length > 0 ? headers : undefined,
+		},
+	};
 }
 
 /** Alias for consistency with other providers (AnthropicChatModel, GrokChatModel, etc.) */
@@ -105,10 +105,10 @@ export type GeminiChatModel = GeminiTextModel;
  * @param config Configuration options (credentials only)
  */
 export function createGeminiChat(
-  model: GeminiChatModel,
-  config: GeminiGatewayConfig,
+	model: GeminiChatModel,
+	config: GeminiGatewayConfig,
 ): AnyTextAdapter {
-  return new GeminiTextAdapter(buildGeminiGatewayConfig(config), model);
+	return new GeminiTextAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 /**
@@ -119,7 +119,7 @@ export function createGeminiChat(
  * @param config Configuration options (credentials only)
  */
 export function createGeminiImage(model: GeminiImageModel, config: GeminiGatewayConfig) {
-  return new GeminiImageAdapter(buildGeminiGatewayConfig(config), model);
+	return new GeminiImageAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 /**
@@ -130,11 +130,11 @@ export function createGeminiImage(model: GeminiImageModel, config: GeminiGateway
  * @param config Configuration options (credentials only)
  */
 export function createGeminiSummarize(
-  model: GeminiSummarizeModel,
-  config: GeminiGatewayConfig,
+	model: GeminiSummarizeModel,
+	config: GeminiGatewayConfig,
 ): AnySummarizeAdapter {
-  const { apiKey, httpOptions } = buildGeminiGatewayConfig(config);
-  return createGeminiSummarizeAdapter(apiKey, model, { httpOptions });
+	const { apiKey, httpOptions } = buildGeminiGatewayConfig(config);
+	return createGeminiSummarizeAdapter(apiKey, model, { httpOptions });
 }
 
 /**
@@ -147,14 +147,14 @@ export function createGeminiSummarize(
  * @param config Configuration options (credentials only)
  */
 export function createGeminiTts(model: GeminiTTSModel, config: GeminiGatewayConfig) {
-  return new GeminiTTSAdapter(buildGeminiGatewayConfig(config), model);
+	return new GeminiTTSAdapter(buildGeminiGatewayConfig(config), model);
 }
 
 export {
-  GeminiTextModels,
-  GeminiImageModels,
-  GeminiTTSModels,
-  type GeminiTextModel,
-  type GeminiImageModel,
-  type GeminiSummarizeModel,
+	GeminiTextModels,
+	GeminiImageModels,
+	GeminiTTSModels,
+	type GeminiTextModel,
+	type GeminiImageModel,
+	type GeminiSummarizeModel,
 };

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -61,24 +61,17 @@ export interface AiGatewayConfig {
 	cacheTtl?: number;
 	customCacheKey?: string;
 	metadata?: Record<string, unknown>;
+	/**
+	 * BYOK stored-key alias (`cf-aig-byok-alias`). Honored on credentials /
+	 * REST / provider-passthrough only. The AI binding ignores this header
+	 * for third-party models.
+	 * See https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/
+	 */
+	byokAlias?: string;
 }
 
-/**
- * Binding configs cannot carry `byokAlias`: `cf-aig-byok-alias` is a
- * provider-passthrough header and the AI binding does not honor it for
- * third-party models.
- */
-export type AiGatewayAdapterConfig =
-	| (AiGatewayBindingConfig & AiGatewayConfig)
-	| (AiGatewayCredentialsConfig &
-			AiGatewayConfig & {
-				/**
-				 * BYOK stored-key alias (`cf-aig-byok-alias`). REST /
-				 * provider-passthrough only.
-				 * See https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/
-				 */
-				byokAlias?: string;
-			});
+export type AiGatewayAdapterConfig = (AiGatewayBindingConfig | AiGatewayCredentialsConfig) &
+	AiGatewayConfig;
 
 // ---------------------------------------------------------------------------
 // Plain Workers AI types (direct binding or REST, no gateway)
@@ -272,7 +265,9 @@ export function createGatewayFetch(
 			...(config.metadata && typeof config.metadata === "object"
 				? { metadata: config.metadata as GatewayMetadata }
 				: {}),
-			...("gatewayId" in config && typeof config.byokAlias === "string"
+			...("gatewayId" in config &&
+			typeof config.byokAlias === "string" &&
+			config.byokAlias.length > 0
 				? { byokAlias: config.byokAlias }
 				: {}),
 		});

--- a/packages/tanstack-ai/src/utils/create-fetcher.ts
+++ b/packages/tanstack-ai/src/utils/create-fetcher.ts
@@ -63,8 +63,22 @@ export interface AiGatewayConfig {
 	metadata?: Record<string, unknown>;
 }
 
-export type AiGatewayAdapterConfig = (AiGatewayBindingConfig | AiGatewayCredentialsConfig) &
-	AiGatewayConfig;
+/**
+ * Binding configs cannot carry `byokAlias`: `cf-aig-byok-alias` is a
+ * provider-passthrough header and the AI binding does not honor it for
+ * third-party models.
+ */
+export type AiGatewayAdapterConfig =
+	| (AiGatewayBindingConfig & AiGatewayConfig)
+	| (AiGatewayCredentialsConfig &
+			AiGatewayConfig & {
+				/**
+				 * BYOK stored-key alias (`cf-aig-byok-alias`). REST /
+				 * provider-passthrough only.
+				 * See https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/
+				 */
+				byokAlias?: string;
+			});
 
 // ---------------------------------------------------------------------------
 // Plain Workers AI types (direct binding or REST, no gateway)
@@ -257,6 +271,9 @@ export function createGatewayFetch(
 				: {}),
 			...(config.metadata && typeof config.metadata === "object"
 				? { metadata: config.metadata as GatewayMetadata }
+				: {}),
+			...("gatewayId" in config && typeof config.byokAlias === "string"
+				? { byokAlias: config.byokAlias }
 				: {}),
 		});
 

--- a/packages/tanstack-ai/test/gateway-adapters.test.ts
+++ b/packages/tanstack-ai/test/gateway-adapters.test.ts
@@ -542,6 +542,31 @@ describe("OpenRouter gateway adapters", () => {
 		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
 		expect(config.apiKey).toBe("unused");
 	});
+
+	it("createOpenRouterChat forwards byokAlias through the HTTPClient fetcher", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
+
+		try {
+			const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+			createOpenRouterChat("openai/gpt-4o", {
+				...credentialsConfig,
+				byokAlias: "development",
+			});
+
+			const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+			await config.httpClient.fetcher("https://openrouter.ai/api/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "openai/gpt-4o", messages: [] }),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 describe("gateway fetch integration", () => {
@@ -564,6 +589,37 @@ describe("gateway fetch integration", () => {
 			expect(mockFetch).toHaveBeenCalledOnce();
 			const [url] = mockFetch.mock.calls[0]!;
 			expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("createOpenAiChat and createAnthropicChat forward byokAlias on REST", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
+
+		try {
+			const { createOpenAiChat } = await import("../src/adapters/openai");
+			const { createAnthropicChat } = await import("../src/adapters/anthropic");
+			const withAlias = { ...credentialsConfig, byokAlias: "development" };
+
+			createOpenAiChat("gpt-4o" as any, withAlias);
+			await mockOpenAITextCtor.mock.calls[0]![0].fetch(
+				"https://api.openai.com/v1/chat/completions",
+				{ body: JSON.stringify({ model: "gpt-4o", messages: [] }) },
+			);
+
+			createAnthropicChat("claude-sonnet-4-5" as any, withAlias);
+			await mockAnthropicTextCtor.mock.calls[0]![0].fetch(
+				"https://api.anthropic.com/v1/messages",
+				{ body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }) },
+			);
+
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+			for (const [, init] of mockFetch.mock.calls) {
+				expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+			}
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
@@ -598,6 +654,7 @@ describe("gateway fetch integration", () => {
 				cacheTtl: 300,
 				customCacheKey: "my-key",
 				metadata: { env: "test" },
+				byokAlias: "development",
 			});
 
 			const [config] = mockGrokTextCtor.mock.calls[0]!;
@@ -612,6 +669,8 @@ describe("gateway fetch integration", () => {
 			expect(body.headers["cf-aig-cache-ttl"]).toBe("300");
 			expect(body.headers["cf-aig-cache-key"]).toBe("my-key");
 			expect(body.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
+			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/packages/tanstack-ai/test/gateway-adapters.test.ts
+++ b/packages/tanstack-ai/test/gateway-adapters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
 import type {
-	AiGatewayBindingConfig,
-	AiGatewayCredentialsConfig,
+  AiGatewayBindingConfig,
+  AiGatewayCredentialsConfig,
 } from "../src/utils/create-fetcher";
 import type { GeminiGatewayConfig } from "../src";
 
@@ -13,16 +13,16 @@ const mockAnthropicTextCtor = vi.fn();
 const mockAnthropicSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-anthropic", () => ({
-	AnthropicTextAdapter: class {
-		constructor(...args: unknown[]) {
-			mockAnthropicTextCtor(...args);
-		}
-	},
-	createAnthropicSummarize: (...args: unknown[]) => {
-		mockAnthropicSummarizeCtor(...args);
-		return {};
-	},
-	ANTHROPIC_MODELS: ["claude-sonnet-4-5"],
+  AnthropicTextAdapter: class {
+    constructor(...args: unknown[]) {
+      mockAnthropicTextCtor(...args);
+    }
+  },
+  createAnthropicSummarize: (...args: unknown[]) => {
+    mockAnthropicSummarizeCtor(...args);
+    return {};
+  },
+  ANTHROPIC_MODELS: ["claude-sonnet-4-5"],
 }));
 
 const mockGeminiTextCtor = vi.fn();
@@ -31,29 +31,29 @@ const mockGeminiSummarizeCtor = vi.fn();
 const mockGeminiTTSCtor = vi.fn();
 
 vi.mock("@tanstack/ai-gemini", () => ({
-	GeminiTextAdapter: class {
-		constructor(...args: unknown[]) {
-			mockGeminiTextCtor(...args);
-		}
-	},
-	GeminiImageAdapter: class {
-		constructor(...args: unknown[]) {
-			mockGeminiImageCtor(...args);
-		}
-	},
-	createGeminiSummarize: (...args: unknown[]) => {
-		mockGeminiSummarizeCtor(...args);
-		return {};
-	},
-	GeminiTTSAdapter: class {
-		constructor(...args: unknown[]) {
-			mockGeminiTTSCtor(...args);
-		}
-	},
-	GeminiTextModels: ["gemini-2.5-flash"],
-	GeminiImageModels: ["imagen-4.0-generate-001"],
-	GeminiSummarizeModels: ["gemini-2.0-flash"],
-	GeminiTTSModels: ["gemini-2.5-flash-preview-tts"],
+  GeminiTextAdapter: class {
+    constructor(...args: unknown[]) {
+      mockGeminiTextCtor(...args);
+    }
+  },
+  GeminiImageAdapter: class {
+    constructor(...args: unknown[]) {
+      mockGeminiImageCtor(...args);
+    }
+  },
+  createGeminiSummarize: (...args: unknown[]) => {
+    mockGeminiSummarizeCtor(...args);
+    return {};
+  },
+  GeminiTTSAdapter: class {
+    constructor(...args: unknown[]) {
+      mockGeminiTTSCtor(...args);
+    }
+  },
+  GeminiTextModels: ["gemini-2.5-flash"],
+  GeminiImageModels: ["imagen-4.0-generate-001"],
+  GeminiSummarizeModels: ["gemini-2.0-flash"],
+  GeminiTTSModels: ["gemini-2.5-flash-preview-tts"],
 }));
 
 const mockGrokTextCtor = vi.fn();
@@ -61,22 +61,22 @@ const mockGrokImageCtor = vi.fn();
 const mockGrokSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-grok", () => ({
-	GrokTextAdapter: class {
-		constructor(...args: unknown[]) {
-			mockGrokTextCtor(...args);
-		}
-	},
-	GrokImageAdapter: class {
-		constructor(...args: unknown[]) {
-			mockGrokImageCtor(...args);
-		}
-	},
-	createGrokSummarize: (...args: unknown[]) => {
-		mockGrokSummarizeCtor(...args);
-		return {};
-	},
-	GROK_CHAT_MODELS: ["grok-3"],
-	GROK_IMAGE_MODELS: ["grok-2-image-1212"],
+  GrokTextAdapter: class {
+    constructor(...args: unknown[]) {
+      mockGrokTextCtor(...args);
+    }
+  },
+  GrokImageAdapter: class {
+    constructor(...args: unknown[]) {
+      mockGrokImageCtor(...args);
+    }
+  },
+  createGrokSummarize: (...args: unknown[]) => {
+    mockGrokSummarizeCtor(...args);
+    return {};
+  },
+  GROK_CHAT_MODELS: ["grok-3"],
+  GROK_IMAGE_MODELS: ["grok-2-image-1212"],
 }));
 
 const mockOpenAITextCtor = vi.fn();
@@ -87,40 +87,40 @@ const mockOpenAITTSCtor = vi.fn();
 const mockOpenAIVideoCtor = vi.fn();
 
 vi.mock("@tanstack/ai-openai", () => ({
-	OpenAITextAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenAITextCtor(...args);
-		}
-	},
-	createOpenaiSummarize: (...args: unknown[]) => {
-		mockOpenAISummarizeCtor(...args);
-		return {};
-	},
-	OpenAIImageAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenAIImageCtor(...args);
-		}
-	},
-	OpenAITranscriptionAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenAITranscriptionCtor(...args);
-		}
-	},
-	OpenAITTSAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenAITTSCtor(...args);
-		}
-	},
-	OpenAIVideoAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenAIVideoCtor(...args);
-		}
-	},
-	OPENAI_CHAT_MODELS: ["gpt-4o"],
-	OPENAI_IMAGE_MODELS: ["dall-e-3"],
-	OPENAI_TRANSCRIPTION_MODELS: ["whisper-1"],
-	OPENAI_TTS_MODELS: ["tts-1"],
-	OPENAI_VIDEO_MODELS: ["sora"],
+  OpenAITextAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenAITextCtor(...args);
+    }
+  },
+  createOpenaiSummarize: (...args: unknown[]) => {
+    mockOpenAISummarizeCtor(...args);
+    return {};
+  },
+  OpenAIImageAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenAIImageCtor(...args);
+    }
+  },
+  OpenAITranscriptionAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenAITranscriptionCtor(...args);
+    }
+  },
+  OpenAITTSAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenAITTSCtor(...args);
+    }
+  },
+  OpenAIVideoAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenAIVideoCtor(...args);
+    }
+  },
+  OPENAI_CHAT_MODELS: ["gpt-4o"],
+  OPENAI_IMAGE_MODELS: ["dall-e-3"],
+  OPENAI_TRANSCRIPTION_MODELS: ["whisper-1"],
+  OPENAI_TTS_MODELS: ["tts-1"],
+  OPENAI_VIDEO_MODELS: ["sora"],
 }));
 
 vi.mock("@tanstack/ai", () => ({}));
@@ -129,29 +129,29 @@ const mockOpenRouterImageCtor = vi.fn();
 const mockOpenRouterSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-openrouter", () => ({
-	OpenRouterTextAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenRouterTextCtor(...args);
-		}
-	},
-	OpenRouterImageAdapter: class {
-		constructor(...args: unknown[]) {
-			mockOpenRouterImageCtor(...args);
-		}
-	},
-	createOpenRouterSummarize: (...args: unknown[]) => {
-		mockOpenRouterSummarizeCtor(...args);
-		return {};
-	},
+  OpenRouterTextAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenRouterTextCtor(...args);
+    }
+  },
+  OpenRouterImageAdapter: class {
+    constructor(...args: unknown[]) {
+      mockOpenRouterImageCtor(...args);
+    }
+  },
+  createOpenRouterSummarize: (...args: unknown[]) => {
+    mockOpenRouterSummarizeCtor(...args);
+    return {};
+  },
 }));
 
 vi.mock("@openrouter/sdk", () => ({
-	HTTPClient: class {
-		fetcher: unknown;
-		constructor(opts: { fetcher?: unknown }) {
-			this.fetcher = opts?.fetcher;
-		}
-	},
+  HTTPClient: class {
+    fetcher: unknown;
+    constructor(opts: { fetcher?: unknown }) {
+      this.fetcher = opts?.fetcher;
+    }
+  },
 }));
 
 vi.mock("openai", () => ({ default: class {} }));
@@ -163,46 +163,46 @@ vi.mock("@google/genai", () => ({ GoogleGenAI: class {} }));
 // ---------------------------------------------------------------------------
 
 const credentialsConfig: AiGatewayCredentialsConfig = {
-	accountId: "test-account",
-	gatewayId: "test-gateway",
-	apiKey: "test-api-key",
+  accountId: "test-account",
+  gatewayId: "test-gateway",
+  apiKey: "test-api-key",
 };
 
 const geminiConfig: GeminiGatewayConfig = {
-	accountId: "test-account",
-	gatewayId: "test-gateway",
-	apiKey: "test-api-key",
+  accountId: "test-account",
+  gatewayId: "test-gateway",
+  apiKey: "test-api-key",
 };
 
 const geminiConfigWithCfKey: GeminiGatewayConfig = {
-	accountId: "test-account",
-	gatewayId: "test-gateway",
-	apiKey: "test-api-key",
-	cfApiKey: "cf-test-key",
+  accountId: "test-account",
+  gatewayId: "test-gateway",
+  apiKey: "test-api-key",
+  cfApiKey: "cf-test-key",
 };
 
 const mockBindingRun = vi.fn(async (..._args: unknown[]) => new Response("ok"));
 const bindingConfig: AiGatewayBindingConfig = {
-	binding: { run: mockBindingRun },
-	apiKey: "binding-api-key",
+  binding: { run: mockBindingRun },
+  apiKey: "binding-api-key",
 };
 
 function assertFetchInjected(ctor: Mock, expectedApiKey: string) {
-	expect(ctor).toHaveBeenCalledOnce();
-	const [config] = ctor.mock.calls[0]!;
-	expect(config.apiKey).toBe(expectedApiKey);
-	expect(typeof config.fetch).toBe("function");
-	return config;
+  expect(ctor).toHaveBeenCalledOnce();
+  const [config] = ctor.mock.calls[0]!;
+  expect(config.apiKey).toBe(expectedApiKey);
+  expect(typeof config.fetch).toBe("function");
+  return config;
 }
 
 function assertGeminiConfig(ctor: Mock, expectedApiKey: string) {
-	expect(ctor).toHaveBeenCalledOnce();
-	const [config] = ctor.mock.calls[0]!;
-	expect(config.apiKey).toBe(expectedApiKey);
-	expect(config.httpOptions).toBeDefined();
-	expect(config.httpOptions.baseUrl).toContain("gateway.ai.cloudflare.com");
-	expect(config.httpOptions.baseUrl).toContain("google-ai-studio");
-	return config;
+  expect(ctor).toHaveBeenCalledOnce();
+  const [config] = ctor.mock.calls[0]!;
+  expect(config.apiKey).toBe(expectedApiKey);
+  expect(config.httpOptions).toBeDefined();
+  expect(config.httpOptions.baseUrl).toContain("gateway.ai.cloudflare.com");
+  expect(config.httpOptions.baseUrl).toContain("google-ai-studio");
+  return config;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,469 +210,480 @@ function assertGeminiConfig(ctor: Mock, expectedApiKey: string) {
 // ---------------------------------------------------------------------------
 
 describe("Anthropic gateway adapters", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("createAnthropicChat with credentials config", async () => {
-		const { createAnthropicChat } = await import("../src/adapters/anthropic");
-		createAnthropicChat("claude-sonnet-4-5" as any, credentialsConfig);
+  it("createAnthropicChat with credentials config", async () => {
+    const { createAnthropicChat } = await import("../src/adapters/anthropic");
+    createAnthropicChat("claude-sonnet-4-5" as any, credentialsConfig);
 
-		assertFetchInjected(mockAnthropicTextCtor, "test-api-key");
-		// model is second arg
-		expect(mockAnthropicTextCtor.mock.calls[0]![1]).toBe("claude-sonnet-4-5");
-	});
+    assertFetchInjected(mockAnthropicTextCtor, "test-api-key");
+    // model is second arg
+    expect(mockAnthropicTextCtor.mock.calls[0]![1]).toBe("claude-sonnet-4-5");
+  });
 
-	it("createAnthropicChat with binding config", async () => {
-		const { createAnthropicChat } = await import("../src/adapters/anthropic");
-		createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
+  it("createAnthropicChat with binding config", async () => {
+    const { createAnthropicChat } = await import("../src/adapters/anthropic");
+    createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
 
-		const config = assertFetchInjected(mockAnthropicTextCtor, "binding-api-key");
-		// Invoke the fetch — should call binding.run
-		await config.fetch("https://api.anthropic.com/v1/messages", {
-			body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
-		});
-		expect(mockBindingRun).toHaveBeenCalledOnce();
-	});
+    const config = assertFetchInjected(mockAnthropicTextCtor, "binding-api-key");
+    // Invoke the fetch — should call binding.run
+    await config.fetch("https://api.anthropic.com/v1/messages", {
+      body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
+    });
+    expect(mockBindingRun).toHaveBeenCalledOnce();
+  });
 
-	it("createAnthropicChat defaults apiKey to 'unused'", async () => {
-		const { createAnthropicChat } = await import("../src/adapters/anthropic");
-		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-		createAnthropicChat("claude-sonnet-4-5" as any, noKeyConfig as any);
+  it("createAnthropicChat defaults apiKey to 'unused'", async () => {
+    const { createAnthropicChat } = await import("../src/adapters/anthropic");
+    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+    createAnthropicChat("claude-sonnet-4-5" as any, noKeyConfig as any);
 
-		const [config] = mockAnthropicTextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("unused");
-	});
+    const [config] = mockAnthropicTextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("unused");
+  });
 
-	it("createAnthropicSummarize with credentials config", async () => {
-		const { createAnthropicSummarize } = await import("../src/adapters/anthropic");
-		createAnthropicSummarize("claude-sonnet-4-5" as any, credentialsConfig);
+  it("createAnthropicSummarize with credentials config", async () => {
+    const { createAnthropicSummarize } = await import("../src/adapters/anthropic");
+    createAnthropicSummarize("claude-sonnet-4-5" as any, credentialsConfig);
 
-		expect(mockAnthropicSummarizeCtor).toHaveBeenCalledOnce();
-		const [model, apiKey, cfg] = mockAnthropicSummarizeCtor.mock.calls[0]!;
-		expect(model).toBe("claude-sonnet-4-5");
-		expect(apiKey).toBe("test-api-key");
-		expect(typeof cfg.fetch).toBe("function");
-	});
+    expect(mockAnthropicSummarizeCtor).toHaveBeenCalledOnce();
+    const [model, apiKey, cfg] = mockAnthropicSummarizeCtor.mock.calls[0]!;
+    expect(model).toBe("claude-sonnet-4-5");
+    expect(apiKey).toBe("test-api-key");
+    expect(typeof cfg.fetch).toBe("function");
+  });
 });
 
 describe("Gemini gateway adapters", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("createGeminiChat with credentials config", async () => {
-		const { createGeminiChat } = await import("../src/adapters/gemini");
-		createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
+  it("createGeminiChat with credentials config", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
 
-		const config = assertGeminiConfig(mockGeminiTextCtor, "test-api-key");
-		expect(config.httpOptions.baseUrl).toBe(
-			"https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/google-ai-studio",
-		);
-		expect(mockGeminiTextCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash");
-	});
+    const config = assertGeminiConfig(mockGeminiTextCtor, "test-api-key");
+    expect(config.httpOptions.baseUrl).toBe(
+      "https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/google-ai-studio",
+    );
+    expect(mockGeminiTextCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash");
+  });
 
-	it("createGeminiChat includes cf-aig-authorization header when cfApiKey provided", async () => {
-		const { createGeminiChat } = await import("../src/adapters/gemini");
-		createGeminiChat("gemini-2.5-flash" as any, geminiConfigWithCfKey);
+  it("createGeminiChat includes cf-aig-authorization header when cfApiKey provided", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    createGeminiChat("gemini-2.5-flash" as any, geminiConfigWithCfKey);
 
-		const [config] = mockGeminiTextCtor.mock.calls[0]!;
-		expect(config.httpOptions.headers).toEqual({
-			"cf-aig-authorization": "Bearer cf-test-key",
-		});
-	});
+    const [config] = mockGeminiTextCtor.mock.calls[0]!;
+    expect(config.httpOptions.headers).toEqual({
+      "cf-aig-authorization": "Bearer cf-test-key",
+    });
+  });
 
-	it("createGeminiChat omits headers when no cfApiKey or cache options", async () => {
-		const { createGeminiChat } = await import("../src/adapters/gemini");
-		createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
+  it("createGeminiChat omits headers when no cfApiKey or cache options", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
 
-		const [config] = mockGeminiTextCtor.mock.calls[0]!;
-		expect(config.httpOptions.headers).toBeUndefined();
-	});
+    const [config] = mockGeminiTextCtor.mock.calls[0]!;
+    expect(config.httpOptions.headers).toBeUndefined();
+  });
 
-	it("createGeminiChat passes cache headers via httpOptions.headers", async () => {
-		const { createGeminiChat } = await import("../src/adapters/gemini");
-		const configWithCache: GeminiGatewayConfig = {
-			...geminiConfig,
-			skipCache: true,
-			cacheTtl: 300,
-			customCacheKey: "my-key",
-			metadata: { env: "test" },
-		};
-		createGeminiChat("gemini-2.5-flash" as any, configWithCache);
+  it("createGeminiChat passes cache headers via httpOptions.headers", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    const configWithCache: GeminiGatewayConfig = {
+      ...geminiConfig,
+      skipCache: true,
+      cacheTtl: 300,
+      customCacheKey: "my-key",
+      metadata: { env: "test" },
+    };
+    createGeminiChat("gemini-2.5-flash" as any, configWithCache);
 
-		const [config] = mockGeminiTextCtor.mock.calls[0]!;
-		expect(config.httpOptions.headers["cf-aig-skip-cache"]).toBe("true");
-		expect(config.httpOptions.headers["cf-aig-cache-ttl"]).toBe("300");
-		expect(config.httpOptions.headers["cf-aig-cache-key"]).toBe("my-key");
-		expect(config.httpOptions.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
-	});
+    const [config] = mockGeminiTextCtor.mock.calls[0]!;
+    expect(config.httpOptions.headers["cf-aig-skip-cache"]).toBe("true");
+    expect(config.httpOptions.headers["cf-aig-cache-ttl"]).toBe("300");
+    expect(config.httpOptions.headers["cf-aig-cache-key"]).toBe("my-key");
+    expect(config.httpOptions.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
+  });
 
-	it("createGeminiImage with credentials config", async () => {
-		const { createGeminiImage } = await import("../src/adapters/gemini");
-		createGeminiImage("imagen-4.0-generate-001" as any, geminiConfig);
+  it("createGeminiChat passes byokAlias via httpOptions.headers", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    const configWithAlias: GeminiGatewayConfig = {
+      ...geminiConfig,
+      byokAlias: "development",
+    };
+    createGeminiChat("gemini-2.5-flash" as any, configWithAlias);
 
-		assertGeminiConfig(mockGeminiImageCtor, "test-api-key");
-		expect(mockGeminiImageCtor.mock.calls[0]![1]).toBe("imagen-4.0-generate-001");
-	});
+    const [config] = mockGeminiTextCtor.mock.calls[0]!;
+    expect(config.httpOptions.headers["cf-aig-byok-alias"]).toBe("development");
+  });
 
-	it("createGeminiSummarize with credentials config", async () => {
-		const { createGeminiSummarize } = await import("../src/adapters/gemini");
-		createGeminiSummarize("gemini-2.0-flash" as any, geminiConfig);
+  it("createGeminiImage with credentials config", async () => {
+    const { createGeminiImage } = await import("../src/adapters/gemini");
+    createGeminiImage("imagen-4.0-generate-001" as any, geminiConfig);
 
-		expect(mockGeminiSummarizeCtor).toHaveBeenCalledOnce();
-		const [apiKey, model, cfg] = mockGeminiSummarizeCtor.mock.calls[0]!;
-		expect(apiKey).toBe("test-api-key");
-		expect(model).toBe("gemini-2.0-flash");
-		expect(cfg.httpOptions.baseUrl).toContain("google-ai-studio");
-	});
+    assertGeminiConfig(mockGeminiImageCtor, "test-api-key");
+    expect(mockGeminiImageCtor.mock.calls[0]![1]).toBe("imagen-4.0-generate-001");
+  });
 
-	it("createGeminiTts with credentials config", async () => {
-		const { createGeminiTts } = await import("../src/adapters/gemini");
-		createGeminiTts("gemini-2.5-flash-preview-tts" as any, geminiConfig);
+  it("createGeminiSummarize with credentials config", async () => {
+    const { createGeminiSummarize } = await import("../src/adapters/gemini");
+    createGeminiSummarize("gemini-2.0-flash" as any, geminiConfig);
 
-		assertGeminiConfig(mockGeminiTTSCtor, "test-api-key");
-		expect(mockGeminiTTSCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash-preview-tts");
-	});
+    expect(mockGeminiSummarizeCtor).toHaveBeenCalledOnce();
+    const [apiKey, model, cfg] = mockGeminiSummarizeCtor.mock.calls[0]!;
+    expect(apiKey).toBe("test-api-key");
+    expect(model).toBe("gemini-2.0-flash");
+    expect(cfg.httpOptions.baseUrl).toContain("google-ai-studio");
+  });
 
-	it("createGeminiChat throws on binding config (runtime guard)", async () => {
-		const { createGeminiChat } = await import("../src/adapters/gemini");
-		const bindingStyleConfig = {
-			binding: { run: async () => new Response("ok") },
-		};
-		expect(() =>
-			createGeminiChat("gemini-2.5-flash" as any, bindingStyleConfig as any),
-		).toThrow(/Gemini adapters do not support binding config/);
-	});
+  it("createGeminiTts with credentials config", async () => {
+    const { createGeminiTts } = await import("../src/adapters/gemini");
+    createGeminiTts("gemini-2.5-flash-preview-tts" as any, geminiConfig);
 
-	it("createGeminiImage throws on binding config (runtime guard)", async () => {
-		const { createGeminiImage } = await import("../src/adapters/gemini");
-		const bindingStyleConfig = {
-			binding: { run: async () => new Response("ok") },
-		};
-		expect(() =>
-			createGeminiImage("imagen-4.0-generate-001" as any, bindingStyleConfig as any),
-		).toThrow(/Gemini adapters do not support binding config/);
-	});
+    assertGeminiConfig(mockGeminiTTSCtor, "test-api-key");
+    expect(mockGeminiTTSCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash-preview-tts");
+  });
 
-	it("createGeminiTts throws on binding config (runtime guard)", async () => {
-		const { createGeminiTts } = await import("../src/adapters/gemini");
-		const bindingStyleConfig = {
-			binding: { run: async () => new Response("ok") },
-		};
-		expect(() =>
-			createGeminiTts("gemini-2.5-flash-preview-tts" as any, bindingStyleConfig as any),
-		).toThrow(/googleapis\/js-genai/);
-	});
+  it("createGeminiChat throws on binding config (runtime guard)", async () => {
+    const { createGeminiChat } = await import("../src/adapters/gemini");
+    const bindingStyleConfig = {
+      binding: { run: async () => new Response("ok") },
+    };
+    expect(() => createGeminiChat("gemini-2.5-flash" as any, bindingStyleConfig as any)).toThrow(
+      /Gemini adapters do not support binding config/,
+    );
+  });
+
+  it("createGeminiImage throws on binding config (runtime guard)", async () => {
+    const { createGeminiImage } = await import("../src/adapters/gemini");
+    const bindingStyleConfig = {
+      binding: { run: async () => new Response("ok") },
+    };
+    expect(() =>
+      createGeminiImage("imagen-4.0-generate-001" as any, bindingStyleConfig as any),
+    ).toThrow(/Gemini adapters do not support binding config/);
+  });
+
+  it("createGeminiTts throws on binding config (runtime guard)", async () => {
+    const { createGeminiTts } = await import("../src/adapters/gemini");
+    const bindingStyleConfig = {
+      binding: { run: async () => new Response("ok") },
+    };
+    expect(() =>
+      createGeminiTts("gemini-2.5-flash-preview-tts" as any, bindingStyleConfig as any),
+    ).toThrow(/googleapis\/js-genai/);
+  });
 });
 
 describe("Grok gateway adapters", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("createGrokChat with credentials config", async () => {
-		const { createGrokChat } = await import("../src/adapters/grok");
-		createGrokChat("grok-3" as any, credentialsConfig);
+  it("createGrokChat with credentials config", async () => {
+    const { createGrokChat } = await import("../src/adapters/grok");
+    createGrokChat("grok-3" as any, credentialsConfig);
 
-		assertFetchInjected(mockGrokTextCtor, "test-api-key");
-		expect(mockGrokTextCtor.mock.calls[0]![1]).toBe("grok-3");
-	});
+    assertFetchInjected(mockGrokTextCtor, "test-api-key");
+    expect(mockGrokTextCtor.mock.calls[0]![1]).toBe("grok-3");
+  });
 
-	it("createGrokChat with binding config", async () => {
-		const { createGrokChat } = await import("../src/adapters/grok");
-		createGrokChat("grok-3" as any, bindingConfig);
+  it("createGrokChat with binding config", async () => {
+    const { createGrokChat } = await import("../src/adapters/grok");
+    createGrokChat("grok-3" as any, bindingConfig);
 
-		const config = assertFetchInjected(mockGrokTextCtor, "binding-api-key");
-		await config.fetch("https://api.x.ai/v1/chat/completions", {
-			body: JSON.stringify({ model: "grok-3", messages: [] }),
-		});
-		expect(mockBindingRun).toHaveBeenCalledOnce();
-	});
+    const config = assertFetchInjected(mockGrokTextCtor, "binding-api-key");
+    await config.fetch("https://api.x.ai/v1/chat/completions", {
+      body: JSON.stringify({ model: "grok-3", messages: [] }),
+    });
+    expect(mockBindingRun).toHaveBeenCalledOnce();
+  });
 
-	it("createGrokImage with credentials config", async () => {
-		const { createGrokImage } = await import("../src/adapters/grok");
-		createGrokImage("grok-2-image-1212" as any, credentialsConfig);
+  it("createGrokImage with credentials config", async () => {
+    const { createGrokImage } = await import("../src/adapters/grok");
+    createGrokImage("grok-2-image-1212" as any, credentialsConfig);
 
-		assertFetchInjected(mockGrokImageCtor, "test-api-key");
-		expect(mockGrokImageCtor.mock.calls[0]![1]).toBe("grok-2-image-1212");
-	});
+    assertFetchInjected(mockGrokImageCtor, "test-api-key");
+    expect(mockGrokImageCtor.mock.calls[0]![1]).toBe("grok-2-image-1212");
+  });
 
-	it("createGrokSummarize with credentials config", async () => {
-		const { createGrokSummarize } = await import("../src/adapters/grok");
-		createGrokSummarize("grok-3" as any, credentialsConfig);
+  it("createGrokSummarize with credentials config", async () => {
+    const { createGrokSummarize } = await import("../src/adapters/grok");
+    createGrokSummarize("grok-3" as any, credentialsConfig);
 
-		expect(mockGrokSummarizeCtor).toHaveBeenCalledOnce();
-		const [model, apiKey, cfg] = mockGrokSummarizeCtor.mock.calls[0]!;
-		expect(model).toBe("grok-3");
-		expect(apiKey).toBe("test-api-key");
-		expect(typeof cfg.fetch).toBe("function");
-	});
+    expect(mockGrokSummarizeCtor).toHaveBeenCalledOnce();
+    const [model, apiKey, cfg] = mockGrokSummarizeCtor.mock.calls[0]!;
+    expect(model).toBe("grok-3");
+    expect(apiKey).toBe("test-api-key");
+    expect(typeof cfg.fetch).toBe("function");
+  });
 
-	it("createGrokChat defaults apiKey to 'unused'", async () => {
-		const { createGrokChat } = await import("../src/adapters/grok");
-		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-		createGrokChat("grok-3" as any, noKeyConfig as any);
+  it("createGrokChat defaults apiKey to 'unused'", async () => {
+    const { createGrokChat } = await import("../src/adapters/grok");
+    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+    createGrokChat("grok-3" as any, noKeyConfig as any);
 
-		const [config] = mockGrokTextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("unused");
-	});
+    const [config] = mockGrokTextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("unused");
+  });
 });
 
 describe("OpenAI gateway adapters", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("createOpenAiChat with credentials config", async () => {
-		const { createOpenAiChat } = await import("../src/adapters/openai");
-		createOpenAiChat("gpt-4o" as any, credentialsConfig);
+  it("createOpenAiChat with credentials config", async () => {
+    const { createOpenAiChat } = await import("../src/adapters/openai");
+    createOpenAiChat("gpt-4o" as any, credentialsConfig);
 
-		assertFetchInjected(mockOpenAITextCtor, "test-api-key");
-		expect(mockOpenAITextCtor.mock.calls[0]![1]).toBe("gpt-4o");
-	});
+    assertFetchInjected(mockOpenAITextCtor, "test-api-key");
+    expect(mockOpenAITextCtor.mock.calls[0]![1]).toBe("gpt-4o");
+  });
 
-	it("createOpenAiChat with binding config", async () => {
-		const { createOpenAiChat } = await import("../src/adapters/openai");
-		createOpenAiChat("gpt-4o" as any, bindingConfig);
+  it("createOpenAiChat with binding config", async () => {
+    const { createOpenAiChat } = await import("../src/adapters/openai");
+    createOpenAiChat("gpt-4o" as any, bindingConfig);
 
-		const config = assertFetchInjected(mockOpenAITextCtor, "binding-api-key");
-		await config.fetch("https://api.openai.com/v1/chat/completions", {
-			body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-		});
-		expect(mockBindingRun).toHaveBeenCalledOnce();
-	});
+    const config = assertFetchInjected(mockOpenAITextCtor, "binding-api-key");
+    await config.fetch("https://api.openai.com/v1/chat/completions", {
+      body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+    });
+    expect(mockBindingRun).toHaveBeenCalledOnce();
+  });
 
-	it("createOpenAiSummarize with credentials config", async () => {
-		const { createOpenAiSummarize } = await import("../src/adapters/openai");
-		createOpenAiSummarize("gpt-4o" as any, credentialsConfig);
+  it("createOpenAiSummarize with credentials config", async () => {
+    const { createOpenAiSummarize } = await import("../src/adapters/openai");
+    createOpenAiSummarize("gpt-4o" as any, credentialsConfig);
 
-		expect(mockOpenAISummarizeCtor).toHaveBeenCalledOnce();
-		const [model, apiKey, cfg] = mockOpenAISummarizeCtor.mock.calls[0]!;
-		expect(model).toBe("gpt-4o");
-		expect(apiKey).toBe("test-api-key");
-		expect(typeof cfg.fetch).toBe("function");
-	});
+    expect(mockOpenAISummarizeCtor).toHaveBeenCalledOnce();
+    const [model, apiKey, cfg] = mockOpenAISummarizeCtor.mock.calls[0]!;
+    expect(model).toBe("gpt-4o");
+    expect(apiKey).toBe("test-api-key");
+    expect(typeof cfg.fetch).toBe("function");
+  });
 
-	it("createOpenAiImage with credentials config", async () => {
-		const { createOpenAiImage } = await import("../src/adapters/openai");
-		createOpenAiImage("dall-e-3" as any, credentialsConfig);
+  it("createOpenAiImage with credentials config", async () => {
+    const { createOpenAiImage } = await import("../src/adapters/openai");
+    createOpenAiImage("dall-e-3" as any, credentialsConfig);
 
-		assertFetchInjected(mockOpenAIImageCtor, "test-api-key");
-		expect(mockOpenAIImageCtor.mock.calls[0]![1]).toBe("dall-e-3");
-	});
+    assertFetchInjected(mockOpenAIImageCtor, "test-api-key");
+    expect(mockOpenAIImageCtor.mock.calls[0]![1]).toBe("dall-e-3");
+  });
 
-	it("createOpenAiTranscription with credentials config", async () => {
-		const { createOpenAiTranscription } = await import("../src/adapters/openai");
-		createOpenAiTranscription("whisper-1" as any, credentialsConfig);
+  it("createOpenAiTranscription with credentials config", async () => {
+    const { createOpenAiTranscription } = await import("../src/adapters/openai");
+    createOpenAiTranscription("whisper-1" as any, credentialsConfig);
 
-		assertFetchInjected(mockOpenAITranscriptionCtor, "test-api-key");
-		expect(mockOpenAITranscriptionCtor.mock.calls[0]![1]).toBe("whisper-1");
-	});
+    assertFetchInjected(mockOpenAITranscriptionCtor, "test-api-key");
+    expect(mockOpenAITranscriptionCtor.mock.calls[0]![1]).toBe("whisper-1");
+  });
 
-	it("createOpenAiTts with credentials config", async () => {
-		const { createOpenAiTts } = await import("../src/adapters/openai");
-		createOpenAiTts("tts-1" as any, credentialsConfig);
+  it("createOpenAiTts with credentials config", async () => {
+    const { createOpenAiTts } = await import("../src/adapters/openai");
+    createOpenAiTts("tts-1" as any, credentialsConfig);
 
-		assertFetchInjected(mockOpenAITTSCtor, "test-api-key");
-		expect(mockOpenAITTSCtor.mock.calls[0]![1]).toBe("tts-1");
-	});
+    assertFetchInjected(mockOpenAITTSCtor, "test-api-key");
+    expect(mockOpenAITTSCtor.mock.calls[0]![1]).toBe("tts-1");
+  });
 
-	it("createOpenAiVideo with credentials config", async () => {
-		const { createOpenAiVideo } = await import("../src/adapters/openai");
-		createOpenAiVideo("sora" as any, credentialsConfig);
+  it("createOpenAiVideo with credentials config", async () => {
+    const { createOpenAiVideo } = await import("../src/adapters/openai");
+    createOpenAiVideo("sora" as any, credentialsConfig);
 
-		assertFetchInjected(mockOpenAIVideoCtor, "test-api-key");
-		expect(mockOpenAIVideoCtor.mock.calls[0]![1]).toBe("sora");
-	});
+    assertFetchInjected(mockOpenAIVideoCtor, "test-api-key");
+    expect(mockOpenAIVideoCtor.mock.calls[0]![1]).toBe("sora");
+  });
 
-	it("createOpenAiChat defaults apiKey to 'unused'", async () => {
-		const { createOpenAiChat } = await import("../src/adapters/openai");
-		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-		createOpenAiChat("gpt-4o" as any, noKeyConfig as any);
+  it("createOpenAiChat defaults apiKey to 'unused'", async () => {
+    const { createOpenAiChat } = await import("../src/adapters/openai");
+    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+    createOpenAiChat("gpt-4o" as any, noKeyConfig as any);
 
-		const [config] = mockOpenAITextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("unused");
-	});
+    const [config] = mockOpenAITextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("unused");
+  });
 });
 
 describe("OpenRouter gateway adapters", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("createOpenRouterChat with credentials config", async () => {
-		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-		createOpenRouterChat("openai/gpt-4o", credentialsConfig);
+  it("createOpenRouterChat with credentials config", async () => {
+    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+    createOpenRouterChat("openai/gpt-4o", credentialsConfig);
 
-		expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
-		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("test-api-key");
-		expect(config.httpClient).toBeDefined();
-		expect(mockOpenRouterTextCtor.mock.calls[0]![1]).toBe("openai/gpt-4o");
-	});
+    expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
+    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("test-api-key");
+    expect(config.httpClient).toBeDefined();
+    expect(mockOpenRouterTextCtor.mock.calls[0]![1]).toBe("openai/gpt-4o");
+  });
 
-	it("createOpenRouterChat with binding config", async () => {
-		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-		createOpenRouterChat("openai/gpt-4o", bindingConfig);
+  it("createOpenRouterChat with binding config", async () => {
+    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+    createOpenRouterChat("openai/gpt-4o", bindingConfig);
 
-		expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
-		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("binding-api-key");
-		expect(config.httpClient).toBeDefined();
-	});
+    expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
+    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("binding-api-key");
+    expect(config.httpClient).toBeDefined();
+  });
 
-	it("createOpenRouterImage with credentials config", async () => {
-		const { createOpenRouterImage } = await import("../src/adapters/openrouter");
-		createOpenRouterImage("openai/dall-e-3", credentialsConfig);
+  it("createOpenRouterImage with credentials config", async () => {
+    const { createOpenRouterImage } = await import("../src/adapters/openrouter");
+    createOpenRouterImage("openai/dall-e-3", credentialsConfig);
 
-		expect(mockOpenRouterImageCtor).toHaveBeenCalledOnce();
-		const [config] = mockOpenRouterImageCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("test-api-key");
-		expect(config.httpClient).toBeDefined();
-		expect(mockOpenRouterImageCtor.mock.calls[0]![1]).toBe("openai/dall-e-3");
-	});
+    expect(mockOpenRouterImageCtor).toHaveBeenCalledOnce();
+    const [config] = mockOpenRouterImageCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("test-api-key");
+    expect(config.httpClient).toBeDefined();
+    expect(mockOpenRouterImageCtor.mock.calls[0]![1]).toBe("openai/dall-e-3");
+  });
 
-	it("createOpenRouterSummarize with credentials config", async () => {
-		const { createOpenRouterSummarize } = await import("../src/adapters/openrouter");
-		createOpenRouterSummarize("openai/gpt-4o", credentialsConfig);
+  it("createOpenRouterSummarize with credentials config", async () => {
+    const { createOpenRouterSummarize } = await import("../src/adapters/openrouter");
+    createOpenRouterSummarize("openai/gpt-4o", credentialsConfig);
 
-		expect(mockOpenRouterSummarizeCtor).toHaveBeenCalledOnce();
-		const [model, apiKey, cfg] = mockOpenRouterSummarizeCtor.mock.calls[0]!;
-		expect(model).toBe("openai/gpt-4o");
-		expect(apiKey).toBe("test-api-key");
-		expect(cfg.httpClient).toBeDefined();
-	});
+    expect(mockOpenRouterSummarizeCtor).toHaveBeenCalledOnce();
+    const [model, apiKey, cfg] = mockOpenRouterSummarizeCtor.mock.calls[0]!;
+    expect(model).toBe("openai/gpt-4o");
+    expect(apiKey).toBe("test-api-key");
+    expect(cfg.httpClient).toBeDefined();
+  });
 
-	it("createOpenRouterChat defaults apiKey to 'unused'", async () => {
-		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-		createOpenRouterChat("openai/gpt-4o", noKeyConfig as any);
+  it("createOpenRouterChat defaults apiKey to 'unused'", async () => {
+    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+    createOpenRouterChat("openai/gpt-4o", noKeyConfig as any);
 
-		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-		expect(config.apiKey).toBe("unused");
-	});
+    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+    expect(config.apiKey).toBe("unused");
+  });
 
-	it("createOpenRouterChat forwards byokAlias through the HTTPClient fetcher", async () => {
-		const originalFetch = globalThis.fetch;
-		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-		globalThis.fetch = mockFetch as any;
+  it("createOpenRouterChat forwards byokAlias through the HTTPClient fetcher", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+    globalThis.fetch = mockFetch as any;
 
-		try {
-			const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-			createOpenRouterChat("openai/gpt-4o", {
-				...credentialsConfig,
-				byokAlias: "development",
-			});
+    try {
+      const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+      createOpenRouterChat("openai/gpt-4o", {
+        ...credentialsConfig,
+        byokAlias: "development",
+      });
 
-			const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-			await config.httpClient.fetcher("https://openrouter.ai/api/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({ model: "openai/gpt-4o", messages: [] }),
-			});
+      const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+      await config.httpClient.fetcher("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "openai/gpt-4o", messages: [] }),
+      });
 
-			const [, init] = mockFetch.mock.calls[0]!;
-			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("gateway fetch integration", () => {
-	beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
-	it("credentials config produces fetch that calls global fetch with gateway URL", async () => {
-		const originalFetch = globalThis.fetch;
-		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-		globalThis.fetch = mockFetch as any;
+  it("credentials config produces fetch that calls global fetch with gateway URL", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+    globalThis.fetch = mockFetch as any;
 
-		try {
-			const { createOpenAiChat } = await import("../src/adapters/openai");
-			createOpenAiChat("gpt-4o" as any, credentialsConfig);
+    try {
+      const { createOpenAiChat } = await import("../src/adapters/openai");
+      createOpenAiChat("gpt-4o" as any, credentialsConfig);
 
-			const [config] = mockOpenAITextCtor.mock.calls[0]!;
-			await config.fetch("https://api.openai.com/v1/chat/completions", {
-				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-			});
+      const [config] = mockOpenAITextCtor.mock.calls[0]!;
+      await config.fetch("https://api.openai.com/v1/chat/completions", {
+        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+      });
 
-			expect(mockFetch).toHaveBeenCalledOnce();
-			const [url] = mockFetch.mock.calls[0]!;
-			expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	it("createOpenAiChat and createAnthropicChat forward byokAlias on REST", async () => {
-		const originalFetch = globalThis.fetch;
-		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-		globalThis.fetch = mockFetch as any;
+  it("createOpenAiChat and createAnthropicChat forward byokAlias on REST", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+    globalThis.fetch = mockFetch as any;
 
-		try {
-			const { createOpenAiChat } = await import("../src/adapters/openai");
-			const { createAnthropicChat } = await import("../src/adapters/anthropic");
-			const withAlias = { ...credentialsConfig, byokAlias: "development" };
+    try {
+      const { createOpenAiChat } = await import("../src/adapters/openai");
+      const { createAnthropicChat } = await import("../src/adapters/anthropic");
+      const withAlias = { ...credentialsConfig, byokAlias: "development" };
 
-			createOpenAiChat("gpt-4o" as any, withAlias);
-			await mockOpenAITextCtor.mock.calls[0]![0].fetch(
-				"https://api.openai.com/v1/chat/completions",
-				{ body: JSON.stringify({ model: "gpt-4o", messages: [] }) },
-			);
+      createOpenAiChat("gpt-4o" as any, withAlias);
+      await mockOpenAITextCtor.mock.calls[0]![0].fetch(
+        "https://api.openai.com/v1/chat/completions",
+        { body: JSON.stringify({ model: "gpt-4o", messages: [] }) },
+      );
 
-			createAnthropicChat("claude-sonnet-4-5" as any, withAlias);
-			await mockAnthropicTextCtor.mock.calls[0]![0].fetch(
-				"https://api.anthropic.com/v1/messages",
-				{ body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }) },
-			);
+      createAnthropicChat("claude-sonnet-4-5" as any, withAlias);
+      await mockAnthropicTextCtor.mock.calls[0]![0].fetch("https://api.anthropic.com/v1/messages", {
+        body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
+      });
 
-			expect(mockFetch).toHaveBeenCalledTimes(2);
-			for (const [, init] of mockFetch.mock.calls) {
-				expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-			}
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      for (const [, init] of mockFetch.mock.calls) {
+        expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
-	it("binding config produces fetch that calls binding.run", async () => {
-		const { createAnthropicChat } = await import("../src/adapters/anthropic");
-		createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
+  it("binding config produces fetch that calls binding.run", async () => {
+    const { createAnthropicChat } = await import("../src/adapters/anthropic");
+    createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
 
-		const [config] = mockAnthropicTextCtor.mock.calls[0]!;
-		await config.fetch("https://api.anthropic.com/v1/messages", {
-			body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
-		});
+    const [config] = mockAnthropicTextCtor.mock.calls[0]!;
+    await config.fetch("https://api.anthropic.com/v1/messages", {
+      body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
+    });
 
-		expect(mockBindingRun).toHaveBeenCalledOnce();
-		const requestPayload = mockBindingRun.mock.calls[0]![0] as Record<string, any>;
-		expect(requestPayload.provider).toBe("anthropic");
-		expect(requestPayload.headers).toBeDefined();
-		expect(requestPayload.headers["authorization"]).toBe("Bearer binding-api-key");
-	});
+    expect(mockBindingRun).toHaveBeenCalledOnce();
+    const requestPayload = mockBindingRun.mock.calls[0]![0] as Record<string, any>;
+    expect(requestPayload.provider).toBe("anthropic");
+    expect(requestPayload.headers).toBeDefined();
+    expect(requestPayload.headers["authorization"]).toBe("Bearer binding-api-key");
+  });
 
-	it("cache headers are passed through when config has caching options", async () => {
-		const originalFetch = globalThis.fetch;
-		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-		globalThis.fetch = mockFetch as any;
+  it("cache headers are passed through when config has caching options", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+    globalThis.fetch = mockFetch as any;
 
-		try {
-			const { createGrokChat } = await import("../src/adapters/grok");
-			createGrokChat("grok-3" as any, {
-				...credentialsConfig,
-				skipCache: true,
-				cacheTtl: 300,
-				customCacheKey: "my-key",
-				metadata: { env: "test" },
-				byokAlias: "development",
-			});
+    try {
+      const { createGrokChat } = await import("../src/adapters/grok");
+      createGrokChat("grok-3" as any, {
+        ...credentialsConfig,
+        skipCache: true,
+        cacheTtl: 300,
+        customCacheKey: "my-key",
+        metadata: { env: "test" },
+        byokAlias: "development",
+      });
 
-			const [config] = mockGrokTextCtor.mock.calls[0]!;
-			await config.fetch("https://api.x.ai/v1/chat/completions", {
-				body: JSON.stringify({ model: "grok-3", messages: [] }),
-			});
+      const [config] = mockGrokTextCtor.mock.calls[0]!;
+      await config.fetch("https://api.x.ai/v1/chat/completions", {
+        body: JSON.stringify({ model: "grok-3", messages: [] }),
+      });
 
-			expect(mockFetch).toHaveBeenCalledOnce();
-			const [, init] = mockFetch.mock.calls[0]!;
-			const body = JSON.parse((init as any).body);
-			expect(body.headers["cf-aig-skip-cache"]).toBe("true");
-			expect(body.headers["cf-aig-cache-ttl"]).toBe("300");
-			expect(body.headers["cf-aig-cache-key"]).toBe("my-key");
-			expect(body.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
-			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
-			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
-	});
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0]!;
+      const body = JSON.parse((init as any).body);
+      expect(body.headers["cf-aig-skip-cache"]).toBe("true");
+      expect(body.headers["cf-aig-cache-ttl"]).toBe("300");
+      expect(body.headers["cf-aig-cache-key"]).toBe("my-key");
+      expect(body.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
+      expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+      expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/tanstack-ai/test/gateway-adapters.test.ts
+++ b/packages/tanstack-ai/test/gateway-adapters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
 import type {
-  AiGatewayBindingConfig,
-  AiGatewayCredentialsConfig,
+	AiGatewayBindingConfig,
+	AiGatewayCredentialsConfig,
 } from "../src/utils/create-fetcher";
 import type { GeminiGatewayConfig } from "../src";
 
@@ -13,16 +13,16 @@ const mockAnthropicTextCtor = vi.fn();
 const mockAnthropicSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-anthropic", () => ({
-  AnthropicTextAdapter: class {
-    constructor(...args: unknown[]) {
-      mockAnthropicTextCtor(...args);
-    }
-  },
-  createAnthropicSummarize: (...args: unknown[]) => {
-    mockAnthropicSummarizeCtor(...args);
-    return {};
-  },
-  ANTHROPIC_MODELS: ["claude-sonnet-4-5"],
+	AnthropicTextAdapter: class {
+		constructor(...args: unknown[]) {
+			mockAnthropicTextCtor(...args);
+		}
+	},
+	createAnthropicSummarize: (...args: unknown[]) => {
+		mockAnthropicSummarizeCtor(...args);
+		return {};
+	},
+	ANTHROPIC_MODELS: ["claude-sonnet-4-5"],
 }));
 
 const mockGeminiTextCtor = vi.fn();
@@ -31,29 +31,29 @@ const mockGeminiSummarizeCtor = vi.fn();
 const mockGeminiTTSCtor = vi.fn();
 
 vi.mock("@tanstack/ai-gemini", () => ({
-  GeminiTextAdapter: class {
-    constructor(...args: unknown[]) {
-      mockGeminiTextCtor(...args);
-    }
-  },
-  GeminiImageAdapter: class {
-    constructor(...args: unknown[]) {
-      mockGeminiImageCtor(...args);
-    }
-  },
-  createGeminiSummarize: (...args: unknown[]) => {
-    mockGeminiSummarizeCtor(...args);
-    return {};
-  },
-  GeminiTTSAdapter: class {
-    constructor(...args: unknown[]) {
-      mockGeminiTTSCtor(...args);
-    }
-  },
-  GeminiTextModels: ["gemini-2.5-flash"],
-  GeminiImageModels: ["imagen-4.0-generate-001"],
-  GeminiSummarizeModels: ["gemini-2.0-flash"],
-  GeminiTTSModels: ["gemini-2.5-flash-preview-tts"],
+	GeminiTextAdapter: class {
+		constructor(...args: unknown[]) {
+			mockGeminiTextCtor(...args);
+		}
+	},
+	GeminiImageAdapter: class {
+		constructor(...args: unknown[]) {
+			mockGeminiImageCtor(...args);
+		}
+	},
+	createGeminiSummarize: (...args: unknown[]) => {
+		mockGeminiSummarizeCtor(...args);
+		return {};
+	},
+	GeminiTTSAdapter: class {
+		constructor(...args: unknown[]) {
+			mockGeminiTTSCtor(...args);
+		}
+	},
+	GeminiTextModels: ["gemini-2.5-flash"],
+	GeminiImageModels: ["imagen-4.0-generate-001"],
+	GeminiSummarizeModels: ["gemini-2.0-flash"],
+	GeminiTTSModels: ["gemini-2.5-flash-preview-tts"],
 }));
 
 const mockGrokTextCtor = vi.fn();
@@ -61,22 +61,22 @@ const mockGrokImageCtor = vi.fn();
 const mockGrokSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-grok", () => ({
-  GrokTextAdapter: class {
-    constructor(...args: unknown[]) {
-      mockGrokTextCtor(...args);
-    }
-  },
-  GrokImageAdapter: class {
-    constructor(...args: unknown[]) {
-      mockGrokImageCtor(...args);
-    }
-  },
-  createGrokSummarize: (...args: unknown[]) => {
-    mockGrokSummarizeCtor(...args);
-    return {};
-  },
-  GROK_CHAT_MODELS: ["grok-3"],
-  GROK_IMAGE_MODELS: ["grok-2-image-1212"],
+	GrokTextAdapter: class {
+		constructor(...args: unknown[]) {
+			mockGrokTextCtor(...args);
+		}
+	},
+	GrokImageAdapter: class {
+		constructor(...args: unknown[]) {
+			mockGrokImageCtor(...args);
+		}
+	},
+	createGrokSummarize: (...args: unknown[]) => {
+		mockGrokSummarizeCtor(...args);
+		return {};
+	},
+	GROK_CHAT_MODELS: ["grok-3"],
+	GROK_IMAGE_MODELS: ["grok-2-image-1212"],
 }));
 
 const mockOpenAITextCtor = vi.fn();
@@ -87,40 +87,40 @@ const mockOpenAITTSCtor = vi.fn();
 const mockOpenAIVideoCtor = vi.fn();
 
 vi.mock("@tanstack/ai-openai", () => ({
-  OpenAITextAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenAITextCtor(...args);
-    }
-  },
-  createOpenaiSummarize: (...args: unknown[]) => {
-    mockOpenAISummarizeCtor(...args);
-    return {};
-  },
-  OpenAIImageAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenAIImageCtor(...args);
-    }
-  },
-  OpenAITranscriptionAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenAITranscriptionCtor(...args);
-    }
-  },
-  OpenAITTSAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenAITTSCtor(...args);
-    }
-  },
-  OpenAIVideoAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenAIVideoCtor(...args);
-    }
-  },
-  OPENAI_CHAT_MODELS: ["gpt-4o"],
-  OPENAI_IMAGE_MODELS: ["dall-e-3"],
-  OPENAI_TRANSCRIPTION_MODELS: ["whisper-1"],
-  OPENAI_TTS_MODELS: ["tts-1"],
-  OPENAI_VIDEO_MODELS: ["sora"],
+	OpenAITextAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenAITextCtor(...args);
+		}
+	},
+	createOpenaiSummarize: (...args: unknown[]) => {
+		mockOpenAISummarizeCtor(...args);
+		return {};
+	},
+	OpenAIImageAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenAIImageCtor(...args);
+		}
+	},
+	OpenAITranscriptionAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenAITranscriptionCtor(...args);
+		}
+	},
+	OpenAITTSAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenAITTSCtor(...args);
+		}
+	},
+	OpenAIVideoAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenAIVideoCtor(...args);
+		}
+	},
+	OPENAI_CHAT_MODELS: ["gpt-4o"],
+	OPENAI_IMAGE_MODELS: ["dall-e-3"],
+	OPENAI_TRANSCRIPTION_MODELS: ["whisper-1"],
+	OPENAI_TTS_MODELS: ["tts-1"],
+	OPENAI_VIDEO_MODELS: ["sora"],
 }));
 
 vi.mock("@tanstack/ai", () => ({}));
@@ -129,29 +129,29 @@ const mockOpenRouterImageCtor = vi.fn();
 const mockOpenRouterSummarizeCtor = vi.fn();
 
 vi.mock("@tanstack/ai-openrouter", () => ({
-  OpenRouterTextAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenRouterTextCtor(...args);
-    }
-  },
-  OpenRouterImageAdapter: class {
-    constructor(...args: unknown[]) {
-      mockOpenRouterImageCtor(...args);
-    }
-  },
-  createOpenRouterSummarize: (...args: unknown[]) => {
-    mockOpenRouterSummarizeCtor(...args);
-    return {};
-  },
+	OpenRouterTextAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenRouterTextCtor(...args);
+		}
+	},
+	OpenRouterImageAdapter: class {
+		constructor(...args: unknown[]) {
+			mockOpenRouterImageCtor(...args);
+		}
+	},
+	createOpenRouterSummarize: (...args: unknown[]) => {
+		mockOpenRouterSummarizeCtor(...args);
+		return {};
+	},
 }));
 
 vi.mock("@openrouter/sdk", () => ({
-  HTTPClient: class {
-    fetcher: unknown;
-    constructor(opts: { fetcher?: unknown }) {
-      this.fetcher = opts?.fetcher;
-    }
-  },
+	HTTPClient: class {
+		fetcher: unknown;
+		constructor(opts: { fetcher?: unknown }) {
+			this.fetcher = opts?.fetcher;
+		}
+	},
 }));
 
 vi.mock("openai", () => ({ default: class {} }));
@@ -163,46 +163,46 @@ vi.mock("@google/genai", () => ({ GoogleGenAI: class {} }));
 // ---------------------------------------------------------------------------
 
 const credentialsConfig: AiGatewayCredentialsConfig = {
-  accountId: "test-account",
-  gatewayId: "test-gateway",
-  apiKey: "test-api-key",
+	accountId: "test-account",
+	gatewayId: "test-gateway",
+	apiKey: "test-api-key",
 };
 
 const geminiConfig: GeminiGatewayConfig = {
-  accountId: "test-account",
-  gatewayId: "test-gateway",
-  apiKey: "test-api-key",
+	accountId: "test-account",
+	gatewayId: "test-gateway",
+	apiKey: "test-api-key",
 };
 
 const geminiConfigWithCfKey: GeminiGatewayConfig = {
-  accountId: "test-account",
-  gatewayId: "test-gateway",
-  apiKey: "test-api-key",
-  cfApiKey: "cf-test-key",
+	accountId: "test-account",
+	gatewayId: "test-gateway",
+	apiKey: "test-api-key",
+	cfApiKey: "cf-test-key",
 };
 
 const mockBindingRun = vi.fn(async (..._args: unknown[]) => new Response("ok"));
 const bindingConfig: AiGatewayBindingConfig = {
-  binding: { run: mockBindingRun },
-  apiKey: "binding-api-key",
+	binding: { run: mockBindingRun },
+	apiKey: "binding-api-key",
 };
 
 function assertFetchInjected(ctor: Mock, expectedApiKey: string) {
-  expect(ctor).toHaveBeenCalledOnce();
-  const [config] = ctor.mock.calls[0]!;
-  expect(config.apiKey).toBe(expectedApiKey);
-  expect(typeof config.fetch).toBe("function");
-  return config;
+	expect(ctor).toHaveBeenCalledOnce();
+	const [config] = ctor.mock.calls[0]!;
+	expect(config.apiKey).toBe(expectedApiKey);
+	expect(typeof config.fetch).toBe("function");
+	return config;
 }
 
 function assertGeminiConfig(ctor: Mock, expectedApiKey: string) {
-  expect(ctor).toHaveBeenCalledOnce();
-  const [config] = ctor.mock.calls[0]!;
-  expect(config.apiKey).toBe(expectedApiKey);
-  expect(config.httpOptions).toBeDefined();
-  expect(config.httpOptions.baseUrl).toContain("gateway.ai.cloudflare.com");
-  expect(config.httpOptions.baseUrl).toContain("google-ai-studio");
-  return config;
+	expect(ctor).toHaveBeenCalledOnce();
+	const [config] = ctor.mock.calls[0]!;
+	expect(config.apiKey).toBe(expectedApiKey);
+	expect(config.httpOptions).toBeDefined();
+	expect(config.httpOptions.baseUrl).toContain("gateway.ai.cloudflare.com");
+	expect(config.httpOptions.baseUrl).toContain("google-ai-studio");
+	return config;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,480 +210,481 @@ function assertGeminiConfig(ctor: Mock, expectedApiKey: string) {
 // ---------------------------------------------------------------------------
 
 describe("Anthropic gateway adapters", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("createAnthropicChat with credentials config", async () => {
-    const { createAnthropicChat } = await import("../src/adapters/anthropic");
-    createAnthropicChat("claude-sonnet-4-5" as any, credentialsConfig);
+	it("createAnthropicChat with credentials config", async () => {
+		const { createAnthropicChat } = await import("../src/adapters/anthropic");
+		createAnthropicChat("claude-sonnet-4-5" as any, credentialsConfig);
 
-    assertFetchInjected(mockAnthropicTextCtor, "test-api-key");
-    // model is second arg
-    expect(mockAnthropicTextCtor.mock.calls[0]![1]).toBe("claude-sonnet-4-5");
-  });
+		assertFetchInjected(mockAnthropicTextCtor, "test-api-key");
+		// model is second arg
+		expect(mockAnthropicTextCtor.mock.calls[0]![1]).toBe("claude-sonnet-4-5");
+	});
 
-  it("createAnthropicChat with binding config", async () => {
-    const { createAnthropicChat } = await import("../src/adapters/anthropic");
-    createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
+	it("createAnthropicChat with binding config", async () => {
+		const { createAnthropicChat } = await import("../src/adapters/anthropic");
+		createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
 
-    const config = assertFetchInjected(mockAnthropicTextCtor, "binding-api-key");
-    // Invoke the fetch — should call binding.run
-    await config.fetch("https://api.anthropic.com/v1/messages", {
-      body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
-    });
-    expect(mockBindingRun).toHaveBeenCalledOnce();
-  });
+		const config = assertFetchInjected(mockAnthropicTextCtor, "binding-api-key");
+		// Invoke the fetch — should call binding.run
+		await config.fetch("https://api.anthropic.com/v1/messages", {
+			body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
+		});
+		expect(mockBindingRun).toHaveBeenCalledOnce();
+	});
 
-  it("createAnthropicChat defaults apiKey to 'unused'", async () => {
-    const { createAnthropicChat } = await import("../src/adapters/anthropic");
-    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-    createAnthropicChat("claude-sonnet-4-5" as any, noKeyConfig as any);
+	it("createAnthropicChat defaults apiKey to 'unused'", async () => {
+		const { createAnthropicChat } = await import("../src/adapters/anthropic");
+		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+		createAnthropicChat("claude-sonnet-4-5" as any, noKeyConfig as any);
 
-    const [config] = mockAnthropicTextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("unused");
-  });
+		const [config] = mockAnthropicTextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("unused");
+	});
 
-  it("createAnthropicSummarize with credentials config", async () => {
-    const { createAnthropicSummarize } = await import("../src/adapters/anthropic");
-    createAnthropicSummarize("claude-sonnet-4-5" as any, credentialsConfig);
+	it("createAnthropicSummarize with credentials config", async () => {
+		const { createAnthropicSummarize } = await import("../src/adapters/anthropic");
+		createAnthropicSummarize("claude-sonnet-4-5" as any, credentialsConfig);
 
-    expect(mockAnthropicSummarizeCtor).toHaveBeenCalledOnce();
-    const [model, apiKey, cfg] = mockAnthropicSummarizeCtor.mock.calls[0]!;
-    expect(model).toBe("claude-sonnet-4-5");
-    expect(apiKey).toBe("test-api-key");
-    expect(typeof cfg.fetch).toBe("function");
-  });
+		expect(mockAnthropicSummarizeCtor).toHaveBeenCalledOnce();
+		const [model, apiKey, cfg] = mockAnthropicSummarizeCtor.mock.calls[0]!;
+		expect(model).toBe("claude-sonnet-4-5");
+		expect(apiKey).toBe("test-api-key");
+		expect(typeof cfg.fetch).toBe("function");
+	});
 });
 
 describe("Gemini gateway adapters", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("createGeminiChat with credentials config", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
+	it("createGeminiChat with credentials config", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
 
-    const config = assertGeminiConfig(mockGeminiTextCtor, "test-api-key");
-    expect(config.httpOptions.baseUrl).toBe(
-      "https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/google-ai-studio",
-    );
-    expect(mockGeminiTextCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash");
-  });
+		const config = assertGeminiConfig(mockGeminiTextCtor, "test-api-key");
+		expect(config.httpOptions.baseUrl).toBe(
+			"https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/google-ai-studio",
+		);
+		expect(mockGeminiTextCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash");
+	});
 
-  it("createGeminiChat includes cf-aig-authorization header when cfApiKey provided", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    createGeminiChat("gemini-2.5-flash" as any, geminiConfigWithCfKey);
+	it("createGeminiChat includes cf-aig-authorization header when cfApiKey provided", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		createGeminiChat("gemini-2.5-flash" as any, geminiConfigWithCfKey);
 
-    const [config] = mockGeminiTextCtor.mock.calls[0]!;
-    expect(config.httpOptions.headers).toEqual({
-      "cf-aig-authorization": "Bearer cf-test-key",
-    });
-  });
+		const [config] = mockGeminiTextCtor.mock.calls[0]!;
+		expect(config.httpOptions.headers).toEqual({
+			"cf-aig-authorization": "Bearer cf-test-key",
+		});
+	});
 
-  it("createGeminiChat omits headers when no cfApiKey or cache options", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
+	it("createGeminiChat omits headers when no cfApiKey or cache options", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		createGeminiChat("gemini-2.5-flash" as any, geminiConfig);
 
-    const [config] = mockGeminiTextCtor.mock.calls[0]!;
-    expect(config.httpOptions.headers).toBeUndefined();
-  });
+		const [config] = mockGeminiTextCtor.mock.calls[0]!;
+		expect(config.httpOptions.headers).toBeUndefined();
+	});
 
-  it("createGeminiChat passes cache headers via httpOptions.headers", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    const configWithCache: GeminiGatewayConfig = {
-      ...geminiConfig,
-      skipCache: true,
-      cacheTtl: 300,
-      customCacheKey: "my-key",
-      metadata: { env: "test" },
-    };
-    createGeminiChat("gemini-2.5-flash" as any, configWithCache);
+	it("createGeminiChat passes cache headers via httpOptions.headers", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		const configWithCache: GeminiGatewayConfig = {
+			...geminiConfig,
+			skipCache: true,
+			cacheTtl: 300,
+			customCacheKey: "my-key",
+			metadata: { env: "test" },
+		};
+		createGeminiChat("gemini-2.5-flash" as any, configWithCache);
 
-    const [config] = mockGeminiTextCtor.mock.calls[0]!;
-    expect(config.httpOptions.headers["cf-aig-skip-cache"]).toBe("true");
-    expect(config.httpOptions.headers["cf-aig-cache-ttl"]).toBe("300");
-    expect(config.httpOptions.headers["cf-aig-cache-key"]).toBe("my-key");
-    expect(config.httpOptions.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
-  });
+		const [config] = mockGeminiTextCtor.mock.calls[0]!;
+		expect(config.httpOptions.headers["cf-aig-skip-cache"]).toBe("true");
+		expect(config.httpOptions.headers["cf-aig-cache-ttl"]).toBe("300");
+		expect(config.httpOptions.headers["cf-aig-cache-key"]).toBe("my-key");
+		expect(config.httpOptions.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
+	});
 
-  it("createGeminiChat passes byokAlias via httpOptions.headers", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    const configWithAlias: GeminiGatewayConfig = {
-      ...geminiConfig,
-      byokAlias: "development",
-    };
-    createGeminiChat("gemini-2.5-flash" as any, configWithAlias);
+	it("createGeminiChat passes byokAlias via httpOptions.headers", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		const configWithAlias: GeminiGatewayConfig = {
+			...geminiConfig,
+			byokAlias: "development",
+		};
+		createGeminiChat("gemini-2.5-flash" as any, configWithAlias);
 
-    const [config] = mockGeminiTextCtor.mock.calls[0]!;
-    expect(config.httpOptions.headers["cf-aig-byok-alias"]).toBe("development");
-  });
+		const [config] = mockGeminiTextCtor.mock.calls[0]!;
+		expect(config.httpOptions.headers["cf-aig-byok-alias"]).toBe("development");
+	});
 
-  it("createGeminiImage with credentials config", async () => {
-    const { createGeminiImage } = await import("../src/adapters/gemini");
-    createGeminiImage("imagen-4.0-generate-001" as any, geminiConfig);
+	it("createGeminiImage with credentials config", async () => {
+		const { createGeminiImage } = await import("../src/adapters/gemini");
+		createGeminiImage("imagen-4.0-generate-001" as any, geminiConfig);
 
-    assertGeminiConfig(mockGeminiImageCtor, "test-api-key");
-    expect(mockGeminiImageCtor.mock.calls[0]![1]).toBe("imagen-4.0-generate-001");
-  });
+		assertGeminiConfig(mockGeminiImageCtor, "test-api-key");
+		expect(mockGeminiImageCtor.mock.calls[0]![1]).toBe("imagen-4.0-generate-001");
+	});
 
-  it("createGeminiSummarize with credentials config", async () => {
-    const { createGeminiSummarize } = await import("../src/adapters/gemini");
-    createGeminiSummarize("gemini-2.0-flash" as any, geminiConfig);
+	it("createGeminiSummarize with credentials config", async () => {
+		const { createGeminiSummarize } = await import("../src/adapters/gemini");
+		createGeminiSummarize("gemini-2.0-flash" as any, geminiConfig);
 
-    expect(mockGeminiSummarizeCtor).toHaveBeenCalledOnce();
-    const [apiKey, model, cfg] = mockGeminiSummarizeCtor.mock.calls[0]!;
-    expect(apiKey).toBe("test-api-key");
-    expect(model).toBe("gemini-2.0-flash");
-    expect(cfg.httpOptions.baseUrl).toContain("google-ai-studio");
-  });
+		expect(mockGeminiSummarizeCtor).toHaveBeenCalledOnce();
+		const [apiKey, model, cfg] = mockGeminiSummarizeCtor.mock.calls[0]!;
+		expect(apiKey).toBe("test-api-key");
+		expect(model).toBe("gemini-2.0-flash");
+		expect(cfg.httpOptions.baseUrl).toContain("google-ai-studio");
+	});
 
-  it("createGeminiTts with credentials config", async () => {
-    const { createGeminiTts } = await import("../src/adapters/gemini");
-    createGeminiTts("gemini-2.5-flash-preview-tts" as any, geminiConfig);
+	it("createGeminiTts with credentials config", async () => {
+		const { createGeminiTts } = await import("../src/adapters/gemini");
+		createGeminiTts("gemini-2.5-flash-preview-tts" as any, geminiConfig);
 
-    assertGeminiConfig(mockGeminiTTSCtor, "test-api-key");
-    expect(mockGeminiTTSCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash-preview-tts");
-  });
+		assertGeminiConfig(mockGeminiTTSCtor, "test-api-key");
+		expect(mockGeminiTTSCtor.mock.calls[0]![1]).toBe("gemini-2.5-flash-preview-tts");
+	});
 
-  it("createGeminiChat throws on binding config (runtime guard)", async () => {
-    const { createGeminiChat } = await import("../src/adapters/gemini");
-    const bindingStyleConfig = {
-      binding: { run: async () => new Response("ok") },
-    };
-    expect(() => createGeminiChat("gemini-2.5-flash" as any, bindingStyleConfig as any)).toThrow(
-      /Gemini adapters do not support binding config/,
-    );
-  });
+	it("createGeminiChat throws on binding config (runtime guard)", async () => {
+		const { createGeminiChat } = await import("../src/adapters/gemini");
+		const bindingStyleConfig = {
+			binding: { run: async () => new Response("ok") },
+		};
+		expect(() =>
+			createGeminiChat("gemini-2.5-flash" as any, bindingStyleConfig as any),
+		).toThrow(/Gemini adapters do not support binding config/);
+	});
 
-  it("createGeminiImage throws on binding config (runtime guard)", async () => {
-    const { createGeminiImage } = await import("../src/adapters/gemini");
-    const bindingStyleConfig = {
-      binding: { run: async () => new Response("ok") },
-    };
-    expect(() =>
-      createGeminiImage("imagen-4.0-generate-001" as any, bindingStyleConfig as any),
-    ).toThrow(/Gemini adapters do not support binding config/);
-  });
+	it("createGeminiImage throws on binding config (runtime guard)", async () => {
+		const { createGeminiImage } = await import("../src/adapters/gemini");
+		const bindingStyleConfig = {
+			binding: { run: async () => new Response("ok") },
+		};
+		expect(() =>
+			createGeminiImage("imagen-4.0-generate-001" as any, bindingStyleConfig as any),
+		).toThrow(/Gemini adapters do not support binding config/);
+	});
 
-  it("createGeminiTts throws on binding config (runtime guard)", async () => {
-    const { createGeminiTts } = await import("../src/adapters/gemini");
-    const bindingStyleConfig = {
-      binding: { run: async () => new Response("ok") },
-    };
-    expect(() =>
-      createGeminiTts("gemini-2.5-flash-preview-tts" as any, bindingStyleConfig as any),
-    ).toThrow(/googleapis\/js-genai/);
-  });
+	it("createGeminiTts throws on binding config (runtime guard)", async () => {
+		const { createGeminiTts } = await import("../src/adapters/gemini");
+		const bindingStyleConfig = {
+			binding: { run: async () => new Response("ok") },
+		};
+		expect(() =>
+			createGeminiTts("gemini-2.5-flash-preview-tts" as any, bindingStyleConfig as any),
+		).toThrow(/googleapis\/js-genai/);
+	});
 });
 
 describe("Grok gateway adapters", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("createGrokChat with credentials config", async () => {
-    const { createGrokChat } = await import("../src/adapters/grok");
-    createGrokChat("grok-3" as any, credentialsConfig);
+	it("createGrokChat with credentials config", async () => {
+		const { createGrokChat } = await import("../src/adapters/grok");
+		createGrokChat("grok-3" as any, credentialsConfig);
 
-    assertFetchInjected(mockGrokTextCtor, "test-api-key");
-    expect(mockGrokTextCtor.mock.calls[0]![1]).toBe("grok-3");
-  });
+		assertFetchInjected(mockGrokTextCtor, "test-api-key");
+		expect(mockGrokTextCtor.mock.calls[0]![1]).toBe("grok-3");
+	});
 
-  it("createGrokChat with binding config", async () => {
-    const { createGrokChat } = await import("../src/adapters/grok");
-    createGrokChat("grok-3" as any, bindingConfig);
+	it("createGrokChat with binding config", async () => {
+		const { createGrokChat } = await import("../src/adapters/grok");
+		createGrokChat("grok-3" as any, bindingConfig);
 
-    const config = assertFetchInjected(mockGrokTextCtor, "binding-api-key");
-    await config.fetch("https://api.x.ai/v1/chat/completions", {
-      body: JSON.stringify({ model: "grok-3", messages: [] }),
-    });
-    expect(mockBindingRun).toHaveBeenCalledOnce();
-  });
+		const config = assertFetchInjected(mockGrokTextCtor, "binding-api-key");
+		await config.fetch("https://api.x.ai/v1/chat/completions", {
+			body: JSON.stringify({ model: "grok-3", messages: [] }),
+		});
+		expect(mockBindingRun).toHaveBeenCalledOnce();
+	});
 
-  it("createGrokImage with credentials config", async () => {
-    const { createGrokImage } = await import("../src/adapters/grok");
-    createGrokImage("grok-2-image-1212" as any, credentialsConfig);
+	it("createGrokImage with credentials config", async () => {
+		const { createGrokImage } = await import("../src/adapters/grok");
+		createGrokImage("grok-2-image-1212" as any, credentialsConfig);
 
-    assertFetchInjected(mockGrokImageCtor, "test-api-key");
-    expect(mockGrokImageCtor.mock.calls[0]![1]).toBe("grok-2-image-1212");
-  });
+		assertFetchInjected(mockGrokImageCtor, "test-api-key");
+		expect(mockGrokImageCtor.mock.calls[0]![1]).toBe("grok-2-image-1212");
+	});
 
-  it("createGrokSummarize with credentials config", async () => {
-    const { createGrokSummarize } = await import("../src/adapters/grok");
-    createGrokSummarize("grok-3" as any, credentialsConfig);
+	it("createGrokSummarize with credentials config", async () => {
+		const { createGrokSummarize } = await import("../src/adapters/grok");
+		createGrokSummarize("grok-3" as any, credentialsConfig);
 
-    expect(mockGrokSummarizeCtor).toHaveBeenCalledOnce();
-    const [model, apiKey, cfg] = mockGrokSummarizeCtor.mock.calls[0]!;
-    expect(model).toBe("grok-3");
-    expect(apiKey).toBe("test-api-key");
-    expect(typeof cfg.fetch).toBe("function");
-  });
+		expect(mockGrokSummarizeCtor).toHaveBeenCalledOnce();
+		const [model, apiKey, cfg] = mockGrokSummarizeCtor.mock.calls[0]!;
+		expect(model).toBe("grok-3");
+		expect(apiKey).toBe("test-api-key");
+		expect(typeof cfg.fetch).toBe("function");
+	});
 
-  it("createGrokChat defaults apiKey to 'unused'", async () => {
-    const { createGrokChat } = await import("../src/adapters/grok");
-    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-    createGrokChat("grok-3" as any, noKeyConfig as any);
+	it("createGrokChat defaults apiKey to 'unused'", async () => {
+		const { createGrokChat } = await import("../src/adapters/grok");
+		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+		createGrokChat("grok-3" as any, noKeyConfig as any);
 
-    const [config] = mockGrokTextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("unused");
-  });
+		const [config] = mockGrokTextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("unused");
+	});
 });
 
 describe("OpenAI gateway adapters", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("createOpenAiChat with credentials config", async () => {
-    const { createOpenAiChat } = await import("../src/adapters/openai");
-    createOpenAiChat("gpt-4o" as any, credentialsConfig);
+	it("createOpenAiChat with credentials config", async () => {
+		const { createOpenAiChat } = await import("../src/adapters/openai");
+		createOpenAiChat("gpt-4o" as any, credentialsConfig);
 
-    assertFetchInjected(mockOpenAITextCtor, "test-api-key");
-    expect(mockOpenAITextCtor.mock.calls[0]![1]).toBe("gpt-4o");
-  });
+		assertFetchInjected(mockOpenAITextCtor, "test-api-key");
+		expect(mockOpenAITextCtor.mock.calls[0]![1]).toBe("gpt-4o");
+	});
 
-  it("createOpenAiChat with binding config", async () => {
-    const { createOpenAiChat } = await import("../src/adapters/openai");
-    createOpenAiChat("gpt-4o" as any, bindingConfig);
+	it("createOpenAiChat with binding config", async () => {
+		const { createOpenAiChat } = await import("../src/adapters/openai");
+		createOpenAiChat("gpt-4o" as any, bindingConfig);
 
-    const config = assertFetchInjected(mockOpenAITextCtor, "binding-api-key");
-    await config.fetch("https://api.openai.com/v1/chat/completions", {
-      body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-    });
-    expect(mockBindingRun).toHaveBeenCalledOnce();
-  });
+		const config = assertFetchInjected(mockOpenAITextCtor, "binding-api-key");
+		await config.fetch("https://api.openai.com/v1/chat/completions", {
+			body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+		});
+		expect(mockBindingRun).toHaveBeenCalledOnce();
+	});
 
-  it("createOpenAiSummarize with credentials config", async () => {
-    const { createOpenAiSummarize } = await import("../src/adapters/openai");
-    createOpenAiSummarize("gpt-4o" as any, credentialsConfig);
+	it("createOpenAiSummarize with credentials config", async () => {
+		const { createOpenAiSummarize } = await import("../src/adapters/openai");
+		createOpenAiSummarize("gpt-4o" as any, credentialsConfig);
 
-    expect(mockOpenAISummarizeCtor).toHaveBeenCalledOnce();
-    const [model, apiKey, cfg] = mockOpenAISummarizeCtor.mock.calls[0]!;
-    expect(model).toBe("gpt-4o");
-    expect(apiKey).toBe("test-api-key");
-    expect(typeof cfg.fetch).toBe("function");
-  });
+		expect(mockOpenAISummarizeCtor).toHaveBeenCalledOnce();
+		const [model, apiKey, cfg] = mockOpenAISummarizeCtor.mock.calls[0]!;
+		expect(model).toBe("gpt-4o");
+		expect(apiKey).toBe("test-api-key");
+		expect(typeof cfg.fetch).toBe("function");
+	});
 
-  it("createOpenAiImage with credentials config", async () => {
-    const { createOpenAiImage } = await import("../src/adapters/openai");
-    createOpenAiImage("dall-e-3" as any, credentialsConfig);
+	it("createOpenAiImage with credentials config", async () => {
+		const { createOpenAiImage } = await import("../src/adapters/openai");
+		createOpenAiImage("dall-e-3" as any, credentialsConfig);
 
-    assertFetchInjected(mockOpenAIImageCtor, "test-api-key");
-    expect(mockOpenAIImageCtor.mock.calls[0]![1]).toBe("dall-e-3");
-  });
+		assertFetchInjected(mockOpenAIImageCtor, "test-api-key");
+		expect(mockOpenAIImageCtor.mock.calls[0]![1]).toBe("dall-e-3");
+	});
 
-  it("createOpenAiTranscription with credentials config", async () => {
-    const { createOpenAiTranscription } = await import("../src/adapters/openai");
-    createOpenAiTranscription("whisper-1" as any, credentialsConfig);
+	it("createOpenAiTranscription with credentials config", async () => {
+		const { createOpenAiTranscription } = await import("../src/adapters/openai");
+		createOpenAiTranscription("whisper-1" as any, credentialsConfig);
 
-    assertFetchInjected(mockOpenAITranscriptionCtor, "test-api-key");
-    expect(mockOpenAITranscriptionCtor.mock.calls[0]![1]).toBe("whisper-1");
-  });
+		assertFetchInjected(mockOpenAITranscriptionCtor, "test-api-key");
+		expect(mockOpenAITranscriptionCtor.mock.calls[0]![1]).toBe("whisper-1");
+	});
 
-  it("createOpenAiTts with credentials config", async () => {
-    const { createOpenAiTts } = await import("../src/adapters/openai");
-    createOpenAiTts("tts-1" as any, credentialsConfig);
+	it("createOpenAiTts with credentials config", async () => {
+		const { createOpenAiTts } = await import("../src/adapters/openai");
+		createOpenAiTts("tts-1" as any, credentialsConfig);
 
-    assertFetchInjected(mockOpenAITTSCtor, "test-api-key");
-    expect(mockOpenAITTSCtor.mock.calls[0]![1]).toBe("tts-1");
-  });
+		assertFetchInjected(mockOpenAITTSCtor, "test-api-key");
+		expect(mockOpenAITTSCtor.mock.calls[0]![1]).toBe("tts-1");
+	});
 
-  it("createOpenAiVideo with credentials config", async () => {
-    const { createOpenAiVideo } = await import("../src/adapters/openai");
-    createOpenAiVideo("sora" as any, credentialsConfig);
+	it("createOpenAiVideo with credentials config", async () => {
+		const { createOpenAiVideo } = await import("../src/adapters/openai");
+		createOpenAiVideo("sora" as any, credentialsConfig);
 
-    assertFetchInjected(mockOpenAIVideoCtor, "test-api-key");
-    expect(mockOpenAIVideoCtor.mock.calls[0]![1]).toBe("sora");
-  });
+		assertFetchInjected(mockOpenAIVideoCtor, "test-api-key");
+		expect(mockOpenAIVideoCtor.mock.calls[0]![1]).toBe("sora");
+	});
 
-  it("createOpenAiChat defaults apiKey to 'unused'", async () => {
-    const { createOpenAiChat } = await import("../src/adapters/openai");
-    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-    createOpenAiChat("gpt-4o" as any, noKeyConfig as any);
+	it("createOpenAiChat defaults apiKey to 'unused'", async () => {
+		const { createOpenAiChat } = await import("../src/adapters/openai");
+		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+		createOpenAiChat("gpt-4o" as any, noKeyConfig as any);
 
-    const [config] = mockOpenAITextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("unused");
-  });
+		const [config] = mockOpenAITextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("unused");
+	});
 });
 
 describe("OpenRouter gateway adapters", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("createOpenRouterChat with credentials config", async () => {
-    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-    createOpenRouterChat("openai/gpt-4o", credentialsConfig);
+	it("createOpenRouterChat with credentials config", async () => {
+		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+		createOpenRouterChat("openai/gpt-4o", credentialsConfig);
 
-    expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
-    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("test-api-key");
-    expect(config.httpClient).toBeDefined();
-    expect(mockOpenRouterTextCtor.mock.calls[0]![1]).toBe("openai/gpt-4o");
-  });
+		expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
+		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("test-api-key");
+		expect(config.httpClient).toBeDefined();
+		expect(mockOpenRouterTextCtor.mock.calls[0]![1]).toBe("openai/gpt-4o");
+	});
 
-  it("createOpenRouterChat with binding config", async () => {
-    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-    createOpenRouterChat("openai/gpt-4o", bindingConfig);
+	it("createOpenRouterChat with binding config", async () => {
+		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+		createOpenRouterChat("openai/gpt-4o", bindingConfig);
 
-    expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
-    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("binding-api-key");
-    expect(config.httpClient).toBeDefined();
-  });
+		expect(mockOpenRouterTextCtor).toHaveBeenCalledOnce();
+		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("binding-api-key");
+		expect(config.httpClient).toBeDefined();
+	});
 
-  it("createOpenRouterImage with credentials config", async () => {
-    const { createOpenRouterImage } = await import("../src/adapters/openrouter");
-    createOpenRouterImage("openai/dall-e-3", credentialsConfig);
+	it("createOpenRouterImage with credentials config", async () => {
+		const { createOpenRouterImage } = await import("../src/adapters/openrouter");
+		createOpenRouterImage("openai/dall-e-3", credentialsConfig);
 
-    expect(mockOpenRouterImageCtor).toHaveBeenCalledOnce();
-    const [config] = mockOpenRouterImageCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("test-api-key");
-    expect(config.httpClient).toBeDefined();
-    expect(mockOpenRouterImageCtor.mock.calls[0]![1]).toBe("openai/dall-e-3");
-  });
+		expect(mockOpenRouterImageCtor).toHaveBeenCalledOnce();
+		const [config] = mockOpenRouterImageCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("test-api-key");
+		expect(config.httpClient).toBeDefined();
+		expect(mockOpenRouterImageCtor.mock.calls[0]![1]).toBe("openai/dall-e-3");
+	});
 
-  it("createOpenRouterSummarize with credentials config", async () => {
-    const { createOpenRouterSummarize } = await import("../src/adapters/openrouter");
-    createOpenRouterSummarize("openai/gpt-4o", credentialsConfig);
+	it("createOpenRouterSummarize with credentials config", async () => {
+		const { createOpenRouterSummarize } = await import("../src/adapters/openrouter");
+		createOpenRouterSummarize("openai/gpt-4o", credentialsConfig);
 
-    expect(mockOpenRouterSummarizeCtor).toHaveBeenCalledOnce();
-    const [model, apiKey, cfg] = mockOpenRouterSummarizeCtor.mock.calls[0]!;
-    expect(model).toBe("openai/gpt-4o");
-    expect(apiKey).toBe("test-api-key");
-    expect(cfg.httpClient).toBeDefined();
-  });
+		expect(mockOpenRouterSummarizeCtor).toHaveBeenCalledOnce();
+		const [model, apiKey, cfg] = mockOpenRouterSummarizeCtor.mock.calls[0]!;
+		expect(model).toBe("openai/gpt-4o");
+		expect(apiKey).toBe("test-api-key");
+		expect(cfg.httpClient).toBeDefined();
+	});
 
-  it("createOpenRouterChat defaults apiKey to 'unused'", async () => {
-    const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-    const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
-    createOpenRouterChat("openai/gpt-4o", noKeyConfig as any);
+	it("createOpenRouterChat defaults apiKey to 'unused'", async () => {
+		const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+		const noKeyConfig = { ...credentialsConfig, apiKey: undefined };
+		createOpenRouterChat("openai/gpt-4o", noKeyConfig as any);
 
-    const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-    expect(config.apiKey).toBe("unused");
-  });
+		const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+		expect(config.apiKey).toBe("unused");
+	});
 
-  it("createOpenRouterChat forwards byokAlias through the HTTPClient fetcher", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-    globalThis.fetch = mockFetch as any;
+	it("createOpenRouterChat forwards byokAlias through the HTTPClient fetcher", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
 
-    try {
-      const { createOpenRouterChat } = await import("../src/adapters/openrouter");
-      createOpenRouterChat("openai/gpt-4o", {
-        ...credentialsConfig,
-        byokAlias: "development",
-      });
+		try {
+			const { createOpenRouterChat } = await import("../src/adapters/openrouter");
+			createOpenRouterChat("openai/gpt-4o", {
+				...credentialsConfig,
+				byokAlias: "development",
+			});
 
-      const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
-      await config.httpClient.fetcher("https://openrouter.ai/api/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({ model: "openai/gpt-4o", messages: [] }),
-      });
+			const [config] = mockOpenRouterTextCtor.mock.calls[0]!;
+			await config.httpClient.fetcher("https://openrouter.ai/api/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "openai/gpt-4o", messages: [] }),
+			});
 
-      const [, init] = mockFetch.mock.calls[0]!;
-      expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });
 
 describe("gateway fetch integration", () => {
-  beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => vi.clearAllMocks());
 
-  it("credentials config produces fetch that calls global fetch with gateway URL", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-    globalThis.fetch = mockFetch as any;
+	it("credentials config produces fetch that calls global fetch with gateway URL", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
 
-    try {
-      const { createOpenAiChat } = await import("../src/adapters/openai");
-      createOpenAiChat("gpt-4o" as any, credentialsConfig);
+		try {
+			const { createOpenAiChat } = await import("../src/adapters/openai");
+			createOpenAiChat("gpt-4o" as any, credentialsConfig);
 
-      const [config] = mockOpenAITextCtor.mock.calls[0]!;
-      await config.fetch("https://api.openai.com/v1/chat/completions", {
-        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-      });
+			const [config] = mockOpenAITextCtor.mock.calls[0]!;
+			await config.fetch("https://api.openai.com/v1/chat/completions", {
+				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+			});
 
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
+			expect(mockFetch).toHaveBeenCalledOnce();
+			const [url] = mockFetch.mock.calls[0]!;
+			expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 
-  it("createOpenAiChat and createAnthropicChat forward byokAlias on REST", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-    globalThis.fetch = mockFetch as any;
+	it("createOpenAiChat and createAnthropicChat forward byokAlias on REST", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
 
-    try {
-      const { createOpenAiChat } = await import("../src/adapters/openai");
-      const { createAnthropicChat } = await import("../src/adapters/anthropic");
-      const withAlias = { ...credentialsConfig, byokAlias: "development" };
+		try {
+			const { createOpenAiChat } = await import("../src/adapters/openai");
+			const { createAnthropicChat } = await import("../src/adapters/anthropic");
+			const withAlias = { ...credentialsConfig, byokAlias: "development" };
 
-      createOpenAiChat("gpt-4o" as any, withAlias);
-      await mockOpenAITextCtor.mock.calls[0]![0].fetch(
-        "https://api.openai.com/v1/chat/completions",
-        { body: JSON.stringify({ model: "gpt-4o", messages: [] }) },
-      );
+			createOpenAiChat("gpt-4o" as any, withAlias);
+			await mockOpenAITextCtor.mock.calls[0]![0].fetch(
+				"https://api.openai.com/v1/chat/completions",
+				{ body: JSON.stringify({ model: "gpt-4o", messages: [] }) },
+			);
 
-      createAnthropicChat("claude-sonnet-4-5" as any, withAlias);
-      await mockAnthropicTextCtor.mock.calls[0]![0].fetch("https://api.anthropic.com/v1/messages", {
-        body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
-      });
+			createAnthropicChat("claude-sonnet-4-5" as any, withAlias);
+			await mockAnthropicTextCtor.mock.calls[0]![0].fetch(
+				"https://api.anthropic.com/v1/messages",
+				{ body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }) },
+			);
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      for (const [, init] of mockFetch.mock.calls) {
-        expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-      }
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+			for (const [, init] of mockFetch.mock.calls) {
+				expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+			}
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 
-  it("binding config produces fetch that calls binding.run", async () => {
-    const { createAnthropicChat } = await import("../src/adapters/anthropic");
-    createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
+	it("binding config produces fetch that calls binding.run", async () => {
+		const { createAnthropicChat } = await import("../src/adapters/anthropic");
+		createAnthropicChat("claude-sonnet-4-5" as any, bindingConfig);
 
-    const [config] = mockAnthropicTextCtor.mock.calls[0]!;
-    await config.fetch("https://api.anthropic.com/v1/messages", {
-      body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
-    });
+		const [config] = mockAnthropicTextCtor.mock.calls[0]!;
+		await config.fetch("https://api.anthropic.com/v1/messages", {
+			body: JSON.stringify({ model: "claude-sonnet-4-5", messages: [] }),
+		});
 
-    expect(mockBindingRun).toHaveBeenCalledOnce();
-    const requestPayload = mockBindingRun.mock.calls[0]![0] as Record<string, any>;
-    expect(requestPayload.provider).toBe("anthropic");
-    expect(requestPayload.headers).toBeDefined();
-    expect(requestPayload.headers["authorization"]).toBe("Bearer binding-api-key");
-  });
+		expect(mockBindingRun).toHaveBeenCalledOnce();
+		const requestPayload = mockBindingRun.mock.calls[0]![0] as Record<string, any>;
+		expect(requestPayload.provider).toBe("anthropic");
+		expect(requestPayload.headers).toBeDefined();
+		expect(requestPayload.headers["authorization"]).toBe("Bearer binding-api-key");
+	});
 
-  it("cache headers are passed through when config has caching options", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
-    globalThis.fetch = mockFetch as any;
+	it("cache headers are passed through when config has caching options", async () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn(async (..._args: unknown[]) => new Response("ok"));
+		globalThis.fetch = mockFetch as any;
 
-    try {
-      const { createGrokChat } = await import("../src/adapters/grok");
-      createGrokChat("grok-3" as any, {
-        ...credentialsConfig,
-        skipCache: true,
-        cacheTtl: 300,
-        customCacheKey: "my-key",
-        metadata: { env: "test" },
-        byokAlias: "development",
-      });
+		try {
+			const { createGrokChat } = await import("../src/adapters/grok");
+			createGrokChat("grok-3" as any, {
+				...credentialsConfig,
+				skipCache: true,
+				cacheTtl: 300,
+				customCacheKey: "my-key",
+				metadata: { env: "test" },
+				byokAlias: "development",
+			});
 
-      const [config] = mockGrokTextCtor.mock.calls[0]!;
-      await config.fetch("https://api.x.ai/v1/chat/completions", {
-        body: JSON.stringify({ model: "grok-3", messages: [] }),
-      });
+			const [config] = mockGrokTextCtor.mock.calls[0]!;
+			await config.fetch("https://api.x.ai/v1/chat/completions", {
+				body: JSON.stringify({ model: "grok-3", messages: [] }),
+			});
 
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [, init] = mockFetch.mock.calls[0]!;
-      const body = JSON.parse((init as any).body);
-      expect(body.headers["cf-aig-skip-cache"]).toBe("true");
-      expect(body.headers["cf-aig-cache-ttl"]).toBe("300");
-      expect(body.headers["cf-aig-cache-key"]).toBe("my-key");
-      expect(body.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
-      expect(body.headers["cf-aig-byok-alias"]).toBe("development");
-      expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
+			expect(mockFetch).toHaveBeenCalledOnce();
+			const [, init] = mockFetch.mock.calls[0]!;
+			const body = JSON.parse((init as any).body);
+			expect(body.headers["cf-aig-skip-cache"]).toBe("true");
+			expect(body.headers["cf-aig-cache-ttl"]).toBe("300");
+			expect(body.headers["cf-aig-cache-key"]).toBe("my-key");
+			expect(body.headers["cf-aig-metadata"]).toBe(JSON.stringify({ env: "test" }));
+			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+			expect((init as any).headers["cf-aig-byok-alias"]).toBe("development");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
 });

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -212,6 +212,24 @@ describe("createGatewayFetch", () => {
 			const [, init] = mockFetch.mock.calls[0]!;
 			expect(init.headers["cf-aig-authorization"]).toBeUndefined();
 		});
+
+		it("should set cf-aig-byok-alias on the outer REST request", async () => {
+			const fetcher = createGatewayFetch("openrouter", {
+				...credentialsConfig,
+				byokAlias: "development",
+			});
+
+			await fetcher("https://openrouter.ai/api/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect(init.headers["cf-aig-byok-alias"]).toBe("development");
+			const body = JSON.parse(init.body);
+			expect(body.provider).toBe("openrouter");
+			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+		});
 	});
 
 	describe("cache headers", () => {
@@ -304,6 +322,23 @@ describe("createGatewayFetch", () => {
 			expect(request.headers["cf-aig-cache-ttl"]).toBeUndefined();
 			expect(request.headers["cf-aig-cache-key"]).toBeUndefined();
 			expect(request.headers["cf-aig-metadata"]).toBeUndefined();
+			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
+		});
+
+		it("does not set cf-aig-byok-alias on the binding path", async () => {
+			const config = {
+				binding: mockBinding,
+				byokAlias: "development",
+			} as AiGatewayAdapterConfig;
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
 		});
 	});
 

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  createGatewayFetch,
-  type AiGatewayAdapterConfig,
-  type AiGatewayBindingConfig,
-  type AiGatewayCredentialsConfig,
+	createGatewayFetch,
+	type AiGatewayAdapterConfig,
+	type AiGatewayBindingConfig,
+	type AiGatewayCredentialsConfig,
 } from "../src/utils/create-fetcher";
 
 // ---------------------------------------------------------------------------
@@ -11,538 +11,538 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("createGatewayFetch", () => {
-  const mockResponse = new Response("ok", { status: 200 });
-
-  describe("binding config", () => {
-    const mockBinding = {
-      run: vi.fn().mockResolvedValue(mockResponse),
-    };
-
-    const bindingConfig: AiGatewayBindingConfig = {
-      binding: mockBinding,
-    };
-
-    beforeEach(() => {
-      mockBinding.run.mockClear();
-    });
-
-    it("should call binding.run with the correct request structure", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-      });
-
-      expect(mockBinding.run).toHaveBeenCalledOnce();
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.provider).toBe("openai");
-      expect(request.endpoint).toBe("chat/completions");
-      expect(request.query).toEqual({ model: "gpt-4o", messages: [] });
-      expect(request.headers["Content-Type"]).toBe("application/json");
-    });
-
-    it("should strip /v1/ prefix from endpoint", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-
-      await fetcher("https://api.openai.com/v1/audio/transcriptions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("audio/transcriptions");
-    });
-
-    it("should handle URL objects as input", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-      const url = new URL("https://api.openai.com/v1/chat/completions");
-
-      await fetcher(url, {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o" }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("chat/completions");
-    });
-
-    it("should handle Request objects as input", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-      const req = new Request("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o" }),
-      });
-
-      await fetcher(req, {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o" }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("chat/completions");
-    });
-
-    it("should set authorization header when apiKey is provided", async () => {
-      const configWithKey: AiGatewayBindingConfig = {
-        binding: mockBinding,
-        apiKey: "sk-test-key",
-      };
-      const fetcher = createGatewayFetch("openai", configWithKey);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["authorization"]).toBe("Bearer sk-test-key");
-    });
-
-    it("should not set authorization header when apiKey is absent", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["authorization"]).toBeUndefined();
-    });
-
-    it("should include extra headers passed to createGatewayFetch", async () => {
-      const fetcher = createGatewayFetch("anthropic", bindingConfig, {
-        "anthropic-version": "2023-06-01",
-      });
-
-      await fetcher("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["anthropic-version"]).toBe("2023-06-01");
-    });
-
-    it("should handle non-JSON body by wrapping in _raw", async () => {
-      const fetcher = createGatewayFetch("openai", bindingConfig);
-
-      await fetcher("https://api.openai.com/v1/audio/transcriptions", {
-        method: "POST",
-        body: "not-json-content",
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.query).toEqual({ _raw: "not-json-content" });
-    });
-  });
-
-  describe("credentials config", () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
-
-    beforeEach(() => {
-      globalThis.fetch = mockFetch;
-      mockFetch.mockClear();
-    });
-
-    afterEach(() => {
-      globalThis.fetch = originalFetch;
-    });
-
-    const credentialsConfig: AiGatewayCredentialsConfig = {
-      accountId: "test-account",
-      gatewayId: "test-gateway",
-      apiKey: "test-cf-api-key",
-    };
-
-    it("should call fetch with the correct gateway URL", async () => {
-      const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o" }),
-      });
-
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
-    });
-
-    it("should send the request object as JSON body", async () => {
-      const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-      });
-
-      const [, init] = mockFetch.mock.calls[0]!;
-      const body = JSON.parse(init.body);
-      expect(body.provider).toBe("openai");
-      expect(body.endpoint).toBe("chat/completions");
-      expect(body.query).toEqual({ model: "gpt-4o", messages: [] });
-    });
-
-    it("should set cf-aig-authorization header when cfApiKey is provided", async () => {
-      const configWithCfKey: AiGatewayCredentialsConfig = {
-        ...credentialsConfig,
-        cfApiKey: "cf-test-key",
-      };
-      const fetcher = createGatewayFetch("openai", configWithCfKey);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const [, init] = mockFetch.mock.calls[0]!;
-      expect(init.headers["cf-aig-authorization"]).toBe("Bearer cf-test-key");
-    });
-
-    it("should not set cf-aig-authorization header when cfApiKey is absent", async () => {
-      const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const [, init] = mockFetch.mock.calls[0]!;
-      expect(init.headers["cf-aig-authorization"]).toBeUndefined();
-    });
-
-    it("should set cf-aig-byok-alias on the outer REST request", async () => {
-      const fetcher = createGatewayFetch("openrouter", {
-        ...credentialsConfig,
-        byokAlias: "development",
-      });
-
-      await fetcher("https://openrouter.ai/api/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const [, init] = mockFetch.mock.calls[0]!;
-      expect(init.headers["cf-aig-byok-alias"]).toBe("development");
-      const body = JSON.parse(init.body);
-      expect(body.provider).toBe("openrouter");
-      expect(body.headers["cf-aig-byok-alias"]).toBe("development");
-    });
-  });
-
-  describe("cache headers", () => {
-    const mockBinding = {
-      run: vi.fn().mockResolvedValue(mockResponse),
-    };
-
-    beforeEach(() => {
-      mockBinding.run.mockClear();
-    });
-
-    it("should set cf-aig-skip-cache when skipCache is true", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        skipCache: true,
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-skip-cache"]).toBe("true");
-    });
-
-    it("should set cf-aig-cache-ttl when cacheTtl is provided", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        cacheTtl: 3600,
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-cache-ttl"]).toBe("3600");
-    });
-
-    it("should set cf-aig-cache-key when customCacheKey is provided", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        customCacheKey: "my-cache-key",
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-cache-key"]).toBe("my-cache-key");
-    });
-
-    it("should set cf-aig-metadata as JSON when metadata is provided", async () => {
-      const metadata = { user: "test", session: "abc123" };
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        metadata,
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-metadata"]).toBe(JSON.stringify(metadata));
-    });
-
-    it("should not set cache headers when no cache options are provided", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-skip-cache"]).toBeUndefined();
-      expect(request.headers["cf-aig-cache-ttl"]).toBeUndefined();
-      expect(request.headers["cf-aig-cache-key"]).toBeUndefined();
-      expect(request.headers["cf-aig-metadata"]).toBeUndefined();
-      expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
-    });
-
-    it("does not set cf-aig-byok-alias on the binding path", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        byokAlias: "development",
-      };
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
-    });
-  });
-
-  describe("workers-ai provider", () => {
-    const mockBinding = {
-      run: vi.fn().mockResolvedValue(mockResponse),
-    };
-
-    beforeEach(() => {
-      mockBinding.run.mockClear();
-    });
-
-    it("should set endpoint to model name and strip model from query", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-          messages: [{ role: "user", content: "Hello" }],
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.provider).toBe("workers-ai");
-      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-      expect(request.query.model).toBeUndefined();
-      expect(request.query.messages).toEqual([{ role: "user", content: "Hello" }]);
-    });
-
-    it("should strip instructions from query", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-          instructions: "You are a helpful assistant",
-          messages: [],
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.query.instructions).toBeUndefined();
-      expect(request.query.messages).toEqual([]);
-    });
-
-    it("should not double-prefix run/ when URL path already contains it", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher(
-        "https://gateway.ai.cloudflare.com/v1/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-        {
-          method: "POST",
-          body: JSON.stringify({
-            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-            messages: [{ role: "user", content: "Hello" }],
-          }),
-        },
-      );
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-      expect(request.query.model).toBeUndefined();
-    });
-
-    it("should prepend run/ when endpoint does not start with run/", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-          messages: [{ role: "user", content: "Hello" }],
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-    });
-
-    // https://github.com/cloudflare/ai/issues/503
-    it("should forward reasoning_effort and chat_template_kwargs in the gateway query", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/zai-org/glm-4.7-flash",
-          messages: [{ role: "user", content: "Hi" }],
-          reasoning_effort: "low",
-          chat_template_kwargs: { enable_thinking: false },
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.query.reasoning_effort).toBe("low");
-      expect(request.query.chat_template_kwargs).toEqual({
-        enable_thinking: false,
-      });
-      // model is still stripped (becomes part of endpoint)
-      expect(request.query.model).toBeUndefined();
-    });
-
-    it("should preserve reasoning_effort: null in the gateway query", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/zai-org/glm-4.7-flash",
-          messages: [],
-          reasoning_effort: null,
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.query).toHaveProperty("reasoning_effort");
-      expect(request.query.reasoning_effort).toBeNull();
-    });
-
-    // Counterpart to the binding shim's allowlist: the gateway path
-    // forwards arbitrary fields. This is the escape-hatch side of the
-    // asymmetry documented on `WorkersAiTextModelOptions`.
-    it("should forward arbitrary unknown fields on the gateway query", async () => {
-      const config: AiGatewayAdapterConfig = {
-        binding: mockBinding,
-        apiKey: "test-key",
-      };
-      const fetcher = createGatewayFetch("workers-ai", config);
-
-      await fetcher("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: JSON.stringify({
-          model: "@cf/zai-org/glm-4.7-flash",
-          messages: [],
-          seed: 42,
-          some_future_field: "hello",
-        }),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.query.seed).toBe(42);
-      expect(request.query.some_future_field).toBe("hello");
-    });
-  });
-
-  describe("endpoint extraction", () => {
-    const mockBinding = {
-      run: vi.fn().mockResolvedValue(mockResponse),
-    };
-
-    beforeEach(() => {
-      mockBinding.run.mockClear();
-    });
-
-    const config: AiGatewayAdapterConfig = { binding: mockBinding };
-
-    it("should preserve query parameters in endpoint", async () => {
-      const fetcher = createGatewayFetch("openai", config);
-
-      await fetcher("https://api.openai.com/v1/files?purpose=assistants", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("files?purpose=assistants");
-    });
-
-    it("should handle paths without /v1/ prefix", async () => {
-      const fetcher = createGatewayFetch("anthropic", config);
-
-      await fetcher("https://api.anthropic.com/messages", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-
-      const request = mockBinding.run.mock.calls[0]![0];
-      expect(request.endpoint).toBe("messages");
-    });
-  });
+	const mockResponse = new Response("ok", { status: 200 });
+
+	describe("binding config", () => {
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(mockResponse),
+		};
+
+		const bindingConfig: AiGatewayBindingConfig = {
+			binding: mockBinding,
+		};
+
+		beforeEach(() => {
+			mockBinding.run.mockClear();
+		});
+
+		it("should call binding.run with the correct request structure", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+			});
+
+			expect(mockBinding.run).toHaveBeenCalledOnce();
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.provider).toBe("openai");
+			expect(request.endpoint).toBe("chat/completions");
+			expect(request.query).toEqual({ model: "gpt-4o", messages: [] });
+			expect(request.headers["Content-Type"]).toBe("application/json");
+		});
+
+		it("should strip /v1/ prefix from endpoint", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+
+			await fetcher("https://api.openai.com/v1/audio/transcriptions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("audio/transcriptions");
+		});
+
+		it("should handle URL objects as input", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+			const url = new URL("https://api.openai.com/v1/chat/completions");
+
+			await fetcher(url, {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o" }),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("chat/completions");
+		});
+
+		it("should handle Request objects as input", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+			const req = new Request("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o" }),
+			});
+
+			await fetcher(req, {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o" }),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("chat/completions");
+		});
+
+		it("should set authorization header when apiKey is provided", async () => {
+			const configWithKey: AiGatewayBindingConfig = {
+				binding: mockBinding,
+				apiKey: "sk-test-key",
+			};
+			const fetcher = createGatewayFetch("openai", configWithKey);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["authorization"]).toBe("Bearer sk-test-key");
+		});
+
+		it("should not set authorization header when apiKey is absent", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["authorization"]).toBeUndefined();
+		});
+
+		it("should include extra headers passed to createGatewayFetch", async () => {
+			const fetcher = createGatewayFetch("anthropic", bindingConfig, {
+				"anthropic-version": "2023-06-01",
+			});
+
+			await fetcher("https://api.anthropic.com/v1/messages", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["anthropic-version"]).toBe("2023-06-01");
+		});
+
+		it("should handle non-JSON body by wrapping in _raw", async () => {
+			const fetcher = createGatewayFetch("openai", bindingConfig);
+
+			await fetcher("https://api.openai.com/v1/audio/transcriptions", {
+				method: "POST",
+				body: "not-json-content",
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query).toEqual({ _raw: "not-json-content" });
+		});
+	});
+
+	describe("credentials config", () => {
+		const originalFetch = globalThis.fetch;
+		const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+		beforeEach(() => {
+			globalThis.fetch = mockFetch;
+			mockFetch.mockClear();
+		});
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
+		});
+
+		const credentialsConfig: AiGatewayCredentialsConfig = {
+			accountId: "test-account",
+			gatewayId: "test-gateway",
+			apiKey: "test-cf-api-key",
+		};
+
+		it("should call fetch with the correct gateway URL", async () => {
+			const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o" }),
+			});
+
+			expect(mockFetch).toHaveBeenCalledOnce();
+			const [url] = mockFetch.mock.calls[0]!;
+			expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
+		});
+
+		it("should send the request object as JSON body", async () => {
+			const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			const body = JSON.parse(init.body);
+			expect(body.provider).toBe("openai");
+			expect(body.endpoint).toBe("chat/completions");
+			expect(body.query).toEqual({ model: "gpt-4o", messages: [] });
+		});
+
+		it("should set cf-aig-authorization header when cfApiKey is provided", async () => {
+			const configWithCfKey: AiGatewayCredentialsConfig = {
+				...credentialsConfig,
+				cfApiKey: "cf-test-key",
+			};
+			const fetcher = createGatewayFetch("openai", configWithCfKey);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect(init.headers["cf-aig-authorization"]).toBe("Bearer cf-test-key");
+		});
+
+		it("should not set cf-aig-authorization header when cfApiKey is absent", async () => {
+			const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect(init.headers["cf-aig-authorization"]).toBeUndefined();
+		});
+
+		it("should set cf-aig-byok-alias on the outer REST request", async () => {
+			const fetcher = createGatewayFetch("openrouter", {
+				...credentialsConfig,
+				byokAlias: "development",
+			});
+
+			await fetcher("https://openrouter.ai/api/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const [, init] = mockFetch.mock.calls[0]!;
+			expect(init.headers["cf-aig-byok-alias"]).toBe("development");
+			const body = JSON.parse(init.body);
+			expect(body.provider).toBe("openrouter");
+			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+		});
+	});
+
+	describe("cache headers", () => {
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(mockResponse),
+		};
+
+		beforeEach(() => {
+			mockBinding.run.mockClear();
+		});
+
+		it("should set cf-aig-skip-cache when skipCache is true", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				skipCache: true,
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-skip-cache"]).toBe("true");
+		});
+
+		it("should set cf-aig-cache-ttl when cacheTtl is provided", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				cacheTtl: 3600,
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-cache-ttl"]).toBe("3600");
+		});
+
+		it("should set cf-aig-cache-key when customCacheKey is provided", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				customCacheKey: "my-cache-key",
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-cache-key"]).toBe("my-cache-key");
+		});
+
+		it("should set cf-aig-metadata as JSON when metadata is provided", async () => {
+			const metadata = { user: "test", session: "abc123" };
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				metadata,
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-metadata"]).toBe(JSON.stringify(metadata));
+		});
+
+		it("should not set cache headers when no cache options are provided", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-skip-cache"]).toBeUndefined();
+			expect(request.headers["cf-aig-cache-ttl"]).toBeUndefined();
+			expect(request.headers["cf-aig-cache-key"]).toBeUndefined();
+			expect(request.headers["cf-aig-metadata"]).toBeUndefined();
+			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
+		});
+
+		it("does not set cf-aig-byok-alias on the binding path", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				byokAlias: "development",
+			};
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
+		});
+	});
+
+	describe("workers-ai provider", () => {
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(mockResponse),
+		};
+
+		beforeEach(() => {
+			mockBinding.run.mockClear();
+		});
+
+		it("should set endpoint to model name and strip model from query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [{ role: "user", content: "Hello" }],
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.provider).toBe("workers-ai");
+			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+			expect(request.query.model).toBeUndefined();
+			expect(request.query.messages).toEqual([{ role: "user", content: "Hello" }]);
+		});
+
+		it("should strip instructions from query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					instructions: "You are a helpful assistant",
+					messages: [],
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.instructions).toBeUndefined();
+			expect(request.query.messages).toEqual([]);
+		});
+
+		it("should not double-prefix run/ when URL path already contains it", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher(
+				"https://gateway.ai.cloudflare.com/v1/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				{
+					method: "POST",
+					body: JSON.stringify({
+						model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+						messages: [{ role: "user", content: "Hello" }],
+					}),
+				},
+			);
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+			expect(request.query.model).toBeUndefined();
+		});
+
+		it("should prepend run/ when endpoint does not start with run/", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+					messages: [{ role: "user", content: "Hello" }],
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+		});
+
+		// https://github.com/cloudflare/ai/issues/503
+		it("should forward reasoning_effort and chat_template_kwargs in the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [{ role: "user", content: "Hi" }],
+					reasoning_effort: "low",
+					chat_template_kwargs: { enable_thinking: false },
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.reasoning_effort).toBe("low");
+			expect(request.query.chat_template_kwargs).toEqual({
+				enable_thinking: false,
+			});
+			// model is still stripped (becomes part of endpoint)
+			expect(request.query.model).toBeUndefined();
+		});
+
+		it("should preserve reasoning_effort: null in the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [],
+					reasoning_effort: null,
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query).toHaveProperty("reasoning_effort");
+			expect(request.query.reasoning_effort).toBeNull();
+		});
+
+		// Counterpart to the binding shim's allowlist: the gateway path
+		// forwards arbitrary fields. This is the escape-hatch side of the
+		// asymmetry documented on `WorkersAiTextModelOptions`.
+		it("should forward arbitrary unknown fields on the gateway query", async () => {
+			const config: AiGatewayAdapterConfig = {
+				binding: mockBinding,
+				apiKey: "test-key",
+			};
+			const fetcher = createGatewayFetch("workers-ai", config);
+
+			await fetcher("https://api.openai.com/v1/chat/completions", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "@cf/zai-org/glm-4.7-flash",
+					messages: [],
+					seed: 42,
+					some_future_field: "hello",
+				}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.query.seed).toBe(42);
+			expect(request.query.some_future_field).toBe("hello");
+		});
+	});
+
+	describe("endpoint extraction", () => {
+		const mockBinding = {
+			run: vi.fn().mockResolvedValue(mockResponse),
+		};
+
+		beforeEach(() => {
+			mockBinding.run.mockClear();
+		});
+
+		const config: AiGatewayAdapterConfig = { binding: mockBinding };
+
+		it("should preserve query parameters in endpoint", async () => {
+			const fetcher = createGatewayFetch("openai", config);
+
+			await fetcher("https://api.openai.com/v1/files?purpose=assistants", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("files?purpose=assistants");
+		});
+
+		it("should handle paths without /v1/ prefix", async () => {
+			const fetcher = createGatewayFetch("anthropic", config);
+
+			await fetcher("https://api.anthropic.com/messages", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+
+			const request = mockBinding.run.mock.calls[0]![0];
+			expect(request.endpoint).toBe("messages");
+		});
+	});
 });

--- a/packages/tanstack-ai/test/gateway-fetch.test.ts
+++ b/packages/tanstack-ai/test/gateway-fetch.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	createGatewayFetch,
-	type AiGatewayAdapterConfig,
-	type AiGatewayBindingConfig,
-	type AiGatewayCredentialsConfig,
+  createGatewayFetch,
+  type AiGatewayAdapterConfig,
+  type AiGatewayBindingConfig,
+  type AiGatewayCredentialsConfig,
 } from "../src/utils/create-fetcher";
 
 // ---------------------------------------------------------------------------
@@ -11,538 +11,538 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("createGatewayFetch", () => {
-	const mockResponse = new Response("ok", { status: 200 });
-
-	describe("binding config", () => {
-		const mockBinding = {
-			run: vi.fn().mockResolvedValue(mockResponse),
-		};
-
-		const bindingConfig: AiGatewayBindingConfig = {
-			binding: mockBinding,
-		};
-
-		beforeEach(() => {
-			mockBinding.run.mockClear();
-		});
-
-		it("should call binding.run with the correct request structure", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-			});
-
-			expect(mockBinding.run).toHaveBeenCalledOnce();
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.provider).toBe("openai");
-			expect(request.endpoint).toBe("chat/completions");
-			expect(request.query).toEqual({ model: "gpt-4o", messages: [] });
-			expect(request.headers["Content-Type"]).toBe("application/json");
-		});
-
-		it("should strip /v1/ prefix from endpoint", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-
-			await fetcher("https://api.openai.com/v1/audio/transcriptions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("audio/transcriptions");
-		});
-
-		it("should handle URL objects as input", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-			const url = new URL("https://api.openai.com/v1/chat/completions");
-
-			await fetcher(url, {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o" }),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("chat/completions");
-		});
-
-		it("should handle Request objects as input", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-			const req = new Request("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o" }),
-			});
-
-			await fetcher(req, {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o" }),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("chat/completions");
-		});
-
-		it("should set authorization header when apiKey is provided", async () => {
-			const configWithKey: AiGatewayBindingConfig = {
-				binding: mockBinding,
-				apiKey: "sk-test-key",
-			};
-			const fetcher = createGatewayFetch("openai", configWithKey);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["authorization"]).toBe("Bearer sk-test-key");
-		});
-
-		it("should not set authorization header when apiKey is absent", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["authorization"]).toBeUndefined();
-		});
-
-		it("should include extra headers passed to createGatewayFetch", async () => {
-			const fetcher = createGatewayFetch("anthropic", bindingConfig, {
-				"anthropic-version": "2023-06-01",
-			});
-
-			await fetcher("https://api.anthropic.com/v1/messages", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["anthropic-version"]).toBe("2023-06-01");
-		});
-
-		it("should handle non-JSON body by wrapping in _raw", async () => {
-			const fetcher = createGatewayFetch("openai", bindingConfig);
-
-			await fetcher("https://api.openai.com/v1/audio/transcriptions", {
-				method: "POST",
-				body: "not-json-content",
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.query).toEqual({ _raw: "not-json-content" });
-		});
-	});
-
-	describe("credentials config", () => {
-		const originalFetch = globalThis.fetch;
-		const mockFetch = vi.fn().mockResolvedValue(mockResponse);
-
-		beforeEach(() => {
-			globalThis.fetch = mockFetch;
-			mockFetch.mockClear();
-		});
-
-		afterEach(() => {
-			globalThis.fetch = originalFetch;
-		});
-
-		const credentialsConfig: AiGatewayCredentialsConfig = {
-			accountId: "test-account",
-			gatewayId: "test-gateway",
-			apiKey: "test-cf-api-key",
-		};
-
-		it("should call fetch with the correct gateway URL", async () => {
-			const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o" }),
-			});
-
-			expect(mockFetch).toHaveBeenCalledOnce();
-			const [url] = mockFetch.mock.calls[0]!;
-			expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
-		});
-
-		it("should send the request object as JSON body", async () => {
-			const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({ model: "gpt-4o", messages: [] }),
-			});
-
-			const [, init] = mockFetch.mock.calls[0]!;
-			const body = JSON.parse(init.body);
-			expect(body.provider).toBe("openai");
-			expect(body.endpoint).toBe("chat/completions");
-			expect(body.query).toEqual({ model: "gpt-4o", messages: [] });
-		});
-
-		it("should set cf-aig-authorization header when cfApiKey is provided", async () => {
-			const configWithCfKey: AiGatewayCredentialsConfig = {
-				...credentialsConfig,
-				cfApiKey: "cf-test-key",
-			};
-			const fetcher = createGatewayFetch("openai", configWithCfKey);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const [, init] = mockFetch.mock.calls[0]!;
-			expect(init.headers["cf-aig-authorization"]).toBe("Bearer cf-test-key");
-		});
-
-		it("should not set cf-aig-authorization header when cfApiKey is absent", async () => {
-			const fetcher = createGatewayFetch("openai", credentialsConfig);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const [, init] = mockFetch.mock.calls[0]!;
-			expect(init.headers["cf-aig-authorization"]).toBeUndefined();
-		});
-
-		it("should set cf-aig-byok-alias on the outer REST request", async () => {
-			const fetcher = createGatewayFetch("openrouter", {
-				...credentialsConfig,
-				byokAlias: "development",
-			});
-
-			await fetcher("https://openrouter.ai/api/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const [, init] = mockFetch.mock.calls[0]!;
-			expect(init.headers["cf-aig-byok-alias"]).toBe("development");
-			const body = JSON.parse(init.body);
-			expect(body.provider).toBe("openrouter");
-			expect(body.headers["cf-aig-byok-alias"]).toBe("development");
-		});
-	});
-
-	describe("cache headers", () => {
-		const mockBinding = {
-			run: vi.fn().mockResolvedValue(mockResponse),
-		};
-
-		beforeEach(() => {
-			mockBinding.run.mockClear();
-		});
-
-		it("should set cf-aig-skip-cache when skipCache is true", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				skipCache: true,
-			};
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-skip-cache"]).toBe("true");
-		});
-
-		it("should set cf-aig-cache-ttl when cacheTtl is provided", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				cacheTtl: 3600,
-			};
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-cache-ttl"]).toBe("3600");
-		});
-
-		it("should set cf-aig-cache-key when customCacheKey is provided", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				customCacheKey: "my-cache-key",
-			};
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-cache-key"]).toBe("my-cache-key");
-		});
-
-		it("should set cf-aig-metadata as JSON when metadata is provided", async () => {
-			const metadata = { user: "test", session: "abc123" };
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				metadata,
-			};
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-metadata"]).toBe(JSON.stringify(metadata));
-		});
-
-		it("should not set cache headers when no cache options are provided", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-			};
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-skip-cache"]).toBeUndefined();
-			expect(request.headers["cf-aig-cache-ttl"]).toBeUndefined();
-			expect(request.headers["cf-aig-cache-key"]).toBeUndefined();
-			expect(request.headers["cf-aig-metadata"]).toBeUndefined();
-			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
-		});
-
-		it("does not set cf-aig-byok-alias on the binding path", async () => {
-			const config = {
-				binding: mockBinding,
-				byokAlias: "development",
-			} as AiGatewayAdapterConfig;
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
-		});
-	});
-
-	describe("workers-ai provider", () => {
-		const mockBinding = {
-			run: vi.fn().mockResolvedValue(mockResponse),
-		};
-
-		beforeEach(() => {
-			mockBinding.run.mockClear();
-		});
-
-		it("should set endpoint to model name and strip model from query", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-					messages: [{ role: "user", content: "Hello" }],
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.provider).toBe("workers-ai");
-			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-			expect(request.query.model).toBeUndefined();
-			expect(request.query.messages).toEqual([{ role: "user", content: "Hello" }]);
-		});
-
-		it("should strip instructions from query", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-					instructions: "You are a helpful assistant",
-					messages: [],
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.query.instructions).toBeUndefined();
-			expect(request.query.messages).toEqual([]);
-		});
-
-		it("should not double-prefix run/ when URL path already contains it", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher(
-				"https://gateway.ai.cloudflare.com/v1/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-				{
-					method: "POST",
-					body: JSON.stringify({
-						model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-						messages: [{ role: "user", content: "Hello" }],
-					}),
-				},
-			);
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-			expect(request.query.model).toBeUndefined();
-		});
-
-		it("should prepend run/ when endpoint does not start with run/", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-					messages: [{ role: "user", content: "Hello" }],
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
-		});
-
-		// https://github.com/cloudflare/ai/issues/503
-		it("should forward reasoning_effort and chat_template_kwargs in the gateway query", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/zai-org/glm-4.7-flash",
-					messages: [{ role: "user", content: "Hi" }],
-					reasoning_effort: "low",
-					chat_template_kwargs: { enable_thinking: false },
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.query.reasoning_effort).toBe("low");
-			expect(request.query.chat_template_kwargs).toEqual({
-				enable_thinking: false,
-			});
-			// model is still stripped (becomes part of endpoint)
-			expect(request.query.model).toBeUndefined();
-		});
-
-		it("should preserve reasoning_effort: null in the gateway query", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/zai-org/glm-4.7-flash",
-					messages: [],
-					reasoning_effort: null,
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.query).toHaveProperty("reasoning_effort");
-			expect(request.query.reasoning_effort).toBeNull();
-		});
-
-		// Counterpart to the binding shim's allowlist: the gateway path
-		// forwards arbitrary fields. This is the escape-hatch side of the
-		// asymmetry documented on `WorkersAiTextModelOptions`.
-		it("should forward arbitrary unknown fields on the gateway query", async () => {
-			const config: AiGatewayAdapterConfig = {
-				binding: mockBinding,
-				apiKey: "test-key",
-			};
-			const fetcher = createGatewayFetch("workers-ai", config);
-
-			await fetcher("https://api.openai.com/v1/chat/completions", {
-				method: "POST",
-				body: JSON.stringify({
-					model: "@cf/zai-org/glm-4.7-flash",
-					messages: [],
-					seed: 42,
-					some_future_field: "hello",
-				}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.query.seed).toBe(42);
-			expect(request.query.some_future_field).toBe("hello");
-		});
-	});
-
-	describe("endpoint extraction", () => {
-		const mockBinding = {
-			run: vi.fn().mockResolvedValue(mockResponse),
-		};
-
-		beforeEach(() => {
-			mockBinding.run.mockClear();
-		});
-
-		const config: AiGatewayAdapterConfig = { binding: mockBinding };
-
-		it("should preserve query parameters in endpoint", async () => {
-			const fetcher = createGatewayFetch("openai", config);
-
-			await fetcher("https://api.openai.com/v1/files?purpose=assistants", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("files?purpose=assistants");
-		});
-
-		it("should handle paths without /v1/ prefix", async () => {
-			const fetcher = createGatewayFetch("anthropic", config);
-
-			await fetcher("https://api.anthropic.com/messages", {
-				method: "POST",
-				body: JSON.stringify({}),
-			});
-
-			const request = mockBinding.run.mock.calls[0]![0];
-			expect(request.endpoint).toBe("messages");
-		});
-	});
+  const mockResponse = new Response("ok", { status: 200 });
+
+  describe("binding config", () => {
+    const mockBinding = {
+      run: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    const bindingConfig: AiGatewayBindingConfig = {
+      binding: mockBinding,
+    };
+
+    beforeEach(() => {
+      mockBinding.run.mockClear();
+    });
+
+    it("should call binding.run with the correct request structure", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+      });
+
+      expect(mockBinding.run).toHaveBeenCalledOnce();
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.provider).toBe("openai");
+      expect(request.endpoint).toBe("chat/completions");
+      expect(request.query).toEqual({ model: "gpt-4o", messages: [] });
+      expect(request.headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("should strip /v1/ prefix from endpoint", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+
+      await fetcher("https://api.openai.com/v1/audio/transcriptions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("audio/transcriptions");
+    });
+
+    it("should handle URL objects as input", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+      const url = new URL("https://api.openai.com/v1/chat/completions");
+
+      await fetcher(url, {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o" }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("chat/completions");
+    });
+
+    it("should handle Request objects as input", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+      const req = new Request("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o" }),
+      });
+
+      await fetcher(req, {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o" }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("chat/completions");
+    });
+
+    it("should set authorization header when apiKey is provided", async () => {
+      const configWithKey: AiGatewayBindingConfig = {
+        binding: mockBinding,
+        apiKey: "sk-test-key",
+      };
+      const fetcher = createGatewayFetch("openai", configWithKey);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["authorization"]).toBe("Bearer sk-test-key");
+    });
+
+    it("should not set authorization header when apiKey is absent", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["authorization"]).toBeUndefined();
+    });
+
+    it("should include extra headers passed to createGatewayFetch", async () => {
+      const fetcher = createGatewayFetch("anthropic", bindingConfig, {
+        "anthropic-version": "2023-06-01",
+      });
+
+      await fetcher("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["anthropic-version"]).toBe("2023-06-01");
+    });
+
+    it("should handle non-JSON body by wrapping in _raw", async () => {
+      const fetcher = createGatewayFetch("openai", bindingConfig);
+
+      await fetcher("https://api.openai.com/v1/audio/transcriptions", {
+        method: "POST",
+        body: "not-json-content",
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.query).toEqual({ _raw: "not-json-content" });
+    });
+  });
+
+  describe("credentials config", () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    beforeEach(() => {
+      globalThis.fetch = mockFetch;
+      mockFetch.mockClear();
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    const credentialsConfig: AiGatewayCredentialsConfig = {
+      accountId: "test-account",
+      gatewayId: "test-gateway",
+      apiKey: "test-cf-api-key",
+    };
+
+    it("should call fetch with the correct gateway URL", async () => {
+      const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o" }),
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://gateway.ai.cloudflare.com/v1/test-account/test-gateway");
+    });
+
+    it("should send the request object as JSON body", async () => {
+      const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-4o", messages: [] }),
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const body = JSON.parse(init.body);
+      expect(body.provider).toBe("openai");
+      expect(body.endpoint).toBe("chat/completions");
+      expect(body.query).toEqual({ model: "gpt-4o", messages: [] });
+    });
+
+    it("should set cf-aig-authorization header when cfApiKey is provided", async () => {
+      const configWithCfKey: AiGatewayCredentialsConfig = {
+        ...credentialsConfig,
+        cfApiKey: "cf-test-key",
+      };
+      const fetcher = createGatewayFetch("openai", configWithCfKey);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers["cf-aig-authorization"]).toBe("Bearer cf-test-key");
+    });
+
+    it("should not set cf-aig-authorization header when cfApiKey is absent", async () => {
+      const fetcher = createGatewayFetch("openai", credentialsConfig);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers["cf-aig-authorization"]).toBeUndefined();
+    });
+
+    it("should set cf-aig-byok-alias on the outer REST request", async () => {
+      const fetcher = createGatewayFetch("openrouter", {
+        ...credentialsConfig,
+        byokAlias: "development",
+      });
+
+      await fetcher("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init.headers["cf-aig-byok-alias"]).toBe("development");
+      const body = JSON.parse(init.body);
+      expect(body.provider).toBe("openrouter");
+      expect(body.headers["cf-aig-byok-alias"]).toBe("development");
+    });
+  });
+
+  describe("cache headers", () => {
+    const mockBinding = {
+      run: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    beforeEach(() => {
+      mockBinding.run.mockClear();
+    });
+
+    it("should set cf-aig-skip-cache when skipCache is true", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        skipCache: true,
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-skip-cache"]).toBe("true");
+    });
+
+    it("should set cf-aig-cache-ttl when cacheTtl is provided", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        cacheTtl: 3600,
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-cache-ttl"]).toBe("3600");
+    });
+
+    it("should set cf-aig-cache-key when customCacheKey is provided", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        customCacheKey: "my-cache-key",
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-cache-key"]).toBe("my-cache-key");
+    });
+
+    it("should set cf-aig-metadata as JSON when metadata is provided", async () => {
+      const metadata = { user: "test", session: "abc123" };
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        metadata,
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-metadata"]).toBe(JSON.stringify(metadata));
+    });
+
+    it("should not set cache headers when no cache options are provided", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-skip-cache"]).toBeUndefined();
+      expect(request.headers["cf-aig-cache-ttl"]).toBeUndefined();
+      expect(request.headers["cf-aig-cache-key"]).toBeUndefined();
+      expect(request.headers["cf-aig-metadata"]).toBeUndefined();
+      expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
+    });
+
+    it("does not set cf-aig-byok-alias on the binding path", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        byokAlias: "development",
+      };
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.headers["cf-aig-byok-alias"]).toBeUndefined();
+    });
+  });
+
+  describe("workers-ai provider", () => {
+    const mockBinding = {
+      run: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    beforeEach(() => {
+      mockBinding.run.mockClear();
+    });
+
+    it("should set endpoint to model name and strip model from query", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.provider).toBe("workers-ai");
+      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+      expect(request.query.model).toBeUndefined();
+      expect(request.query.messages).toEqual([{ role: "user", content: "Hello" }]);
+    });
+
+    it("should strip instructions from query", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+          instructions: "You are a helpful assistant",
+          messages: [],
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.query.instructions).toBeUndefined();
+      expect(request.query.messages).toEqual([]);
+    });
+
+    it("should not double-prefix run/ when URL path already contains it", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher(
+        "https://gateway.ai.cloudflare.com/v1/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            messages: [{ role: "user", content: "Hello" }],
+          }),
+        },
+      );
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+      expect(request.query.model).toBeUndefined();
+    });
+
+    it("should prepend run/ when endpoint does not start with run/", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("run/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+    });
+
+    // https://github.com/cloudflare/ai/issues/503
+    it("should forward reasoning_effort and chat_template_kwargs in the gateway query", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/zai-org/glm-4.7-flash",
+          messages: [{ role: "user", content: "Hi" }],
+          reasoning_effort: "low",
+          chat_template_kwargs: { enable_thinking: false },
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.query.reasoning_effort).toBe("low");
+      expect(request.query.chat_template_kwargs).toEqual({
+        enable_thinking: false,
+      });
+      // model is still stripped (becomes part of endpoint)
+      expect(request.query.model).toBeUndefined();
+    });
+
+    it("should preserve reasoning_effort: null in the gateway query", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/zai-org/glm-4.7-flash",
+          messages: [],
+          reasoning_effort: null,
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.query).toHaveProperty("reasoning_effort");
+      expect(request.query.reasoning_effort).toBeNull();
+    });
+
+    // Counterpart to the binding shim's allowlist: the gateway path
+    // forwards arbitrary fields. This is the escape-hatch side of the
+    // asymmetry documented on `WorkersAiTextModelOptions`.
+    it("should forward arbitrary unknown fields on the gateway query", async () => {
+      const config: AiGatewayAdapterConfig = {
+        binding: mockBinding,
+        apiKey: "test-key",
+      };
+      const fetcher = createGatewayFetch("workers-ai", config);
+
+      await fetcher("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: "@cf/zai-org/glm-4.7-flash",
+          messages: [],
+          seed: 42,
+          some_future_field: "hello",
+        }),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.query.seed).toBe(42);
+      expect(request.query.some_future_field).toBe("hello");
+    });
+  });
+
+  describe("endpoint extraction", () => {
+    const mockBinding = {
+      run: vi.fn().mockResolvedValue(mockResponse),
+    };
+
+    beforeEach(() => {
+      mockBinding.run.mockClear();
+    });
+
+    const config: AiGatewayAdapterConfig = { binding: mockBinding };
+
+    it("should preserve query parameters in endpoint", async () => {
+      const fetcher = createGatewayFetch("openai", config);
+
+      await fetcher("https://api.openai.com/v1/files?purpose=assistants", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("files?purpose=assistants");
+    });
+
+    it("should handle paths without /v1/ prefix", async () => {
+      const fetcher = createGatewayFetch("anthropic", config);
+
+      await fetcher("https://api.anthropic.com/messages", {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+
+      const request = mockBinding.run.mock.calls[0]![0];
+      expect(request.endpoint).toBe("messages");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `byokAlias` on AI Gateway **credentials / REST** config so `createOpenAiChat`, `createAnthropicChat`, `createGeminiChat`, `createGrokChat`, `createOpenRouterChat`, and Workers AI gateway REST can send `cf-aig-byok-alias` and select a stored BYOK key other than `default`.
- Keep the field off the AI binding type. Cloudflare docs: the header is provider-passthrough only, and BYOK is not supported for third-party models called through the AI binding (`env.AI.run()` / Unified Billing).
- Gemini maps the header through `httpOptions.headers` (Google GenAI SDK has no custom `fetch`).

```ts
createGeminiChat("gemini-2.5-flash", {
  accountId: "...",
  gatewayId: "...",
  cfApiKey: "...",
  byokAlias: "development",
});
```

## Test plan

- [x] `pnpm --filter @cloudflare/tanstack-ai exec vitest --run test/gateway-fetch.test.ts test/gateway-adapters.test.ts` (66 passed)
- [x] REST `createGatewayFetch` sets `cf-aig-byok-alias` on the outer request
- [x] Binding config does not emit the header even if `byokAlias` is forced through the type
- [x] `createOpenRouterChat` / `createOpenAiChat` / `createAnthropicChat` HTTPClient fetchers forward the alias
- [x] `createGeminiChat` forwards the alias via `httpOptions.headers`