### PR TITLE
fix(tanstack-ai): enable top-level tree-shaking

### DIFF
--- a/packages/tanstack-ai/package.json
+++ b/packages/tanstack-ai/package.json
@@ -2,6 +2,7 @@
 	"name": "@cloudflare/tanstack-ai",
 	"version": "0.2.1",
 	"description": "Use TanStack AI with Cloudflare Workers AI and AI Gateway",
+	"sideEffects": false,
 	"keywords": [
 		"ai",
 		"chat",

--- a/packages/tanstack-ai/test/package-metadata.test.ts
+++ b/packages/tanstack-ai/test/package-metadata.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("package metadata", () => {
+	it("marks the package as side-effect free for tree-shaking", async () => {
+		const packageJson = JSON.parse(
+			await readFile(resolve(import.meta.dirname, "../package.json"), "utf8"),
+		) as { sideEffects?: boolean };
+
+		expect(packageJson.sideEffects).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

The `@cloudflare/tanstack-ai` package exports multiple optional provider adapters from its top-level entry point, but its package metadata does not declare that those modules are side-effect free. Bundlers therefore cannot safely remove unused adapters when consumers import a single factory from the top-level package.

This change marks the package as side-effect free so tree-shaking can remove unused adapter modules while preserving the existing top-level and deep-import APIs.

## Testing

- `node node_modules/vitest/vitest.mjs run packages/tanstack-ai/test/package-metadata.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit -p packages/tanstack-ai/tsconfig.json`
- `git diff --check`

The package-scoped pnpm command is currently blocked on Windows by the repository postinstall invoking `rm -rf`; the focused Vitest and TypeScript commands pass independently.

Related issue: #609
